### PR TITLE
Disable fail fast for LoadRegulations action

### DIFF
--- a/.github/workflows/load-regulations.yml
+++ b/.github/workflows/load-regulations.yml
@@ -11,6 +11,7 @@ jobs:
       max-parallel: 1
       matrix:
         environment: ["dev", "val", "prod"]
+      fail-fast: false
     environment:
       name: ${{ matrix.environment }}
     runs-on: ubuntu-latest

--- a/tools/ecfr-parser/ecfr/ecfr.go
+++ b/tools/ecfr-parser/ecfr/ecfr.go
@@ -14,7 +14,7 @@ import (
 )
 
 const dateFormat = "2006-01-02"
-const timeout = 60 * time.Second
+const timeout = 10 * time.Second
 
 
 var (

--- a/tools/ecfr-parser/ecfr/ecfr.go
+++ b/tools/ecfr-parser/ecfr/ecfr.go
@@ -14,7 +14,7 @@ import (
 )
 
 const dateFormat = "2006-01-02"
-const timeout = 10 * time.Second
+const timeout = 60 * time.Second
 
 
 var (

--- a/tools/ecfr-parser/main.go
+++ b/tools/ecfr-parser/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 	"sync"
@@ -267,16 +266,7 @@ func handlePart(thread int, ctx context.Context, date time.Time, reg *eregs.Part
 	}
 
 	log.Debug("[worker ", thread, "] Posting part ", reg.Name, " version ", reg.Date, " to eRegs")
-	resp, err := eregs.PostPart(ctx, reg)
-	if err != nil {
-		if resp != nil {
-			defer resp.Body.Close()
-			response, e := io.ReadAll(resp.Body)
-			if e != nil {
-				log.Error(e)
-			}
-			return fmt.Errorf("%s | %s", err.Error(), string(response))
-		}
+	if err := eregs.PostPart(ctx, reg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* Allows jobs to continue if one fails
* Also fixes leaking file descriptors during post to eRegs. Does NOT fix leak in ecfr.go's fetch function. This is temporarily needed for Github Actions.