### PR TITLE
Smaller experimental deploy db's

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -54,6 +54,7 @@ jobs:
           serverless deploy --config ./serverless-experimental.yml --stage dev-$branch_name | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev-$branch_name
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev-$branch_name
+          serverless invoke --config ./serverless-experimental.yml --function populate_content --stage dev-$branch_name
           echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"
           popd
       - uses: actions/setup-go@v2

--- a/serverless/populate_content.py
+++ b/serverless/populate_content.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import os
-import json
-import django
 from django.core.management import call_command
 
 

--- a/serverless/populate_content.py
+++ b/serverless/populate_content.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import json
+import django
+from django.core.management import call_command
 
 
 def handler(event, context):
@@ -8,61 +10,7 @@ def handler(event, context):
     import django
     django.setup()
 
-    content_path = os.environ.get('SUPPLEMENTAL_CONTENT_PATH')
-    content_list = os.listdir(content_path)
-    for file in content_list:
-        print(f'loading {file}...')
-        f = open(f'{content_path}/{file}')
-        data = json.load(f)
-        populate(data)
-
-
-def populate(data):
-    for category in data:
-        print(f'writing {category["title"]}')
-        populate_category(category)
-
-
-def populate_category(category_data):
-    from django.core.exceptions import ObjectDoesNotExist
-    from rest_framework import serializers
-    from supplemental_content.models import Category
-    from supplemental_content.views import SupplementalContentSerializer
-
-    class CategorySerializer(serializers.ModelSerializer):
-        supplemental_content = SupplementalContentSerializer(many=True, read_only=True)
-
-        class Meta:
-            model = Category
-            fields = ("id", "title", "description", "supplemental_content")
-
-    supplemental_contents_data = category_data.pop('supplemental_content')
-
-    try:
-        category = Category.objects.get(title=category_data['title'])
-    except ObjectDoesNotExist:
-        category_serializer = CategorySerializer(data=category_data)
-        if category_serializer.is_valid(raise_exception=True):
-            category = category_serializer.save()
-
-    update_relations(category, supplemental_contents_data)
-
-
-def update_relations(category, supplemental_contents_data):
-    from supplemental_content.models import SupplementalContent, RegulationSection
-
-    for supplemental_content_data in supplemental_contents_data:
-        sections = supplemental_content_data.pop('sections')
-        url = supplemental_content_data.pop('url')
-        supplemental_content, _created = SupplementalContent.objects.get_or_create(
-            url=url,
-            defaults={
-                'category': category,
-                'approved': False,
-                **supplemental_content_data
-            }
-        )
-
-        for section in sections:
-            regulation_section, _created = RegulationSection.objects.get_or_create(**section)
-            regulation_section.supplemental_content.add(supplemental_content)
+    call_command('loaddata', 'supplemental_content.category.json')
+    call_command('loaddata', 'supplemental_content.subcategory.json')
+    call_command('loaddata', 'supplemental_content.section.json')
+    call_command('loaddata', 'supplemental_content.supplementalcontent.json')

--- a/serverless/serverless-experimental.yml
+++ b/serverless/serverless-experimental.yml
@@ -155,7 +155,7 @@ resources:
       Type: AWS::RDS::DBClusterParameterGroup
       Properties:
         Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql10
+        Family: aurora-postgresql13
         Parameters:
           rds.force_ssl: 1
 
@@ -163,7 +163,7 @@ resources:
       Type: AWS::RDS::DBParameterGroup
       Properties:
         Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql10
+        Family: aurora-postgresql13
         Parameters:
           shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
           log_statement: "ddl"

--- a/serverless/serverless-experimental.yml
+++ b/serverless/serverless-experimental.yml
@@ -190,7 +190,7 @@ resources:
         DBSubnetGroupName:
           Ref: DBSubnetGroup
         Engine: aurora-postgresql
-        EngineVersion: "10.18"
+        EngineVersion: "10"
         DatabaseName: ${self:custom.settings.DB_NAME}
         BackupRetentionPeriod: 3
         DBClusterParameterGroupName:
@@ -203,7 +203,7 @@ resources:
       Properties:
         DBInstanceClass: db.t4g.medium
         Engine: aurora-postgresql
-        EngineVersion: "10.18"
+        EngineVersion: "10"
         PubliclyAccessible: false
         DBParameterGroupName:
           Ref: AuroraRDSInstanceParameter

--- a/serverless/serverless-experimental.yml
+++ b/serverless/serverless-experimental.yml
@@ -190,7 +190,7 @@ resources:
         DBSubnetGroupName:
           Ref: DBSubnetGroup
         Engine: aurora-postgresql
-        EngineVersion: "10"
+        EngineVersion: "13.3"
         DatabaseName: ${self:custom.settings.DB_NAME}
         BackupRetentionPeriod: 3
         DBClusterParameterGroupName:
@@ -203,7 +203,7 @@ resources:
       Properties:
         DBInstanceClass: db.t4g.medium
         Engine: aurora-postgresql
-        EngineVersion: "10"
+        EngineVersion: "13.3"
         PubliclyAccessible: false
         DBParameterGroupName:
           Ref: AuroraRDSInstanceParameter

--- a/serverless/serverless-experimental.yml
+++ b/serverless/serverless-experimental.yml
@@ -201,7 +201,7 @@ resources:
     AuroraRDSInstance:
       Type: AWS::RDS::DBInstance
       Properties:
-        DBInstanceClass: db.r5.large
+        DBInstanceClass: db.t4g.medium
         Engine: aurora-postgresql
         EngineVersion: "10.18"
         PubliclyAccessible: false


### PR DESCRIPTION
Using an R(4/5/6).large database was just not required here so I have updated the experimental deploys to use a T4.medium DB as this is the smallest one I can use with the aurora engine.  I also added back in a data load step so now the fixture data will be loaded into the experimental deploys when they are created.