### PR TITLE
EREGCSC-880 fix: must use single quotes for string literals

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,4 +67,4 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: e2e
-          config: baseUrl=${{ steps.deploy-regulations-site-server.outputs.url }},DEPLOYING_TO_PROD=${{ matrix.environment == "prod" }}
+          config: baseUrl=${{ steps.deploy-regulations-site-server.outputs.url }},DEPLOYING_TO_PROD=${{ matrix.environment == 'prod' }}


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#literals