### PR TITLE
EREGCSC-1022 Revise eCFR API fetch strategy

### DIFF
--- a/tools/ecfr-parser/ecfr/ecfr.go
+++ b/tools/ecfr-parser/ecfr/ecfr.go
@@ -50,7 +50,7 @@ func fetch(ctx context.Context, path *url.URL, opts []FetchOption) (io.Reader, e
 
 	u := ecfrSite.ResolveReference(path)
 
-	log.Trace("[ECFR] Attempting fetch from ", u.String())
+	log.Trace("[ecfr] Attempting fetch from ", u.String())
 	start := time.Now()
 
 	c, cancel := context.WithTimeout(ctx, timeout)
@@ -61,15 +61,15 @@ func fetch(ctx context.Context, path *url.URL, opts []FetchOption) (io.Reader, e
 		return nil, fmt.Errorf("from `http.NewRequestWithContext`: %+v", err)
 	}
 
-	log.Trace("[ECFR] Connecting to ", u.String())
+	log.Trace("[ecfr] Connecting to ", u.String())
 	req_start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("from `client.Do`: %+v, took %+v", err, time.Since(req_start))
 	}
-	log.Trace("[ECFR] client.Do took ", time.Since(req_start))
+	log.Trace("[ecfr] client.Do took ", time.Since(req_start))
 	if resp.StatusCode != 200 {
-		log.Trace("[ECFR] Received status code ", resp.StatusCode, " from ", u.String())
+		log.Trace("[ecfr] Received status code ", resp.StatusCode, " from ", u.String())
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusBadGateway {
 			time.Sleep(2 * time.Second)
 			return fetch(ctx, path, opts)
@@ -83,7 +83,7 @@ func fetch(ctx context.Context, path *url.URL, opts []FetchOption) (io.Reader, e
 	}
 	body := bytes.NewBuffer(b)
 
-	log.Trace("[ECFR] Received ", len(b), " bytes in ", time.Since(start), " from ", u.String())
+	log.Trace("[ecfr] Received ", len(b), " bytes in ", time.Since(start), " from ", u.String())
 	return body, nil
 }
 

--- a/tools/ecfr-parser/eregs/eregs.go
+++ b/tools/ecfr-parser/eregs/eregs.go
@@ -35,14 +35,14 @@ type Part struct {
 }
 
 func PostPart(ctx context.Context, p *Part) (*http.Response, error) {
-	log.Debug("[EREGS] Beginning post of part ", p.Name, " to ", BaseURL)
+	log.Trace("[eregs] Beginning post of part ", p.Name, " to ", BaseURL)
 	start := time.Now()
 
 	buff := bytes.NewBuffer([]byte{})
 	enc := json.NewEncoder(buff)
 	enc.SetEscapeHTML(false)
 
-	log.Trace("[EREGS] Encoding part ", p.Name, " to JSON")
+	log.Trace("[eregs] Encoding part ", p.Name, " to JSON")
 	if err := enc.Encode(p); err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func PostPart(ctx context.Context, p *Part) (*http.Response, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(username, password)
-	log.Trace("[EREGS] Posting part ", p.Name)
+	log.Trace("[eregs] Posting part ", p.Name)
 	resp, err := client.Do(req)
 	if err != nil {
 		return resp, err
@@ -65,6 +65,6 @@ func PostPart(ctx context.Context, p *Part) (*http.Response, error) {
 		return resp, fmt.Errorf("%d", resp.StatusCode)
 	}
 
-	log.Debug("[EREGS] Posted ", length, " bytes for part ", p.Name, " in ", time.Since(start))
+	log.Trace("[eregs] Posted ", length, " bytes for part ", p.Name, " in ", time.Since(start))
 	return resp, nil
 }

--- a/tools/ecfr-parser/main.go
+++ b/tools/ecfr-parser/main.go
@@ -135,7 +135,7 @@ func run() error {
 	log.Info("[main] Fetching and processing parts...")
 	ch := make(chan *eregs.Part)
 	var wg sync.WaitGroup
-	for i := 0; i < threads; i++ {
+	for i := 1; i < threads + 1; i++ {
 		wg.Add(1)
 		go startHandlePartWorker(i, ch, &wg, ctx, today)
 	}

--- a/tools/ecfr-parser/main.go
+++ b/tools/ecfr-parser/main.go
@@ -93,7 +93,7 @@ func main() {
 		} else if i == attempts - 1 {
 			log.Fatal("[main] Failed to load regulations ", attempts, " times. Error: ", err)
 		} else {
-			log.Error("[main] Failed to load regulations. Retrying", attempts - i - 1, "more times. Error: ", err)
+			log.Error("[main] Failed to load regulations. Retrying ", attempts - i - 1, " more times. Error: ", err)
 		}
 	}
 }
@@ -175,6 +175,8 @@ func startHandlePartWorker(thread int, ch chan *eregs.Part, wg *sync.WaitGroup, 
 }
 
 func handlePart(thread int, ctx context.Context, date time.Time, reg *eregs.Part) error {
+	start := time.Now()
+
 	log.Debug("[worker ", thread, "] Fetching structure for part ", reg.Name)
 	sbody, err := ecfr.FetchStructure(ctx, date.Format("2006-01-02"), reg.Title, ecfr.PartOption(reg.Name))
 	if err != nil {
@@ -218,6 +220,6 @@ func handlePart(thread int, ctx context.Context, date time.Time, reg *eregs.Part
 		return err
 	}
 
-	log.Debug("[worker ", thread, "] Successfully processed part ", reg.Name)
+	log.Debug("[worker ", thread, "] Successfully processed part ", reg.Name, " in ", time.Since(start))
 	return nil
 }

--- a/tools/ecfr-parser/main.go
+++ b/tools/ecfr-parser/main.go
@@ -70,6 +70,14 @@ func init() {
 		log.Fatal("[main] Title flag is required and must be greater than 0.")
 	}
 
+	if workers < 1 {
+		log.Fatal("[main] Number of worker threads must be at least 1.")
+	}
+
+	if attempts < 1 {
+		log.Fatal("[main] Number of loading attempts must be at least 1.")
+	}
+
 	level := log.WarnLevel
 	switch loglevel {
 	case "fatal":
@@ -82,6 +90,8 @@ func init() {
 		level = log.DebugLevel
 	case "trace":
 		level = log.TraceLevel
+	default:
+		log.Warn("[main] \"", loglevel, "\" is an invalid log level, defaulting to \"warn\".")
 	}
 	log.SetLevel(level)
 }

--- a/tools/ecfr-parser/main.go
+++ b/tools/ecfr-parser/main.go
@@ -26,7 +26,7 @@ var (
 	subchapter      SubchapterArg
 	individualParts PartsArg
 	loglevel        string
-	threads         int
+	workers         int
 )
 
 type SubchapterArg []string
@@ -60,7 +60,7 @@ func init() {
 	flag.Var(&subchapter, "subchapter", "A chapter and subchapter separated by a dash, e.g. IV-C")
 	flag.Var(&individualParts, "parts", "A comma-separated list of parts to load, e.g. 457,460")
 	flag.StringVar(&eregs.BaseURL, "eregs-url", "http://localhost:8080/v2/", "A url specifying where to send eregs parts")
-	flag.IntVar(&threads, "threads", 3, "Number of parts to process simultaneously.")
+	flag.IntVar(&workers, "workers", 3, "Number of parts to process simultaneously.")
 	flag.IntVar(&attempts, "attempts", 1, "The number of times to attempt regulation loading")
 	flag.StringVar(&loglevel, "loglevel", "warn", "Logging severity level. One of: fatal, error, warn, info, debug, trace.")
 	flag.BoolVar(&parseXML.LogParseErrors, "log-parse-errors", true, "Output errors encountered while parsing.")
@@ -132,10 +132,10 @@ func run() error {
 		return err
 	}
 
-	log.Info("[main] Fetching and processing parts...")
+	log.Info("[main] Fetching and processing parts using ", workers, " workers...")
 	ch := make(chan *eregs.Part)
 	var wg sync.WaitGroup
-	for i := 1; i < threads + 1; i++ {
+	for i := 1; i < workers + 1; i++ {
 		wg.Add(1)
 		go startHandlePartWorker(i, ch, &wg, ctx, today)
 	}

--- a/tools/ecfr-parser/parseXML/parseXML.go
+++ b/tools/ecfr-parser/parseXML/parseXML.go
@@ -17,7 +17,7 @@ var LogParseErrors bool
 
 func log_parse_error(err string) {
 	if LogParseErrors {
-		log.Warn("[PARSER] ", err)
+		log.Warn("[parser] ", err)
 	}
 }
 


### PR DESCRIPTION
Utilizing thread pool to limit active connections to 3 at a time. User-configurable via command-line argument "-threads".

Also improved some logging messages. E.g.: changed "[MAIN]" to "[main]" for easier reading.