### PR TITLE
EREGCSC-230 Fix hard coded urls to allow for prefix path (e.g. /dev)

### DIFF
--- a/guidance/content/regulations/generic_universal.html
+++ b/guidance/content/regulations/generic_universal.html
@@ -34,7 +34,7 @@
         <h2 class="hero-header">Join our user research for this tool</h2>
         <div class="hero-text">
           <p>This is a DSG pilot project to make it easier to research and draft regulations and subregulatory guidance for CMCS work.</p>
-          <p>Try this: go to <a href="433-112/2016-27844#433-112">Part 433, Section 112</a>, and see the subregulatory guidance in the sidebar, or <a href="diff/433-112/E8-27810/2016-27844?from_version=2016-27844#433-112">see what changed from 2008 to 2017</a>.</p>
+          <p>Try this: go to <a href="{% url 'chrome_section_view' '433-112' '2016-27844' %}#433-112">Part 433, Section 112</a>, and see the subregulatory guidance in the sidebar, or <a href="{% url 'chrome_section_diff_view' '433-112' 'E8-27810' '2016-27844' %}?from_version=2016-27844#433-112">see what changed from 2008 to 2017</a>.</p>
           <p>If you work with CMCS regs, we want to make this work for you &mdash; <a href="mailto:britta.gustafson@a1msolutions.com">email Britta Gustafson</a> to sign up for a 30-minute interview.</p>
         </div>  
       </div>

--- a/guidance/content/regulations/landing_433.html
+++ b/guidance/content/regulations/landing_433.html
@@ -13,10 +13,10 @@
       </div>
       <div class="collapsible" aria-hidden="true">
         <ul>
-          <li><a href="/433-202/2016-27844#433-202">Expansion Population (Adult Group)</a></li>
-          <li><a href="/433-15/2016-27844#433-15">Administration</a></li>
-          <li><a href="/433-10/2016-27844#433-10">Family Planning Services</a></li>
-          <li><a href="/433-10/2016-27844#433-10">Indian Health Services</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-202' '2016-27844' %}#433-202">Expansion Population (Adult Group)</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-15' '2016-27844' %}#433-15">Administration</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-10' '2016-27844' %}#433-10">Family Planning Services</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-10' '2016-27844' %}#433-10">Indian Health Services</a></li>
         </ul>
       </div>
     </div>
@@ -30,8 +30,8 @@
       </div>
       <div class="collapsible" aria-hidden="true">
         <ul>
-          <li><a href="/433-112/2016-27844#433-112">Design and Implementation</a></li>
-          <li><a href="/433-116/2016-27844#433-116">Operations</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-112' '2016-27844' %}#433-112">Design and Implementation</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-116' '2016-27844' %}#433-116">Operations</a></li>
         </ul>
       </div>
     </div>
@@ -45,9 +45,9 @@
       </div>
       <div class="collapsible" aria-hidden="true">
         <ul>
-          <li><a href="/433-55/2016-27844#433-55">Healthcare-Related Taxes</a></li>
-          <li><a href="/433-54/2016-27844#433-54">Bona Fide Donations</a></li>
-          <li><a href="/433-51/2016-27844#433-51">Public Funds</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-55' '2016-27844' %}#433-55">Healthcare-Related Taxes</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-54' '2016-27844' %}#433-54">Bona Fide Donations</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-51' '2016-27844' %}#433-51">Public Funds</a></li>
         </ul>
       </div>
     </div>
@@ -61,10 +61,10 @@
       </div>
       <div class="collapsible" aria-hidden="true">
         <ul>
-          <li><a href="/433-145/2016-27844#433-145">Assignment of Rights</a></li>
-          <li><a href="/433-135/2016-27844#433-135">Liable Third Parties</a></li>
-          <li><a href="/433-147/2016-27844#433-147">Medical Support</a></li>
-          <li><a href="/433-151/2016-27844#433-151">Cooperation Agreements</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-145' '2016-27844' %}#433-145">Assignment of Rights</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-135' '2016-27844' %}#433-135">Liable Third Parties</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-147' '2016-27844' %}#433-147">Medical Support</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-151' '2016-27844' %}#433-151">Cooperation Agreements</a></li>
         </ul>
       </div>
     </div>
@@ -78,7 +78,7 @@
       </div>
       <div class="collapsible" aria-hidden="true">
         <ul>
-          <li><a href="/433-300/2016-27844#433-300">Overpayment to Providers</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-300' '2016-27844' %}#433-300">Overpayment to Providers</a></li>
         </ul>
       </div>
     </div>
@@ -92,7 +92,7 @@
       </div>
       <div class="collapsible" aria-hidden="true">
         <ul>
-          <li><a href="/433-400/2016-27844#433-400">FMAP Increase During COVID-19</a></li>
+          <li><a href="{% url 'chrome_section_view' '433-400' '2016-27844' %}#433-400">FMAP Increase During COVID-19</a></li>
         </ul>
       </div>
     </div>

--- a/guidance/content/regulations/recent-changes.html
+++ b/guidance/content/regulations/recent-changes.html
@@ -4,7 +4,7 @@
 
 <div class="recent-changes">
     <h1>Recent Changes: Amended 11/06/2020</h1>
-    <a class="change-link" target="_blank" href="/433-400/2020-28567#433-400">
+    <a class="change-link" target="_blank" href="{% url 'chrome_section_view' '433-400' '2020-28567' %}#433-400">
       <p>433 Subpart G: Temporary FMAP Increase During the Public Health Emergency for COVID-19</p>
       <p>§ 433.400 Continued enrollment for temporary FMAP increase.</p>
     </a>


### PR DESCRIPTION
Replaced hard-coded links with Django's 'url' function, e.g. {% url 'chrome_section_view' 'a' 'b' %}

When running under a subdirectory, hard-coded links would not work correctly.