### PR TITLE
Remove depricated make clean call in gh actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
       - name: build static assets 
         run: |
           pushd config/static-assets
-          make clean
           make build
           popd
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Before this builds would break as the `make clean` command no longer exists for static assets