### PR TITLE
EREGCSC-1114 Parser fails while uploading supplemental content sections sometimes - error 500

### DIFF
--- a/tools/ecfr-parser/main.go
+++ b/tools/ecfr-parser/main.go
@@ -310,7 +310,7 @@ func startHandlePartVersionWorker(ctx context.Context, thread int, ch chan *list
 		}
 	}
 
-	log.Trace("[worker ", thread, "] Worker successfully processed ", processedVersions, "/", processingAttempts, " versions of ", processedParts, " parts.")
+	log.Debug("[worker ", thread, "] Worker successfully processed ", processedVersions, "/", processingAttempts, " versions of ", processedParts, " parts.")
 	wg.Done()
 }
 


### PR DESCRIPTION
Resolves #1114

**Description-**

Error received when uploading supplemental content sections & subparts for some parts to eRegs, causes parser to fail with an exit code after 3 attempts. This is caused by a race condition where the parser is attempting to upload supplemental data for multiple versions of a single part simultaneously.

**This pull request changes...**

Now each worker thread sequentially processes an entire batch of all versions of a given part. This way, there's no chance of duplicate supplemental sections and subparts being created as no 2 versions can be simultaneously processed.

**Steps to manually verify this change...**

1. Run `make data.local` on a clean database
2. Verify no parser errors in terminal ("Successfully processed 122/122 versions")
3. Create Django Admin user and verify no duplicate sections exist in the database.
