### PR TITLE
[Dependency] Bump regulations-site lib to - 7c7d586

### DIFF
--- a/config/regulations-site/serverless-experimental.yml
+++ b/config/regulations-site/serverless-experimental.yml
@@ -25,6 +25,7 @@ functions:
       STATIC_URL: ${self:custom.settings.static_url}
       SIDEBAR_CONTENT_DIR: /var/task/cmcs/regulations/sidebar/content
     handler: wsgi_handler.handler
+    timeout: 15
     events:
       - http: ANY /
       - http: ANY {proxy+}

--- a/config/regulations-site/serverless.yml
+++ b/config/regulations-site/serverless.yml
@@ -24,6 +24,7 @@ functions:
       STATIC_URL: ${self:custom.settings.static_url}
       SIDEBAR_CONTENT_DIR: /var/task/cmcs/regulations/sidebar/content
     handler: wsgi_handler.handler
+    timeout: 15
     events:
       - http: ANY /
       - http: ANY {proxy+}

--- a/guidance/content/regulations/sidebar/print_part.html
+++ b/guidance/content/regulations/sidebar/print_part.html
@@ -1,6 +1,6 @@
 <section id="print_part" class="regs-meta">
   <header class="group">
-    <a href="{% url 'chrome_regulation_view' cfr_part version %}?print=true">
+    <a href="{% url 'reader_view' cfr_part version %}?print=true">
       <h4>
       	<span class="cf-icon cf-icon-print"></span>
         Print Part {{ cfr_part }}


### PR DESCRIPTION
Increase timeout for regulations-site lambda function.
Before this a timeout would happen when loading a full part.

Depends on: https://github.com/CMSgov/regulations-site/pull/13