### PR TITLE
EREGCSC-1241 Consistent "View all resources" buttons in JS and PD

### DIFF
--- a/solution/ui/prototype/package.json
+++ b/solution/ui/prototype/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint",
-    "start-container": "docker compose up -d",
+    "start-container": "docker-compose up -d",
     "stop-container": "docker-compose down --remove-orphans --volumes"
   },
   "dependencies": {

--- a/solution/ui/prototype/src/components/SectionResources.vue
+++ b/solution/ui/prototype/src/components/SectionResources.vue
@@ -25,7 +25,7 @@
                 <span class="subsection">§</span>
                 <span class="resource-title"> {{ titleLabel }} Resources </span>
                 <a style="font-size: 14px; margin-left: 30px">
-                    Show All Resources</a
+                    View All Resources</a
                 >
             </div>
             <div class="wrapper">


### PR DESCRIPTION
Resolves #1241

**Description-**

In order to have a smooth usability test flow, we should mend the following gaps identified in our 3/22 walkthrough:
- In JS drawer version, "Show All Resources" button at the top of the drawer should say "View All Resources".

**Steps to manually verify this change...**

1. Visit `/42/433` and click on "View Section Resources" for any section
2. Verify correct link text

