### PR TITLE
EREGCSC-178 Update Dockerfile to use python:3-alpine instead of node:6

### DIFF
--- a/config/regulations-site/Dockerfile
+++ b/config/regulations-site/Dockerfile
@@ -1,22 +1,19 @@
-FROM node:6
-ARG PYTHON3=3
-ENV PIP_PACKAGE=python${PYTHON3}-pip \
-    PIP_CMD=pip$PYTHON3 \
-    PYTHON_CMD=python$PYTHON3
+FROM python:3-alpine
 
-RUN apt-get update \
-    && apt-get install -y $PIP_PACKAGE \
-    && rm -rf /var/lib/apt/lists/*
-RUN $PIP_CMD install --upgrade pip setuptools
-RUN npm install --quiet -g grunt-cli
-
-COPY ["manage.py", "package.json", "example-config.json", "setup.py", "frontendbuild.sh", "Gruntfile.js", ".babelrc", ".eslintignore", ".eslintrc", "/app/src/"]
+COPY ["manage.py", "setup.py", "/app/src/"]
 COPY ["regulations", "/app/src/regulations"]
 COPY ["fr_notices", "/app/src/fr_notices"]
 COPY ["notice_comment", "/app/src/notice_comment"]
 WORKDIR /app/src/
-RUN $PIP_CMD install --no-cache-dir -e .[notice_comment]
+
+RUN apk --update add ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/cache/apk/*
+RUN pip install --no-cache-dir --upgrade pip setuptools \
+    && pip install --no-cache-dir -e .[notice_comment] \
+    && python manage.py migrate
 
 ENV PYTHONUNBUFFERED="1"
 EXPOSE 8000
-CMD $PYTHON_CMD manage.py runserver 0.0.0.0:8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
This removes the dependency on node.js as well as giving us access to Python 3.9 and its features. It also brings our local dev environment more up-to-date with the production environment.