### PR TITLE
EREGCSC-732 Fix paragraph depth

### DIFF
--- a/regulations/templatetags/paragraphs.py
+++ b/regulations/templatetags/paragraphs.py
@@ -8,5 +8,5 @@ section_depth = 2
 def pdepth(value):
     depth = len(value.get("label", []) or []) - section_depth
     if len(value.get("marker", []) or []) > 1:
-        depth = depth - len(value.get("marker", []) or [])
+        depth = depth - (len(value.get("marker", []) or []) - 1)
     return depth


### PR DESCRIPTION
Before this paragraphs with two identifiers, e.g. `(a)(i)`, were underindented.