### PR TITLE
EREGCSC-1110 changed items per page to 200 in admin panel

### DIFF
--- a/supplemental_content/admin.py
+++ b/supplemental_content/admin.py
@@ -31,7 +31,7 @@ from . import actions
 
 class BaseAdmin(admin.ModelAdmin, ExportCsvMixin):
     change_list_template = "admin/export_all_csv.html"
-    list_per_page = 500
+    list_per_page = 200
     admin_priority = 20
     actions = ["export_as_csv"]
 


### PR DESCRIPTION
Resolves #1110

**Description-**

**This pull request changes...**

- Admin panel to display 200 items per page rather than 500.

**Steps to manually verify this change...**

1. Visit admin panel and click Supplemental Content
2. Verify it is only displaying 200 items per page.

