### PR TITLE
EREGCSC-58 Create a "guidance" sidebar of hardcoded html

### DIFF
--- a/config/regulations-site/local_settings.py
+++ b/config/regulations-site/local_settings.py
@@ -15,7 +15,7 @@ SIDEBARS = (
     'regulations.generator.sidebar.analyses.Analyses',
     'regulations.generator.sidebar.help.Help',
     'regulations.generator.sidebar.print_part.PrintPart',
-    'guidance.guidance.Guidance',
+    'cmcs.regulations.sidebar.guidance.Guidance',
 )
 
 TEMPLATES = [
@@ -43,7 +43,7 @@ TEMPLATES = [
         },
         "DIRS": [
             "%s/templates" % BASE_DIR,
-            "/var/lib/eregs/guidance/content",
+            "/var/lib/eregs/cmcs/regulations/sidebar/content",
         ],
     },
 ]

--- a/config/regulations-site/local_settings.py
+++ b/config/regulations-site/local_settings.py
@@ -1,5 +1,49 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
 INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'regulations.apps.RegulationsConfig',
     'notice_comment',
+    # TODO: can django be convinced it can live without the following?
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
 )
+
+SIDEBARS = (
+    'regulations.generator.sidebar.analyses.Analyses',
+    'regulations.generator.sidebar.help.Help',
+    'regulations.generator.sidebar.print_part.PrintPart',
+    'guidance.guidance.Guidance',
+)
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "context_processors": (
+                # "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
+                "regulations.context.eregs_globals",
+            ),
+            # List of callables that know how to import templates from various
+            # sources.
+            "loaders": [
+                ('django.template.loaders.cached.Loader', (
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader'))
+            ],
+        },
+        "DIRS": [
+            "%s/templates" % BASE_DIR,
+            "/var/lib/eregs/guidance/content",
+        ],
+    },
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       dockerfile: ${PWD}/config/regulations-core/Dockerfile
     volumes:
       - ${CORE_CONTEXT:-./regulations-core}:/app/src
-      - ${PWD}/config/regulations-core/local_settings.py:/app/src/local_settings.py
+      - ./config/regulations-core/local_settings.py:/app/src/local_settings.py
     environment:
       DATABASE_URL: postgres://eregs:sgere@db/eregs
       ALLOWED_HOST_LOCAL: regulations-core
@@ -28,12 +28,14 @@ services:
       context: ${SITE_CONTEXT:-./regulations-site}
       dockerfile: ${PWD}/config/regulations-site/Dockerfile
     volumes:
-      - ${SITE_CONTEXT:-./regulations-site:/app/src}
-      - ${PWD}/config/regulations-site/local_settings.py:/app/src/regulations/local_settings.py
-      - ${PWD}/config/regulations-site/config.json:/app/src/regulations/static/config/config.json
-      - ${PWD}/config/regulations-site/build_static.sh:/usr/bin/build_static.sh
+      - ${SITE_CONTEXT:-./regulations-site}:/app/src
+      - ./config/regulations-site/local_settings.py:/var/lib/eregs/local_settings.py
+      - ./config/regulations-site/config.json:/app/src/regulations/static/config/config.json
+      - ./config/regulations-site/build_static.sh:/usr/bin/build_static.sh
+      - ./guidance:/var/lib/eregs/guidance
     environment:
       EREGS_API_BASE: http://regulations-core:8080/
+      PYTHONPATH: /var/lib/eregs
     ports:
       - 8000:8000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - ./config/regulations-site/local_settings.py:/var/lib/eregs/local_settings.py
       - ./config/regulations-site/config.json:/app/src/regulations/static/config/config.json
       - ./config/regulations-site/build_static.sh:/usr/bin/build_static.sh
-      - ./guidance:/var/lib/eregs/guidance
+      - ./guidance:/var/lib/eregs/cmcs/regulations/sidebar
     environment:
       EREGS_API_BASE: http://regulations-core:8080/
       PYTHONPATH: /var/lib/eregs

--- a/guidance/content/guidance/435-905.html
+++ b/guidance/content/guidance/435-905.html
@@ -1,0 +1,16 @@
+<section id="guidance" class="regs-meta">
+  <div class="sidebar-subsection">
+    <h5 class="guidance-title">Related Statutes/Executive Orders</h5>
+    <ul class="guidance-list">
+      <li>
+        <a target="_blank" href="https://www.justice.gov/crt/title-vi-1964-civil-rights-act">Title VI of the Civil Rights Act of 1964</a>
+      </li>
+      <li>
+        <a target="_blank" href="https://www.govinfo.gov/content/pkg/FR-2000-08-16/pdf/00-20938.pdf">Executive Order 13166, "Improving Access to Services for Persons with Limited English Proficiency", August 11, 2000</a>
+      </li>
+      <li>
+        <a target="_blank" href="https://www.hhs.gov/sites/default/files/ppacacon.pdf">Section 1557 of the Affordable Care Act</a>
+      </li>
+    </ul>
+  </div> <!-- /.sidebar-subsection-->
+</section> <!-- /.regs-meta -->

--- a/guidance/content/guidance/blank.html
+++ b/guidance/content/guidance/blank.html
@@ -1,0 +1,1 @@
+No analyses available for {{ human_label_id }} in this tool.

--- a/guidance/content/regulations/sidebar/guidance.html
+++ b/guidance/content/regulations/sidebar/guidance.html
@@ -1,0 +1,11 @@
+<section id="help" class="regs-meta">
+  <header class="expandable group">
+    <h4 tabindex="0">Guidance</h4>
+    <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
+  </header>
+  <div class="chunk expand-drawer start-collapsed">
+    <div class="sidebar-subsection">
+      {{ subtemplate|safe }}
+    </div> <!-- /.sidebar-subsection-->
+  </div> <!-- /.expand-drawer-->
+</section> <!-- /.regs-meta -->

--- a/guidance/guidance.py
+++ b/guidance/guidance.py
@@ -1,0 +1,24 @@
+from django.template import TemplateDoesNotExist
+from django.template.loader import get_template, select_template
+from regulations.generator.node_types import label_to_text
+
+from regulations.generator.sidebar.base import SidebarBase
+# @todo - seems like code in `generator` shouldn't reach in to `views`?
+from regulations.views.utils import layer_names
+
+
+class Guidance(SidebarBase):
+    """Help info; composed of subtemplates defined by the active layers"""
+    shorthand = 'guidance'
+
+    def context(self, http_client, request):
+        t = select_template([
+            'guidance/%s.html' % self.label_id,
+            'guidance/blank.html',
+        ])
+        return {
+            'subtemplate': t.render({
+                'human_label_id': label_to_text(
+                    self.label_parts, include_marker=True),
+            }),
+        }


### PR DESCRIPTION
Guidance can now be authored for a a specific regulations part, e.g. 435-905, by adding a html file at `guidance/content/guidance/435-900.html.

This adds a `guidance` sidebar that pulls an html template by the requested reg and sub part if it exists.