### PR TITLE
Made row clickable django admin

### DIFF
--- a/solution/backend/supplemental_content/admin.py
+++ b/solution/backend/supplemental_content/admin.py
@@ -99,6 +99,8 @@ class SubSubCategoryAdmin(CategoryAdmin):
 class SupplementalContentAdmin(BaseAdmin):
     admin_priority = 0
     list_display = ("date", "name", "description", "category", "updated_at", "approved")
+    list_display_links = ("date", "name", "description", "category", "updated_at")
+    empty_value_display = 'NONE'
     search_fields = ["date", "name", "description"]
     ordering = ("-updated_at", "-date", "name", "category", "-created_at")
     filter_horizontal = ("locations",)


### PR DESCRIPTION
Made whole row clickable  for supplemental content table in django admin.  Added a value of "NONE" if there is no value assigned.  No impact on database just in place of "-"

