### PR TITLE
EREGCSC-1148 Fix missing formula image in 433.10(c)(8)

### DIFF
--- a/solution/parser/ecfr-parser/parsexml/parsexml.go
+++ b/solution/parser/ecfr-parser/parsexml/parsexml.go
@@ -418,11 +418,7 @@ type Image struct {
 // PostProcess checks an image source, if it's /graphics/X.Y change to new source
 func (img *Image) PostProcess() {
 	if strings.HasPrefix(img.Source, "/graphics/") {
-		splitPath := strings.Split(img.Source, "/")
-		if len(splitPath) < 3 {
-			return //Invalid path length, not our responsibility here
-		}
-		splitName := strings.Split(splitPath[2], ".")
+		splitName := strings.Split(strings.Split(img.Source, "/")[2], ".")
 		if len(splitName) < 2 {
 			return //Invalid filename: have "X", need "X.Y", so leave unchanged
 		}

--- a/solution/parser/ecfr-parser/parsexml/parsexml.go
+++ b/solution/parser/ecfr-parser/parsexml/parsexml.go
@@ -415,6 +415,28 @@ type Image struct {
 	Source string `xml:"src,attr" json:"src"`
 }
 
+// PostProcess checks an image source, if it's /graphics/X.Y change to new source
+func (img *Image) PostProcess() {
+	if strings.HasPrefix(img.Source, "/graphics/") {
+		splitPath := strings.Split(img.Source, "/")
+		if len(splitPath) < 3 {
+			return //Invalid path length, not our responsibility here
+		}
+		splitName := strings.Split(splitPath[2], ".")
+		if len(splitName) < 2 {
+			return //Invalid filename: have "X", need "X.Y", so leave unchanged
+		}
+		var nameSlice []string
+		if len(splitName) > 2 && strings.ToLower(splitName[len(splitName) - 2]) == "eps" {
+			nameSlice = splitName[0:len(splitName)-2] //Remove file extension and "eps" (e.g. "X.eps.gif")
+		} else {
+			nameSlice = splitName[0:len(splitName)-1] //Only remove file extension (e.g. "X.gif")
+		}
+		imgName := strings.ToUpper(strings.Join(nameSlice, "."))
+		img.Source = fmt.Sprintf("https://images.federalregister.gov/%s/large.png", imgName)
+	}
+}
+
 // FootNote is a footnote to the regulation
 type FootNote struct {
 	Type    string `json:"node_type"`

--- a/solution/parser/ecfr-parser/parsexml/parsexml_test.go
+++ b/solution/parser/ecfr-parser/parsexml/parsexml_test.go
@@ -1247,3 +1247,50 @@ func TestParagraphLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestImagePostProcess(t *testing.T) {
+	testTable := []struct {
+		Name string
+		Input string
+		Expected string
+	}{
+		{
+			Name: "test-good-image",
+			Input: "https://images.federalregister.gov/ABCDEF/large.png",
+			Expected: "https://images.federalregister.gov/ABCDEF/large.png",
+		},
+		{
+			Name: "test-rewrite",
+			Input: "/graphics/er27jn96.010.gif",
+			Expected: "https://images.federalregister.gov/ER27JN96.010/large.png",
+		},
+		{
+			Name: "test-eps-rewrite",
+			Input: "/graphics/716-106a.eps.gif",
+			Expected: "https://images.federalregister.gov/716-106A/large.png",
+		},
+		{
+			Name: "test-bad-path-1",
+			Input: "/graphics/",
+			Expected: "/graphics/",
+		},
+		{
+			Name: "test-bad-path-2",
+			Input: "/graphics",
+			Expected: "/graphics",
+		},
+	}
+
+	for _, tc := range testTable {
+		t.Run(tc.Name, func(t *testing.T) {
+			img := Image{
+				Type: "Image",
+				Source: tc.Input,
+			}
+			img.PostProcess()
+			if img.Source != tc.Expected {
+				t.Errorf("expected image source=(%s), received (%s)", tc.Expected, img.Source)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #1148

**Description-**
Image references in eCFR source XMLs are of the format: `/graphics/{image}.{ext}` or `/graphics/{image}.eps.{ext}`. These references no longer resolve, and are now instead hosted on the Federal Register servers.

**This pull request changes...**

- If source is `/graphics/{image}.{ext}`, parser rewrites to `https://images.federalregister.gov/{image uppercase}/large.png`. (E.g. `/graphics/ec14no91.132.gif` -> `https://images.federalregister.gov/EC14NO91.132/large.png`)
- If source is `/graphics/{image}.eps.{ext}`, parser drops "eps" extension and rewrites like above.
- Unit test is written for all cases, see bottom of parsexml_test.go.

**Steps to manually verify this change...**

1. Re-run parser, do not skip existing versions if using a preexisting database. (See http://localhost:8000/admin/regcore/parserconfiguration/)
2. Check if image is rendering correctly at: http://localhost:8000/42/433/Subpart-A/2021-03-01/#433-10-c-8

