### PR TITLE
bugfix: add formatted citation templatetage back to pgraph node

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/node_types/Paragraph.html
+++ b/solution/backend/regulations/templates/regulations/partials/node_types/Paragraph.html
@@ -3,6 +3,7 @@
 
 <p tabindex="-1" {% if node.label and node.label|length > 0 %}id="{{node.label | join:'-'}}"{% endif %} class="reg-section depth-{{node|pdepth}}">
     {% if node.label and node.label|length > 0 %}
+        {% paragraph_formatter cfr_title node.label as formatted_citation %}
         <copy-btn btn_type="icon" title="{{node.label | join:'.'}}" hash="{{node.label | join:'-'}}" formatted_citation="{{formatted_citation}}"></copy-btn>
     {% endif %}
     {{node.text | safe}}

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -169,6 +169,11 @@
         border-radius: 3px 0 0 3px;
         outline: none;
 
+        &#search-field {
+            border: 1px solid $border_color;
+            border-right: none;
+        }
+
         &:focus {
             color: $primary_link_hover;
         }


### PR DESCRIPTION
Resolves two issues:

1. on Pilot site where Copy Link tooltip would not show the formatted citation for paragraph nodes.
2. on Pilot site search page, text input was missing border

**Description**
In a previous bugfix story, I removed a templatetag in the paragraph node that created a formatted citation to be used in the copy link/copy citation tooltip.

In another story, styling the prototype header search input removed the border from the pilot site's search page text input.

**This pull request changes*
Adds `paragraph_formatter` templatetag back into paragraph node template.

Adds border styling back to pilot site search page's text input while not affecting the prototype's style.

**Steps to manually verify this change**

To test paragraph formatted citation:
1. Go to the pilot site and visit any subpart.  Click on the chain link icon to the left of a paragraph.  
  a. example: 433.10 (b)
  b. https://regulations-pilot.cms.gov/42/433/Subpart-A/2021-03-01/
  c. ![Screen Shot 2022-03-08 at 15 56 26](https://user-images.githubusercontent.com/1651907/157324171-226b8765-f953-44b7-a9a8-3f14d704c6d4.png)
2. You will see a tooltip that contains a Copy Link button and a Copy Citation button, but no formatted citation.
  a. ![Screen Shot 2022-03-08 at 15 57 18](https://user-images.githubusercontent.com/1651907/157324267-05e15c15-c0da-4c97-90f3-54977d454e70.png)
4. Go to the deploy experimental site (see link in comments below) or build site locally and visit the same section: 433.10 (b). Click on the chain link icon to the left of the paragraph
5. You will see a tooltip that contains a Copy Link button and a Copy Citation button, as well as a formatted citation.
  a. ![Screen Shot 2022-03-08 at 15 57 27](https://user-images.githubusercontent.com/1651907/157324314-66ecc621-1ccd-40d1-8d8e-b5ff127f0dea.png)

To test search text input border:
1. Go to pilot site and search for any term.  You will be taken to the Search page.  Notice the lack of border around the search text input.
  a. example: https://regulations-pilot.cms.gov/search/?q=test
  b. <img width="822" alt="Screen Shot 2022-03-09 at 10 20 20" src="https://user-images.githubusercontent.com/1651907/157473120-b29e8b79-0df3-4545-84eb-076f340cdf59.png">
2. Go to the deploy experimental site (see link in comments below) or build site locally and search for same term.  You should now see a border around the search text input.
  a. <img width="771" alt="Screen Shot 2022-03-09 at 10 19 07" src="https://user-images.githubusercontent.com/1651907/157473284-1e76273f-4368-47b2-b303-e1ceee2d1239.png">
3. Go to prototype site or build it locally and make sure the Search input in header at the top right corner of the screen still does not have a border.
  a. <img width="337" alt="Screen Shot 2022-03-09 at 10 27 54" src="https://user-images.githubusercontent.com/1651907/157473479-f47b588c-44f4-4d5e-88b8-c98262e8097f.png">


