### PR TITLE
EREGSCSC-1022 - Make ECFR parser more reliable

### DIFF
--- a/tools/ecfr-parser/ecfr/versions.go
+++ b/tools/ecfr-parser/ecfr/versions.go
@@ -27,6 +27,10 @@ func PartVersions(versions []Version) map[string]map[string]struct{} {
 		if result[version.Part] == nil {
 			result[version.Part] = map[string]struct{}{}
 		}
+		// 2016 is unreliable, bump it up to 2017
+		if (version.Date[0:4] == "2016"){
+		    version.Date = "2017-01-01"
+		}
 		result[version.Part][version.Date] = struct{}{}
 	}
 	return result


### PR DESCRIPTION
This seems to be choking strictly on versions from 2016 so in the case of a 2016 version the parser will adjust the date of the version to 2017-01-01.  This appears to be relatively consistent across the board, but I will also be following up with the ECFR team.