### PR TITLE
updating regex to allow for A-B and A to match as valid URL's

### DIFF
--- a/regulations/converters.py
+++ b/regulations/converters.py
@@ -11,7 +11,7 @@ class NumericConverter(PathConverter):
 
 
 class SubpartConverter(PathConverter):
-    regex = r'[A-Za-z]'
+    regex = r'[A-Za-z]-[A-Za-z]|[A-Za-z]'
 
 
 class VersionConverter(PathConverter):


### PR DESCRIPTION
fixes the regex for URL's to include one for identifiers in the format of "A-B" that we have begun seeing in the most recent ECFR results.