### PR TITLE
feat: pull GA_ID from AWS parameter store and pipe into template

### DIFF
--- a/cmcs_regulations/context_processors.py
+++ b/cmcs_regulations/context_processors.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+def google_analytics(request):
+    return {
+        "GA_ID": settings.GA_ID,
+    }

--- a/cmcs_regulations/context_processors.py
+++ b/cmcs_regulations/context_processors.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+
 def google_analytics(request):
     return {
         "GA_ID": settings.GA_ID,

--- a/cmcs_regulations/settings.py
+++ b/cmcs_regulations/settings.py
@@ -85,6 +85,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.request",
+                "cmcs_regulations.context_processors.google_analytics"
             ),
         },
         "DIRS": [
@@ -155,3 +156,5 @@ GUIDANCE_DIR = os.environ.get("SIDEBAR_CONTENT_DIR")
 
 HTTP_AUTH_USER = os.environ.get("HTTP_AUTH_USER")
 HTTP_AUTH_PASSWORD = os.environ.get("HTTP_AUTH_PASSWORD")
+
+GA_ID = os.environ.get("GA_ID")

--- a/regulations/templates/regulations/base.html
+++ b/regulations/templates/regulations/base.html
@@ -8,6 +8,15 @@ CSS/Javascript etc., should inherit from this template.
 <!DOCTYPE html>
 <html class="no-js" lang="en">
     <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ID }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag("js", new Date());
+
+        gtag("config", "{{ GA_ID }}");
+    </script>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=11; IE=EDGE">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -11,6 +11,7 @@ provider:
     DB_PASSWORD: ${ssm:/eregulations/db/password~true}
     DB_HOST: !GetAtt [RDSResource, Endpoint.Address]
     DB_PORT: !GetAtt [RDSResource, Endpoint.Port]
+    GA_ID: ${ssm:/eregulations/http/google_analytics}
     HTTP_AUTH_USER: ${ssm:/eregulations/http/user~true}
     HTTP_AUTH_PASSWORD: ${ssm:/eregulations/http/password~true}
     DJANGO_ADMIN_USERNAME: ${ssm:/eregulations/http/user~true}


### PR DESCRIPTION
Google Analytics Measurement ID is stored in AWS parameter store so it is not stored in source control.  This pulls that ID from AWS and adds it to app context so it can be references in a template