### PR TITLE
EREGCSC-1213 - Show Appendices properly

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/node_types/APPENDIX.html
+++ b/solution/backend/regulations/templates/regulations/partials/node_types/APPENDIX.html
@@ -5,8 +5,11 @@
 
 <section aria-labelledby="{{ node.label | join:'-' }}-title" tabindex="-1" id="{{node.label | join:'-'}}" class="appendix-section">
     <h2 class="section-title" id="{{ node.label | join:'-' }}-title">
-        {% appendix_formatter cfr_title node.label as formatted_citation %}
-        {% include "regulations/partials/copy-btn.html" with title=node.label btn_type="icon" formatted_citation=formatted_citation %}
+
+        {% if node.label and node.label|length > 0 %}
+            {% appendix_formatter cfr_title node.label as formatted_citation %}
+            <copy-btn btn_type="icon" title="{{node.label | join:'.'}}" hash="{{node.label | join:'-'}}" formatted_citation="{{formatted_citation}}"></copy-btn>
+        {% endif %}
         {{node.title}}
     </h2>
 

--- a/solution/backend/regulations/templates/regulations/partials/node_types/Paragraph.html
+++ b/solution/backend/regulations/templates/regulations/partials/node_types/Paragraph.html
@@ -1,9 +1,8 @@
 {% load paragraphs %}
 {% load string_formatters %}
 
-<p tabindex="-1" id="{{node.label | join:'-'}}" class="reg-section depth-{{node|pdepth}}">
+<p tabindex="-1" {% if node.label and node.label|length > 0 %}id="{{node.label | join:'-'}}"{% endif %} class="reg-section depth-{{node|pdepth}}">
     {% if node.label and node.label|length > 0 %}
-        {% paragraph_formatter cfr_title node.label as formatted_citation %}
         <copy-btn btn_type="icon" title="{{node.label | join:'.'}}" hash="{{node.label | join:'-'}}" formatted_citation="{{formatted_citation}}"></copy-btn>
     {% endif %}
     {{node.text | safe}}


### PR DESCRIPTION
fix: use copy-btn vue cmpnt in appendix django template; better safet…y when encountering NoneType

Resolves [EREGCSC-1213](https://jiraent.cms.gov/browse/EREGCSC-1213)

**Description**

Appendix to Subpart F of Part 441 has not been displaying on the [Pilot site](https://regulations-pilot.cms.gov/42/441/Subpart-F/2021-11-05/#441-259).  Instead, the word "None" is being rendered in its place.  

Additionally, clicking on the Appendix link in the left sidebar does nothing. 

Finally, clicking on the link to the appendix at the bottom of the Subpart F sections on the [Part 441 Table of Contents page](https://regulations-pilot.cms.gov/42/441) does not take you to the Appendix location in the reader view; instead [it takes you to the top of Subpart F](https://regulations-pilot.cms.gov/42/441/Subpart-F/2021-11-05/#Appendix-to-Subpart-F-of-Part-441).

**This pull request changes:**

The Appendix Django template is referencing another Django template named `copy-btn.html`.  This template no longer exists; it was replaced with a `<copy-btn>` VueJS component several months ago.  

The `copy-btn.html` template has been removed from the Appendix template and the VueJS component has been added in its place.

A few conditional statements have been added to protect against applying the Django `join` filter to a `NoneType` (`null`) object.

**Steps to manually verify this change:**

1. [Visit the affected area on the Pilot site](https://regulations-pilot.cms.gov/42/441/Subpart-F/2021-11-05/#441-259-da6b3d6cac9961825667fc8e056fc4f9).  Notice that the word "None" is displayed below Section 441.259.  
2. Notice that the link to the appendix in the left sidebar does nothing when clicked.
3. Notice that the link to the Appendix in the [Part 441 Table of Contents page](https://regulations-pilot.cms.gov/42/441) sends you to the [top of Subpart F](https://regulations-pilot.cms.gov/42/441/Subpart-F/2021-11-05/#Appendix-to-Subpart-F-of-Part-441) instead of to the location of the Appendix.
4. Visit the [affected area on the Deploy Experimental site](https://bzt2j0vcjg.execute-api.us-east-1.amazonaws.com/dev-347/42/441/Subpart-F/2021-11-05/#441-259-da6b3d6cac9961825667fc8e056fc4f9) for this branch.  Notice that the appendix now appears below section 441.259.
5. Scroll away from the Appendix.  Notice that the link to the appendix in the left sidebar will now return you to the Appendix when clicked.
6. Notice that the link to the Appendix in the [Part 441 Table of Contents page](https://bzt2j0vcjg.execute-api.us-east-1.amazonaws.com/dev-347/42/441/) correctly sends you to the [location of the Appendix](https://bzt2j0vcjg.execute-api.us-east-1.amazonaws.com/dev-347/42/441/Subpart-F/2021-11-05/#Appendix-to-Subpart-F-of-Part-441) .

