### PR TITLE
fixes problem with missing environment variables in migration process

### DIFF
--- a/serverless/serverless-experimental.yml
+++ b/serverless/serverless-experimental.yml
@@ -48,6 +48,8 @@ functions:
       - http: ANY /
       - http: ANY {proxy+}
   reg_core_migrate:
+    environment:
+      STATIC_URL: ${self:custom.settings.static_url}
     handler: migrate.handler
     timeout: 300
   create_su:

--- a/serverless/serverless-experimental.yml
+++ b/serverless/serverless-experimental.yml
@@ -16,6 +16,7 @@ provider:
     DJANGO_ADMIN_USERNAME: ${ssm:/eregulations/http/user~true}
     DJANGO_ADMIN_PASSWORD: ${ssm:/eregulations/http/password~true}
     ALLOWED_HOST: '.amazonaws.com'
+    STATIC_URL: ${self:custom.settings.static_url}
   vpc:
     securityGroupIds:
       - !Ref ServerlessSecurityGroup
@@ -48,8 +49,6 @@ functions:
       - http: ANY /
       - http: ANY {proxy+}
   reg_core_migrate:
-    environment:
-      STATIC_URL: ${self:custom.settings.static_url}
     handler: migrate.handler
     timeout: 300
   create_su:

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -48,6 +48,8 @@ functions:
       - http: ANY /
       - http: ANY {proxy+}
   reg_core_migrate:
+    environment:
+      STATIC_URL: ${self:custom.settings.static_url}
     handler: migrate.handler
     timeout: 300
   create_su:

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -17,6 +17,7 @@ provider:
     DJANGO_ADMIN_USERNAME: ${ssm:/eregulations/http/user~true}
     DJANGO_ADMIN_PASSWORD: ${ssm:/eregulations/http/password~true}
     ALLOWED_HOST: '.amazonaws.com'
+    STATIC_URL: ${self:custom.settings.static_url}
   vpc:
     securityGroupIds:
       - !Ref ServerlessSecurityGroup

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -49,8 +49,6 @@ functions:
       - http: ANY /
       - http: ANY {proxy+}
   reg_core_migrate:
-    environment:
-      STATIC_URL: ${self:custom.settings.static_url}
     handler: migrate.handler
     timeout: 300
   create_su:


### PR DESCRIPTION
This exposes the STATIC_URL variable that is required for the report admin migrations to succeed.  It is confirmed on the experimental deploys.