### PR TITLE
Prevent Site from being scraped by search engines

### DIFF
--- a/cmcs_regulations/settings.py
+++ b/cmcs_regulations/settings.py
@@ -51,6 +51,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'x_robots_tag_middleware.middleware.XRobotsTagMiddleware',
 ]
 
 REST_FRAMEWORK = {
@@ -159,3 +160,5 @@ HTTP_AUTH_USER = os.environ.get("HTTP_AUTH_USER")
 HTTP_AUTH_PASSWORD = os.environ.get("HTTP_AUTH_PASSWORD")
 
 GA_ID = os.environ.get("GA_ID")
+
+X_ROBOTS_TAG = ['noindex', 'nofollow']

--- a/cmcs_regulations/urls.py
+++ b/cmcs_regulations/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path("", include('regulations.urls')),
     path('favicon.ico', RedirectView.as_view(url=settings.STATIC_URL + 'images/favicon/favicon.ico')),
     path('admin/', admin.site.urls),
+    path('robots.txt', RedirectView.as_view(url=settings.STATIC_URL + 'robots.txt')),
 ]

--- a/config/static-assets/nginx_fonts.conf
+++ b/config/static-assets/nginx_fonts.conf
@@ -10,6 +10,7 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         add_header Access-Control-Allow-Origin *;
+        add_header X-Robots-Tag noindex;
     }
 
     #error_page  404              /404.html;

--- a/regulations/static/regulations/robots.txt
+++ b/regulations/static/regulations/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/regulations/templates/regulations/base.html
+++ b/regulations/templates/regulations/base.html
@@ -19,6 +19,8 @@ CSS/Javascript etc., should inherit from this template.
     </script>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=11; IE=EDGE">
+        {% comment %} Tag for bing to show that I control the site. {% endcomment %}
+        <meta name="msvalidate.01" content="2564ADEFA9801CDF3DD1287C2109D2A9" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>
             {% block title %}

--- a/regulations/templates/regulations/base.html
+++ b/regulations/templates/regulations/base.html
@@ -19,8 +19,9 @@ CSS/Javascript etc., should inherit from this template.
     </script>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=11; IE=EDGE">
-        {% comment %} Tag for bing to show that I control the site. {% endcomment %}
+        {% comment %} Tag for bing and google to show that I control the site. {% endcomment %}
         <meta name="msvalidate.01" content="2564ADEFA9801CDF3DD1287C2109D2A9" />
+        <meta name="google-site-verification" content="iNAu2rAPdykHG6aKtClENiu_fRheE-TBM4drtyCVlWk" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>
             {% block title %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django>=3.1,<4
 requests
 djangorestframework
 psycopg2
+django-x-robots-tag-middleware


### PR DESCRIPTION
I added a robots.txt file at http(s)://url.com/robots.txt that will deny all traffic.  I also added in the header of X-Robots-Tag to django and static asset requests.  All of this can be confirmed with the network console.