### PR TITLE
Use new $default-branch macro in deploy gh action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   deploy:


### PR DESCRIPTION
Should allow easy updating of default branch name.