### PR TITLE
EREGCSC-104 Disabled unused content from regulations-site

### DIFF
--- a/config/regulations-site/local_settings.py
+++ b/config/regulations-site/local_settings.py
@@ -13,7 +13,6 @@ INSTALLED_APPS = (
 
 SIDEBARS = (
     'cmcs.regulations.sidebar.guidance.Guidance',
-    'regulations.generator.sidebar.help.Help',
     'regulations.generator.sidebar.print_part.PrintPart',
 )
 

--- a/config/regulations-site/local_settings.py
+++ b/config/regulations-site/local_settings.py
@@ -5,10 +5,19 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'regulations.apps.RegulationsConfig',
-    'notice_comment',
-    # TODO: can django be convinced it can live without the following?
-    'django.contrib.contenttypes',
-    'django.contrib.auth',
+)
+
+ROOT_URLCONF = 'regulations.urls'
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.security.SecurityMiddleware',
+    'django.middleware.cache.UpdateCacheMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 SIDEBARS = (

--- a/load_data.sh
+++ b/load_data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 # Create a directory for the output
 mkdir -p output


### PR DESCRIPTION
- Removed help from sidebar
- Removed dependency on django.contrib.contenttypes & django.contrib.auth apps
- Disabled notice-comment app
- Additionally, modified load_data.sh to run in bash instead of sh due to conflicts on some setups