### PR TITLE
change deploy order of prototype site

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -113,6 +113,33 @@ jobs:
 
             [1]: ${{ steps.deploy-regulations-site-server.outputs.url }}
           reactions: '+1'
+
+      # build the static assets for the website
+      - name: build static assets and deploy prototype
+        id: build-static-assets-and-deploy-prototype
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          PR: ${{ steps.findPr.outputs.pr }}
+          VUE_APP_API_URL: ${{ steps.deploy-regulations-site-server.outputs.url }}
+        run: |
+          pushd solution/ui/prototype
+          npm ci
+          npm install serverless -g
+          npm run build
+          serverless deploy --stage dev-${PR}
+          echo "::set-output name=url::$(serverless info --stage dev-${PR} --verbose | grep StaticURL | cut -c 12-)"
+          popd
+      # Notify github that this is deployed and ready to look at
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.findPr.outputs.pr }}
+          body: |
+            :sparkles: See this Prototype Site [in action][1] :sparkles:
+
+            [1]: ${{ steps.build-static-assets-and-deploy-prototype.outputs.url }}
+          reactions: '+1'
       # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v2

--- a/.github/workflows/deploy-prototype.yml
+++ b/.github/workflows/deploy-prototype.yml
@@ -1,9 +1,6 @@
 name: "Deploy Prototype"
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
+on: [fork]
 
 jobs:
   deploy:

--- a/solution/ui/prototype/src/App.vue
+++ b/solution/ui/prototype/src/App.vue
@@ -6,7 +6,10 @@
 
 export default {
     name: "App",
-    components: {}
+    components: {},
+    created: function(){
+      console.log("API URL: " + process.env.VUE_APP_API_URL)
+    }
 };
 
 </script>


### PR DESCRIPTION
Resolves # 1175

**Description-**
Deploys prototype site after reg site allowing prototype site to be aware of the reg_site url
**This pull request changes...**

- the order of deployment.  prototype site is no longer a separate step and happens after reg_site is deployed
- prototype site logs the api_url to the console to verify it is accurate

**Steps to manually verify this change...**

1. Go to prototype site
2. look at console.log and ensure it prints the right URL.

