### PR TITLE
Add license files + add a bit of context to readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## Public domain
+
+The project is in the public domain within the United States, and
+copyright and related rights in the work worldwide are waived through
+the [CC0 1.0 Universal public domain dedication][CC0].
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.
+
+[CC0]: http://creativecommons.org/publicdomain/zero/1.0/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,35 @@
+# Public domain
+
+As a work of the United States Government, this project is in the
+public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work
+worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the
+[Legal Code (read the full
+text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the
+extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0,
+nor are the rights that other persons may have in the work or in how the
+work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with
+this deed makes no warranties about the work, and disclaims liability for
+all uses of the work, to the fullest extent permitted by applicable law.
+When using or citing the work, you should not imply endorsement by the
+author or the affirmer.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# About
+
+This is part of a one-year pilot project for the Center for Medicaid and CHIP Services (CMCS) to understand and meet needs of CMCS and State staff researching regulations and related guidance, building on the [eRegulations](https://eregs.github.io/) open source project.
+
+Our related repositories with forks of eRegs code: [regulations-core](https://github.com/CMSgov/regulations-core), [regulations-parser](https://github.com/CMSgov/regulations-parser), [regulations-site](https://github.com/CMSgov/regulations-site).
+
 # Prerequisites
 - Docker
 - Docker Compose


### PR DESCRIPTION
These licensing files match the language used in other eRegs projects, to support reuse and interoperability. Examples: https://github.com/18F/atf-eregs/blob/master/LICENSE.md + https://github.com/eregs/regulations-site/blob/master/CONTRIBUTING.md

Also added a summary to the readme to orient readers from other regs projects.