### PR TITLE
existingpart

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'solo',
     'django_opensearch_dsl',
     'corsheaders',
+    'drf_spectacular'
 ]
 
 MIDDLEWARE = [
@@ -68,7 +69,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',
-    )
+    ),
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 ROOT_URLCONF = 'cmcs_regulations.urls'
@@ -186,6 +188,11 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
     r"https://\w+\.execute-api.us-east-1\.amazonaws\.com$",
     r"https://\w+\.cloudfront\.net"
 ]
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'CMCS API',
+    'DESCRIPTION': 'CMCS Project API'
+}
 
 if DEBUG:
     import os  # only if you haven't already imported this

--- a/solution/backend/regcore/views.py
+++ b/solution/backend/regcore/views.py
@@ -12,7 +12,6 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework import authentication
 from rest_framework import exceptions
 
-
 class SettingsUser:
     is_authenticated = False
 
@@ -35,8 +34,7 @@ class ListPartSerializer(serializers.ModelSerializer):
         }
 
 
-class ExistingPartSerializer(serializers.BaseSerializer):
-
+class ExistingPartSerializer(serializers.Serializer):   
     def to_representation(self, instance):
         return {
             'date': instance.get("date"),
@@ -46,7 +44,7 @@ class ExistingPartSerializer(serializers.BaseSerializer):
 
 class PartListView(generics.ListAPIView):
     serializer_class = ListPartSerializer
-
+    
     def get_queryset(self):
         return Part.objects.filter(date__lte=date.today()).distinct("title", "name").order_by("title", "name")
 

--- a/solution/backend/regulations/urls.py
+++ b/solution/backend/regulations/urls.py
@@ -7,6 +7,7 @@ from regulations.views.regulation_landing import RegulationLandingView
 from regulations.views.homepage import HomepageView
 from regulations.views.about import AboutView
 from regulations import converters
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 register_converter(converters.NumericConverter, 'numeric')
 register_converter(converters.SubpartConverter, 'subpart')
@@ -25,4 +26,7 @@ urlpatterns = [
     path('<numeric:title>/<numeric:part>/<version:version>/', PartReaderView.as_view(), name='reader_view'),
     path('goto/', GoToRedirectView.as_view(), name='goto'),
     path('search/', SearchView.as_view(), name='search'),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Optional UI:
+    path('api/swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui')
 ]

--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -12,3 +12,4 @@ django-solo
 django-opensearch-dsl
 python-dateutil~=2.8.2
 django-cors-headers
+drf-spectacular


### PR DESCRIPTION
Resolves #
 CREGCSC-1162

**Description-**
Add swagger documentation to the API

**This pull request changes...**

Adds an api view for our backend.

Slight modification to the api for 
V2/title/{title}/part/{part}/supplmentalcontnent.   Since the swagger view does not work with get_queryset it had to be changed to a get and modifying how the response is serialized.  End result is the same though.
**Steps to manually verify this change...**
 
Go to /api/Swwagger.  This will take you to the swagger view.  Test out any of the apis.  Some require authentication

To test the other change  add this to the end of the url in the normal environment and test environment:
v2/title/42/part/433/supplemental_content?&sections=8&sections=10&sections=11&sections=15&sections=32&sections=34&sections=35&sections=36&sections=37&sections=38&sections=40&subparts=A

Results should be the same.
1. steps to view and verify change

