### PR TITLE
Remove "Using this Tool" section from about page

### DIFF
--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -64,25 +64,6 @@
 
     </section>
 
-    <section id="using-this-tool">
-      <h2>Using this Tool</h2>
-      
-      <p></p>
-
-      <div id="subregulatory-guidance">
-        <h3>Subregulatory Guidance <span class="indicator">Coming Soon</span></h3>
-        <p>See related State Medicaid Director Letters, CMCS Informational Bulletins, and more.</p>
-      </div>
-      <div id="regulation-history">
-        <h3>Regulation History <span class="indicator">Coming Soon</span></h3>
-        <p>View current and past versions and compare them to find changes over time.</p>
-      </div>
-      <div id="cross-references">
-        <h3>Cross-References <span class="indicator">Coming Soon</span></h3>
-        <p>Use direct links to jump to cited statutes, regulations, and rules.</p>
-      </div>
-    </section>
-
     <section>
       <h2>Technical Details</h2>
       <p>This tool has an <a href="https://github.com/CMSgov/cmcs-eregulations" class="external" target="_blank" rel="noopener noreferrer">open source code repository</a> available for reuse by other government teams.</p>


### PR DESCRIPTION
As part of EREGCSC-950 I want to take a different approach here (demo video with description), but it'll take a certain amount of time, and for now it's best to remove the outdated material to avoid confusion. I could not find anywhere that this section is currently referenced from, so I don't think I'm breaking any links.