### PR TITLE
EREGCSC-950 Add explainer to "about" page

### DIFF
--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -17,7 +17,7 @@
       <p><b>Send questions and suggestions</b> about this website (including bug reports), or schedule a presentation or training for your group: <a href="https://docs.google.com/forms/d/e/1FAIpQLSdoovq7qgVRYsgLeZ7TrXNmnTU42iHCvr1x06CgcWQectlVAw/viewform" target="_blank" class="external">contact the team</a>.</p>
       <p><b>Try new features</b> and help make them better: <a href="https://docs.google.com/forms/d/e/1FAIpQLScesNzqS-Kgpcjq3AxESy1tP0zlcs3CdgkCVr3LBOiUTxxbvw/viewform" class="external" target="_blank" rel="noopener noreferrer">sign up for a session</a>.</p>
     </section>
-    
+
     <section id="automated-updates">
       <h2>Automated Updates</h2>
 
@@ -65,7 +65,6 @@
           </div>
         </div>
       </div>
-
     </section>
 
     <section>

--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -58,7 +58,7 @@
           <div class="ds-l-col--6">
             <h3>Links to Additional Resources</h3>
             <p>Resource links are curated and updated by Medicaid subject matter experts on our team.</p>
-            <p>For example, when Medicaid.gov publishes a new piece of subregulatory guidance in the <a href="https://www.medicaid.gov/new-notable/index.html" class="external" target="_blank">New &amp; Notable Resource Center</a>, we add a link in the sidebar of each relevant subpart within three business days.</p>
+            <p>For example, when Medicaid.gov publishes a new piece of subregulatory guidance in the <a href="https://www.medicaid.gov/new-notable/index.html" class="external" target="_blank">New &amp; Notable Resource Center</a>, we add a link in the sidebar of each relevant subpart.</p>
           </div>
           <div class="ds-l-col--6">
             <img src="{% static 'images/about_additional_resources.svg' %}" alt="Screenshot of Subregulatory Guidance in the right sidebar of this site" />

--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -8,12 +8,16 @@
     <h1>About This Tool</h1>
 
     <section>
+      <p>eRegulations organizes together regulations, subregulatory guidance, and other related policy materials. Our team updates content and functionality several times a week.</p>
+      <p><a href="https://www.youtube.com/watch?v=_6kqjEVHrZM" class="external" target="_blank" rel="noopener noreferrer">View a 3-minute video demonstration.</a></p>
+    </section>
+
+    <section>
       <h2>Contact</h2>
       <p><b>Send questions and suggestions</b> about this website (including bug reports), or schedule a presentation or training for your group: <a href="https://docs.google.com/forms/d/e/1FAIpQLSdoovq7qgVRYsgLeZ7TrXNmnTU42iHCvr1x06CgcWQectlVAw/viewform" target="_blank" class="external">contact the team</a>.</p>
       <p><b>Try new features</b> and help make them better: <a href="https://docs.google.com/forms/d/e/1FAIpQLScesNzqS-Kgpcjq3AxESy1tP0zlcs3CdgkCVr3LBOiUTxxbvw/viewform" class="external" target="_blank" rel="noopener noreferrer">sign up for a session</a>.</p>
-
     </section>
-
+    
     <section id="automated-updates">
       <h2>Automated Updates</h2>
 
@@ -53,8 +57,8 @@
         <div class="ds-l-row">
           <div class="ds-l-col--6">
             <h3>Links to Additional Resources</h3>
-            <p>Resource links are curated and updated by a Medicaid subject matter expert on our team.</p>
-            <p>For example, when Medicaid.gov publishes a new State Medicaid Director Letter in the <a href="https://www.medicaid.gov/new-notable/index.html" class="external" target="_blank">New &amp; Notable Resource Center</a>, we add a link in the sidebar of each relevant subpart.</p>
+            <p>Resource links are curated and updated by Medicaid subject matter experts on our team.</p>
+            <p>For example, when Medicaid.gov publishes a new piece of subregulatory guidance in the <a href="https://www.medicaid.gov/new-notable/index.html" class="external" target="_blank">New &amp; Notable Resource Center</a>, we add a link in the sidebar of each relevant subpart within three business days.</p>
           </div>
           <div class="ds-l-col--6">
             <img src="{% static 'images/about_additional_resources.svg' %}" alt="Screenshot of Subregulatory Guidance in the right sidebar of this site" />


### PR DESCRIPTION
Add brief explanation and video link to the top of the about page; small updates to SME section. This should have team content review before merging.