### PR TITLE
Update cloudfrontInvalidate to be an array

### DIFF
--- a/serverless/static-assets/serverless/serverless.yml
+++ b/serverless/static-assets/serverless/serverless.yml
@@ -11,9 +11,9 @@ custom:
     - bucketName: eregs-${self:custom.stage}-site-assets
       localDir: ../static
   cloudfrontInvalidate:
-    distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId, false}
-    items:
-      - "/*"
+    - distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId, false}
+      items:
+        - "/*"
 
 plugins:
   - serverless-s3-sync


### PR DESCRIPTION
version 1.5 changed the form of the variables needed in serverless.yml

https://github.com/aghadiry/serverless-cloudfront-invalidate/compare/v1.4.0...v.1.5.0#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R95-R135