### PR TITLE
copied in deployment for prototype site.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @theabrad @PhilR8 @cgodwin1 @knollfear
+*  @twalker6 @PhilR8 @cgodwin1 @knollfear

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,21 @@ jobs:
           serverless deploy --stage ${{ matrix.environment }}
           AWS_CLIENT_TIMEOUT=360000 serverless invoke --function ecfr_parser --stage ${{ matrix.environment }}
           popd
+      # build the static assets for the prototype website
+      - name: build static assets and deploy prototype
+        id: build-static-assets-and-deploy-prototype
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          VUE_APP_API_URL: ${{ steps.deploy-regulations-site-server.outputs.url }}
+        run: |
+          pushd solution/ui/prototype
+          npm ci
+          npm install serverless -g
+          npm run build
+          serverless deploy --stage ${{ matrix.environment }}
+          echo "::set-output name=url::$(serverless info --stage ${{ matrix.environment }} --verbose | grep StaticURL | cut -c 12-)"
+          popd
       - name: end-to-end tests
         uses: cypress-io/github-action@v2
         with:


### PR DESCRIPTION
Resolves #1239

**Description-**

Adds deployment of the prototype site to the main deployment process.  This will allow for a static, non changing URL for the prototype site that connects to the production database.

**This pull request changes...**

- deployment action adds a section for deploying the prototype.

**Steps to manually verify this change...**

1. This can not be verified until it the PR is approved and the deployment action is run.
2. When the deploy script runs it should print the cloudfront ID to the console.  Otherwise the URL should be available on the AWS console.  That URL should show the prototype site.

