### PR TITLE
EREGCSC-1226 hide show resource buttons

### DIFF
--- a/solution/ui/prototype/src/components/PDPart/SectionCards.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCards.vue
@@ -50,13 +50,11 @@
 </template>
 
 <script>
-import { getSupplementalContentNew } from "@/utilities/api";
 
 export default {
     name: "SectionCards",
     data: () => ({
         show: false,
-        supList: null
     }),
     props: {
         title: { type: String },

--- a/solution/ui/prototype/src/components/SectionResources.vue
+++ b/solution/ui/prototype/src/components/SectionResources.vue
@@ -137,7 +137,7 @@ export default {
     props: {
         title: String,
         part: String,
-        selectedIdentifier: String,
+        selectedIdentifier: Array,
         selectedScope: String,
     },
 

--- a/solution/ui/prototype/src/components/SectionResourcesSidebar.vue
+++ b/solution/ui/prototype/src/components/SectionResourcesSidebar.vue
@@ -66,7 +66,7 @@ export default {
     props: {
         title: String,
         part: String,
-        selectedIdentifier: String,
+        selectedIdentifier: Array,
         selectedScope: String,
     },
 

--- a/solution/ui/prototype/src/components/node_types/Node.vue
+++ b/solution/ui/prototype/src/components/node_types/Node.vue
@@ -8,6 +8,8 @@
         :resourceParamsEmitter="resourceParamsEmitter"
         :showResourceButtons="showResourceButtons"
         :supplementalContentCount="supplementalContentCount"
+        :title="title"
+        :part="part"
     ></component>
 </template>
 
@@ -36,6 +38,14 @@ export default {
     },
 
     props: {
+        title: {
+            type: String,
+            required: false,
+        },
+        part: {
+            type: String,
+            required: false,
+        },
         node: {
             type: Object,
             required: true,

--- a/solution/ui/prototype/src/components/node_types/Section.vue
+++ b/solution/ui/prototype/src/components/node_types/Section.vue
@@ -50,6 +50,14 @@ export default {
     },
 
     props: {
+        title: {
+            type: String,
+            required: false,
+        },
+        part: {
+            type: String,
+            required: false,
+        },
         node: {
             type: Object,
             required: true,
@@ -85,19 +93,7 @@ export default {
 
     methods: {
         async handleBtnClick() {
-            try {
-                this.supList = await getSupplementalContentNew(
-                    42,
-                    this.node.label[0],
-                    [this.node.label[1]]
-                );
-            } catch (error) {
-                console.error(error);
-            } finally {
-                console.log(this.structure);
-            }
-            
-            this.resourceParamsEmitter("supList", this.supList);
+            this.resourceParamsEmitter("section", [this.node.label[1]]);
         },
     },
 };

--- a/solution/ui/prototype/src/components/node_types/Section.vue
+++ b/solution/ui/prototype/src/components/node_types/Section.vue
@@ -8,7 +8,7 @@
         <h2 class="section-title" :id="kebabTitle">
             <button
                 v-on:click="handleBtnClick"
-                v-if="numSupplementalContent"
+                v-if="numSupplementalContent && !showResourceButtons"
                 class="supplemental-content-count"
             >
                 {{ numSupplementalContent }}
@@ -26,7 +26,7 @@
                 />
             </template>
         </div>
-        <div v-if="showResourceButtons" class="btn-container">
+        <div v-if="showResourceButtons && numSupplementalContent" class="btn-container">
             <ResourcesBtn
                 :clickHandler="handleBtnClick"
                 label="Section"

--- a/solution/ui/prototype/src/components/node_types/Subpart.vue
+++ b/solution/ui/prototype/src/components/node_types/Subpart.vue
@@ -2,7 +2,7 @@
     <article>
         <h1 tabindex="-1" :id="kebabTitle">
             <button
-                v-if="numSupplementalContent"
+                v-if="numSupplementalContent && !showResourceButtons"
                 v-on:click="handleBtnClick"
                 class="supplemental-content-count"
             >
@@ -10,7 +10,7 @@
             </button>
             {{ node.title }}
         </h1>
-        <div v-if="showResourceButtons" class="btn-container">
+        <div v-if="showResourceButtons  && numSupplementalContent" class="btn-container">
             <ResourcesBtn
                 :clickHandler="handleBtnClick"
                 label="Subpart"

--- a/solution/ui/prototype/src/components/node_types/Subpart.vue
+++ b/solution/ui/prototype/src/components/node_types/Subpart.vue
@@ -3,14 +3,14 @@
         <h1 tabindex="-1" :id="kebabTitle">
             <button
                 v-if="numSupplementalContent && !showResourceButtons"
-                v-on:click="handleBtnClick"
+                v-on:click="handleBlueBtnClick"
                 class="supplemental-content-count"
             >
                 {{ numSupplementalContent }}
             </button>
             {{ node.title }}
         </h1>
-        <div v-if="showResourceButtons  && numSupplementalContent" class="btn-container">
+        <div v-if="showResourceButtons  && numDirectContent" class="btn-container">
             <ResourcesBtn
                 :clickHandler="handleBtnClick"
                 label="Subpart"
@@ -43,6 +43,14 @@ export default {
     },
 
     props: {
+        title: {
+            type: String,
+            required: false,
+        },
+        part: {
+            type: String,
+            required: false,
+        },
         node: {
             type: Object,
             required: true,
@@ -77,6 +85,10 @@ export default {
             }, 0)
           }
           return total
+        },
+        numDirectContent(){
+          console.log(`${this.title} ${this.part} Subpart ${this.node.label[0]}`)
+          return this.supplementalContentCount[`${this.title} ${this.part} Subpart ${this.node.label[0]}`]
         }
     },
 
@@ -84,6 +96,10 @@ export default {
         handleBtnClick() {
             this.resourceParamsEmitter("subpart", this.node.label[0]);
         },
+        handleBlueBtnClick() {
+          console.log(this.node.children.map(child => child.label[1]))
+          this.resourceParamsEmitter("sections", this.node.children.map(child => child.label[1]));
+        }
     },
 };
 </script>

--- a/solution/ui/prototype/src/components/node_types/Subpart.vue
+++ b/solution/ui/prototype/src/components/node_types/Subpart.vue
@@ -87,17 +87,15 @@ export default {
           return total
         },
         numDirectContent(){
-          console.log(`${this.title} ${this.part} Subpart ${this.node.label[0]}`)
           return this.supplementalContentCount[`${this.title} ${this.part} Subpart ${this.node.label[0]}`]
         }
     },
 
     methods: {
         handleBtnClick() {
-            this.resourceParamsEmitter("subpart", this.node.label[0]);
+            this.resourceParamsEmitter("subpart", [this.node.label[0]]);
         },
         handleBlueBtnClick() {
-          console.log(this.node.children.map(child => child.label[1]))
           this.resourceParamsEmitter("sections", this.node.children.map(child => child.label[1]));
         }
     },

--- a/solution/ui/prototype/src/components/part/PartContent.vue
+++ b/solution/ui/prototype/src/components/part/PartContent.vue
@@ -12,6 +12,8 @@
                 :resourceParamsEmitter="emitResourcesParams"
                 :showResourceButtons="showResourceButtons"
                 :supplementalContentCount="supplementalContentCount"
+                :title="title"
+                :part="part"
             />
         </div>
         <div v-else>

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -213,7 +213,7 @@ export default {
             } catch (error) {
                 console.error(error);
             } finally {
-                console.log(this.suplist);
+                console.log(this.supList);
             }
             // Implement response to user choosing a section or subpart here
         },

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -43,6 +43,7 @@ import {
     getPartsList,
     getSectionsForSubPart,
     getSupplementalContentCountForPart,
+    getSupplementalContentNew
 } from "@/utilities/api";
 export default {
     name: "Part",
@@ -202,9 +203,18 @@ export default {
         },
     },
     methods: {
-        setResourcesParams(payload) {
-     
-            this.supList = payload["identifier"];
+        async setResourcesParams(payload) {
+            try {
+                this.supList = await getSupplementalContentNew(
+                    42,
+                    this.part,
+                    payload["identifier"]
+                );
+            } catch (error) {
+                console.error(error);
+            } finally {
+                console.log(this.suplist);
+            }
             // Implement response to user choosing a section or subpart here
         },
         changeSection: function (updatedSection) {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -35,6 +35,7 @@
                             :resourcesDisplay="resourcesDisplay"
                             :selectedIdentifier="selectedIdentifier"
                             :selectedScope="selectedScope"
+                            :supplementalContentCount="supplementalContentCount"
                             @view-resources="setResourcesParams"
                         ></component>
                     </v-tab-item>
@@ -71,7 +72,7 @@ import PartToc from "@/components/part/PartToc.vue";
 import SectionResources from "@/components/SectionResources.vue";
 import SectionResourcesSidebar from "@/components/SectionResourcesSidebar.vue";
 
-import { getPart } from "@/utilities/api";
+import { getPart, getSupplementalContentCountForPart } from "@/utilities/api";
 
 export default {
     components: {
@@ -125,6 +126,7 @@ export default {
             ],
             selectedIdentifier: null,
             selectedScope: null,
+            supplementalContentCount: {},
         };
     },
 
@@ -157,6 +159,7 @@ export default {
                     this.title = toParams.title;
                     this.part = toParams.part;
                     this.resourcesDisplay = toParams.resourcesDisplay || "drawer";
+
                 }
             }
         );
@@ -168,6 +171,7 @@ export default {
         async getPartStructure() {
             try {
                 this.structure = await getPart(this.title, this.part);
+                this.supplementalContentCount = await getSupplementalContentCountForPart(this.part);
             } catch (error) {
                 console.error(error);
             } finally {


### PR DESCRIPTION
Resolves #EREGCSC-1226 and #EREGCSC-1229

**Description-**

Cleans up some interactions between the PD and JS views. Ensures that buttons for "Show Resources" only show if there are resources to show.


**This pull request changes...**

- Show Resources button only shows if that subpart or section resource has resources.  For subpart this means supplemental content directly on the subpart.  For the PD view the blue button will show content for all sections in that subpart.  

**Steps to manually verify this change...**

1. on 42/400 none of the subparts have supplemental content so those buttons should not show.
2.on 42/441 subpart B has content so should show up.  
3. 400.202 has no supplemental content so no show resources button should show.
