### PR TITLE
EREGCSC-1162 - Descriptive Swagger page title + fix typo

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -197,8 +197,8 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
 ]
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'CMCS API',
-    'DESCRIPTION': 'CMCS Project API'
+    'TITLE': 'CMCS eRegulations API',
+    'DESCRIPTION': 'Medicaid and CHIP regulation content and associated supplemental content (such as subregulatory guidance)'
 }
 
 if DEBUG:

--- a/solution/backend/supplemental_content/views.py
+++ b/solution/backend/supplemental_content/views.py
@@ -45,7 +45,7 @@ class SupplementalContentView(generics.ListAPIView):
                                                 required=False, type=arrayStrings),
                                OpenApiParameter(name='subjectgroups', description='Subject groups to filter by.',
                                                 required=False, type=arrayStrings)])
-    @extend_schema(description='Get a list of supplmental content')
+    @extend_schema(description='Get a list of supplemental content')
     def get(self, *args, **kwargs):
         title = kwargs.get("title")
         part = kwargs.get("part")


### PR DESCRIPTION
Followup as part of [EREGCSC-1162](https://jiraent.cms.gov/browse/EREGCSC-1162)

**Description-**

As part of the AC related to helping other developers who may be interested in using the API, this change provides minor clarifications in the documentation.

**This pull request changes...**

- Should make Swagger page display a more accurate title and description at the top
- Fixes typo in description for /v2/title/{title}/part/{part}/supplemental_content

**Steps to manually verify this change...**

1. Check out the Swagger page at /api/swagger/ and see if those two things happened.