### PR TITLE
EREGCSC-64 Exit run.sh on error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
+set -e
+
 if [[ $# -eq 0 ]]; then
   echo "Please enter in an API key as an argument and try again."
   exit 1
 fi
 
 cd regulations-core
-git apply ../patches/regcore-jsonschema.patch
+if git apply --check ../patches/regcore-jsonschema.patch; then
+  git apply ../patches/regcore-jsonschema.patch
+fi
 cd ..
+
 cd regulations-parser
-git apply ../patches/regparser-Dockerfile.patch
+if git apply --check ../patches/regparser-Dockerfile.patch; then
+  git apply ../patches/regparser-Dockerfile.patch
+fi
 cd ..
 
 docker-compose up -d
@@ -18,6 +25,6 @@ docker-compose exec regulations-core python manage.py migrate
 docker-compose restart regulations-core
 docker-compose exec regulations-site /usr/bin/build_static.sh
 
-docker build --no-cache --tag eregs_parser_kaitlin regulations-parser
+docker build --tag eregs_parser_kaitlin regulations-parser
 
 ./load_data.sh $1 pipeline 42 400 http://localhost:8080


### PR DESCRIPTION
- check that a git patch can be applied before applying it.
- allow regulations-parser docker to be built from cache.