### PR TITLE
Prototype cleanup 1

### DIFF
--- a/solution/backend/supplemental_content/views.py
+++ b/solution/backend/supplemental_content/views.py
@@ -117,7 +117,10 @@ class SupplementalContentSectionsView(generics.CreateAPIView):
 class SupplementalContentByPartView(APIView):
     def get(self, request, format=None):
         part = request.GET.get('part', '')
-        results = AbstractLocation.objects.filter(part=part).annotate(num_locations=Count('supplemental_content')).filter(
+        results = AbstractLocation.objects.filter(part=part).annotate(
+            num_locations=Count(
+                'supplemental_content', filter=Q(supplemental_content__approved="t")
+            )).filter(
             num_locations__gt=0)
         data = {}
         for r in results:

--- a/solution/backend/supplemental_content/views.py
+++ b/solution/backend/supplemental_content/views.py
@@ -66,13 +66,7 @@ class SupplementalContentView(generics.ListAPIView):
         ).prefetch_related(
             Prefetch(
                 'locations',
-                queryset=AbstractLocation.objects.filter(
-                    Q(section__section_id__in=section_list) |
-                    Q(subpart__subpart_id__in=subpart_list) |
-                    Q(subjectgroup__subject_group_id__in=subjgrp_list),
-                    title=title,
-                    part=part,
-                )
+                queryset=AbstractLocation.objects.all()
             )
         ).prefetch_related(
             Prefetch(

--- a/solution/ui/prototype/src/components/PDPart/Breadcrumbs.vue
+++ b/solution/ui/prototype/src/components/PDPart/Breadcrumbs.vue
@@ -1,5 +1,5 @@
 <template>
-    <span>
+    <span class="breadcrumbs">
         <router-link
             v-if="subPart"
             :to="{
@@ -43,4 +43,13 @@ export default {
 
 <style scoped>
 
+.breadcrumbs{
+    font-family: Open Sans;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 30px;
+    letter-spacing: 0em;
+    text-align: left;
+}
 </style>

--- a/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
+++ b/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
@@ -42,7 +42,7 @@
                 </v-expansion-panel-content>
             </v-expansion-panel>
         </v-expansion-panels>
-
+        <h1 style="margin-bottom:0px" v-if="!subPart && !section">Part {{this.part}} - {{ this.partLabel }}</h1>
         <PartContent
             v-if="structure.length"
             :structure="structure"
@@ -75,6 +75,7 @@ export default {
         structure: { type: Array },
         navigation: { type: Object },
         supplementalContentCount: { type: Object },
+        partLabel: {type: String},
     },
     methods: {
         setResourcesParams(payload) {

--- a/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
+++ b/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
@@ -9,7 +9,7 @@
                     :section="section"
                 />
             </h2>
-            <span style="float: right">
+            <span style="float: right" class="breadcrumbs">
                 <router-link
                     v-if="navigation.previous"
                     :to="{
@@ -92,4 +92,13 @@ export default {
 </script>
 
 <style scoped>
+  .breadcrumbs{
+      font-family: Open Sans;
+      font-size: 12px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 30px;
+      letter-spacing: 0em;
+      text-align: left;
+  }
 </style>

--- a/solution/ui/prototype/src/components/PDPart/RightColumn.vue
+++ b/solution/ui/prototype/src/components/PDPart/RightColumn.vue
@@ -1,18 +1,61 @@
 <template>
     <div style="width: 100%; margin: 20px">
         <div>
-            <h2 style="display: inline">Part {{ part }} resources</h2>
+            <h2 style="display: inline">
+                Part {{ part }} resources
+            </h2>
             <span style="float: right">
-                <a>Filter and sort resources</a>
+                <a @click="showFilter = !showFilter">Filter and sort resources</a>
             </span>
         </div>
         <div>
-            <v-text-field clearable outlined class="example"> </v-text-field>
+            <v-text-field
+                clearable
+                outlined
+                class="example"
+            />
+        </div>
+        <div v-if="showFilter">
+            <v-container fluid>
+                <v-row
+                    align="center"
+                >
+                    <v-col
+                        cols="8"
+
+                    >
+                        <label
+                            class="label"
+                            style="display: inline"
+                        >Resource Type</label>
+                        <v-select
+                            :items="[1,2,3,4,5]"
+                            multiple
+                            outlined
+                            chips
+                        />
+                    </v-col>
+                    <v-col
+                        cols="3"
+                    >
+                        <label
+                            class="label"
+                            style="display: inline"
+                        >Sort by</label>
+                        <v-select
+                            :items="['Relevance', 'Most Recent', 'Regulation hierarchy', 'Resource type']"
+                            outlined
+                            chips
+                        />
+                    </v-col>
+                </v-row>
+            </v-container>
         </div>
         <TabFilters
-            v-bind:title="title"
-            v-bind:part="part"
-            v-bind:supList="supList"
+            :title="title"
+            :part="part"
+            :sup-list="supList"
+            :suggestedTab="suggestedTab"
         />
     </div>
 </template>
@@ -20,20 +63,29 @@
 <script>
 import TabFilters from "./TabFilters.vue";
 export default {
+    name: "RightColumn",
     components: {
         TabFilters,
     },
-    name: "RightColumn",
     props: {
         title: { type: String },
         part: { type: String },
         supList: { type: Array },
+        suggestedTab: { type: String},
     },
     data() {
         return {
             tabs: null,
+            showFilter:false
         };
     },
+    watch: {
+      supList:{
+          async handler() {
+            this.tabs = 2
+          }
+      }
+    }
 };
 </script>
 
@@ -41,5 +93,9 @@ export default {
 .v-text-field.v-text-field--enclosed .v-input__slot {
     width: 90% !important;
     max-width: 90% !important;
+}
+.label{
+  font-size: 14px;
+  font-weight: 700;
 }
 </style>

--- a/solution/ui/prototype/src/components/PDPart/SectionCard.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCard.vue
@@ -18,6 +18,7 @@
             <v-btn
                 color="#5B616B"
                 text
+                @click="showLocation = !showLocation"
             >
                 Relevant Regulations
             </v-btn>
@@ -31,7 +32,7 @@
             >
                 <v-icon>
                     {{
-                      showLocation ? "mdi-chevron-up" : "mdi-chevron-down"
+                        showLocation ? "mdi-chevron-up" : "mdi-chevron-down"
                     }}
                 </v-icon>
             </v-btn>
@@ -41,49 +42,53 @@
             <div v-show="showLocation">
                 <v-divider />
                 <v-card-text>
-                    This resource is linked to the following subparts:
-                    <ul>
-                        <li v-for="location in subpartLocations">
-                          Part
-                          <router-link
-                            :to="{
-                                name: 'PDpart-subPart',
-                                params: {
-                                  title: location.title,
-                                  part:location.part,
-                                  subPart: 'subPart-' + location.display_name[location.display_name.length -1]
-                                },
-                            }"
-                        >
-                            {{location.display_name.slice(3,)}}
-                          </router-link>
-                        </li>
-                    </ul>
-                    This resource is linked to the following sections:
-                    <ul>
-                        <li v-for="(locations, part) in sectionLocations">
-                            Within <a>Part {{ part }}</a>
-                            <ul>
-                                <li>
-                                    §§ <span v-for="location in locations">
+                    <div v-if="subpartLocations.length > 0">
+                        This resource is linked to the following subparts:
+                        <ul>
+                            <li v-for="location in subpartLocations">
+                                Part
+                                <router-link
+                                    :to="{
+                                        name: 'PDpart-subPart',
+                                        params: {
+                                            title: location.title,
+                                            part:location.part,
+                                            subPart: 'subPart-' + location.display_name[location.display_name.length -1]
+                                        },
+                                    }"
+                                >
+                                    {{ location.display_name.slice(3,) }}
+                                </router-link>
+                            </li>
+                        </ul>
+                    </div>
+                    <div v-if="sectionLocations">
+                        This resource is linked to the following sections:
+                        <ul>
+                            <li v-for="(locations, part) in sectionLocations">
+                                Within <a>Part {{ part }}</a>
+                                <ul>
+                                    <li>
+                                        §§ <span v-for="location in locations">
                               
-                                        <router-link
-                                            :to="{
-                                                name: 'PDpart',
-                                                params: {
-                                                  title: location.title,
-                                                  part: location.part,
-                                                },
-                                            }"
-                                        >
-                                            {{ location.display_name.slice(3,) }}
-                                        </router-link>
+                                            <router-link
+                                                :to="{
+                                                    name: 'PDpart',
+                                                    params: {
+                                                        title: location.title,
+                                                        part: location.part,
+                                                    },
+                                                }"
+                                            >
+                                                {{ location.display_name.slice(3,) }}
+                                            </router-link>
                                     &nbsp;
-                                    </span>
-                                </li>
-                            </ul>
-                        </li>
-                    </ul>
+                                        </span>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
                 </v-card-text>
             </div>
         </v-expand-transition>

--- a/solution/ui/prototype/src/components/PDPart/SectionCard.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCard.vue
@@ -1,0 +1,131 @@
+<template>
+    <v-card
+        outlined
+        elevation="1"
+        width="100%"
+        class="mx-auto"
+    >
+        <v-card-subtitle color="#102e43">
+            {{
+                f.category
+            }}
+        </v-card-subtitle><v-card-text>
+            <a :href="f.url">
+                {{ f.description }}
+            </a>
+        </v-card-text>
+        <v-card-actions>
+            <v-btn
+                color="#5B616B"
+                text
+            >
+                Relevant Regulations
+            </v-btn>
+
+            <v-spacer />
+
+            <v-btn
+                color="#5B616B"
+                icon
+                @click="showLocation = !showLocation"
+            >
+                <v-icon>
+                    {{
+                      showLocation ? "mdi-chevron-up" : "mdi-chevron-down"
+                    }}
+                </v-icon>
+            </v-btn>
+        </v-card-actions>
+
+        <v-expand-transition>
+            <div v-show="showLocation">
+                <v-divider />
+                <v-card-text>
+                    This resource is linked to the following subparts:
+                    <ul>
+                        <li v-for="location in subpartLocations">
+                          Part
+                          <router-link
+                            :to="{
+                                name: 'PDpart-subPart',
+                                params: {
+                                  title: location.title,
+                                  part:location.part,
+                                  subPart: 'subPart-' + location.display_name[location.display_name.length -1]
+                                },
+                            }"
+                        >
+                            {{location.display_name.slice(3,)}}
+                          </router-link>
+                        </li>
+                    </ul>
+                    This resource is linked to the following sections:
+                    <ul>
+                        <li v-for="(locations, part) in sectionLocations">
+                            Within <a>Part {{ part }}</a>
+                            <ul>
+                                <li>
+                                    §§ <span v-for="location in locations">
+                              
+                                        <router-link
+                                            :to="{
+                                                name: 'PDpart',
+                                                params: {
+                                                  title: location.title,
+                                                  part: location.part,
+                                                },
+                                            }"
+                                        >
+                                            {{ location.display_name.slice(3,) }}
+                                        </router-link>
+                                    &nbsp;
+                                    </span>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </v-card-text>
+            </div>
+        </v-expand-transition>
+    </v-card>
+</template>
+
+<script>
+export default {
+  name: "SectionCard",
+  props: {
+    f: {type: Object}
+  },
+  data: () => ({
+    showLocation: false,
+  }),
+  computed:{
+    subpartLocations(){
+      const results = []
+      this.f.locations.forEach( l => {
+        if (l.display_name.indexOf('Subpart') > 0) {
+            results.push(l)
+        }
+      })
+      return results
+    },
+    sectionLocations (){
+      const results = {}
+      this.f.locations.forEach( l => {
+        if (l.display_name.indexOf('Subpart') < 0) {
+          if (results[l.part]) {
+            results[l.part].push(l)
+          } else {
+            results[l.part] = [l]
+          }
+        }
+      })
+      return results
+    },
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/solution/ui/prototype/src/components/PDPart/SectionCard.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCard.vue
@@ -4,6 +4,7 @@
         elevation="1"
         width="100%"
         class="mx-auto"
+        :key="f.url"
     >
         <v-card-subtitle color="#102e43">
             {{
@@ -14,11 +15,12 @@
                 {{ f.description }}
             </a>
         </v-card-text>
-        <v-card-actions>
+        <v-card-actions
+          @click="showLocation = !showLocation"
+        >
             <v-btn
                 color="#5B616B"
                 text
-                @click="showLocation = !showLocation"
             >
                 Relevant Regulations
             </v-btn>
@@ -28,7 +30,6 @@
             <v-btn
                 color="#5B616B"
                 icon
-                @click="showLocation = !showLocation"
             >
                 <v-icon>
                     {{

--- a/solution/ui/prototype/src/components/PDPart/SectionCards.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCards.vue
@@ -5,62 +5,18 @@
             :key="f.name"
             class="card"
         >
-            <v-card
-                outlined
-                elevation="1"
-                width="100%"
-                class="mx-auto"
-            >
-                <v-card-subtitle color="#102e43">
-                    {{
-                        f.category
-                    }}
-                </v-card-subtitle><v-card-text>
-                    <a :href="f.url">
-                        {{ f.description }}
-                    </a>
-                </v-card-text>
-                <v-card-actions>
-                    <v-btn
-                        color="#5B616B"
-                        text
-                    >
-                        Relevant Regulations
-                    </v-btn>
-
-                    <v-spacer />
-
-                    <v-btn
-                        color="#5B616B"
-                        icon
-                        @click="toggleLocations(f)"
-                    >
-                        <v-icon>
-                            {{
-                                show === f.url ? "mdi-chevron-up" : "mdi-chevron-down"
-                            }}
-                        </v-icon>
-                    </v-btn>
-                </v-card-actions>
-
-                <v-expand-transition>
-                    <div v-show="show === f.url">
-                        <v-divider />
-                        <v-card-text>
-                            {{ f.locations }}
-                        </v-card-text>
-                    </div>
-                </v-expand-transition>
-            </v-card>
+            <SectionCard :f="f"/>
         </div>
     </div>
 </template>
 
 <script>
 
+import SectionCard from "./SectionCard";
 export default {
     name: "SectionCards",
-    props: {
+  components: {SectionCard},
+  props: {
         title: { type: String },
         part: { type: String },
         supList: {type: Array},

--- a/solution/ui/prototype/src/components/PDPart/SectionCards.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCards.vue
@@ -46,7 +46,6 @@ export default {
                     .forEach(c => content.push(c))
               })
             })
-        console.log(content)
         return content
       }
     },

--- a/solution/ui/prototype/src/components/PDPart/SectionCards.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCards.vue
@@ -1,50 +1,57 @@
 <template>
     <div>
-        <div v-for="content in supList" :key="content.name">
-            <div v-for="c in content.sub_categories" :key="c.name">
-                <div v-for="f in c.supplemental_content" :key="f.name" class = "card">
-                    <v-card outlined elevation="1" width="100%" class="mx-auto"
-                        ><v-card-subtitle color="#102e43">{{
-                            content.name
-                        }}</v-card-subtitle
-                        ><v-card-text
-                            ><a v-bind:href="f.url">
-                                {{ f.description }}
-                            </a></v-card-text
-                        >
-                        <v-card-actions>
-                            <v-btn color="#5B616B" text>
-                                Relevant Regulations
-                            </v-btn>
-
-                            <v-spacer></v-spacer>
-
-                            <v-btn color="#5B616B" icon @click="show = !show">
-                                <v-icon>{{
-                                    show ? "mdi-chevron-up" : "mdi-chevron-down"
-                                }}</v-icon>
-                            </v-btn>
-                        </v-card-actions>
-
-                        <v-expand-transition>
-                            <div v-show="show">
-                                <v-divider></v-divider>
-
-                                <v-card-text>
-                                    I'm a thing. But, like most politicians, he
-                                    promised more than he could deliver. You
-                                    won't have time for sleeping, soldier, not
-                                    with all the bed making you'll be doing.
-                                    Then we'll go with that data file! Hey, you
-                                    add a one and two zeros to that or we walk!
-                                    You're going to do his laundry? I've got to
-                                    find a way to escape.
-                                </v-card-text>
-                            </div>
-                        </v-expand-transition></v-card
+        <div
+            v-for="f in supplemental_content"
+            :key="f.name"
+            class="card"
+        >
+            <v-card
+                outlined
+                elevation="1"
+                width="100%"
+                class="mx-auto"
+            >
+                <v-card-subtitle color="#102e43">
+                    {{
+                        f.category
+                    }}
+                </v-card-subtitle><v-card-text>
+                    <a :href="f.url">
+                        {{ f.description }}
+                    </a>
+                </v-card-text>
+                <v-card-actions>
+                    <v-btn
+                        color="#5B616B"
+                        text
                     >
-                </div>
-            </div>
+                        Relevant Regulations
+                    </v-btn>
+
+                    <v-spacer />
+
+                    <v-btn
+                        color="#5B616B"
+                        icon
+                        @click="toggleLocations(f)"
+                    >
+                        <v-icon>
+                            {{
+                                show === f.url ? "mdi-chevron-up" : "mdi-chevron-down"
+                            }}
+                        </v-icon>
+                    </v-btn>
+                </v-card-actions>
+
+                <v-expand-transition>
+                    <div v-show="show === f.url">
+                        <v-divider />
+                        <v-card-text>
+                            {{ f.locations }}
+                        </v-card-text>
+                    </div>
+                </v-expand-transition>
+            </v-card>
         </div>
     </div>
 </template>
@@ -53,14 +60,45 @@
 
 export default {
     name: "SectionCards",
-    data: () => ({
-        show: false,
-    }),
     props: {
         title: { type: String },
         part: { type: String },
         supList: {type: Array},
     },
+    data: () => ({
+        show: false,
+    }),
+    computed: {
+      supplemental_content(){
+        const content = []
+        this.supList.forEach( category => {
+              category
+                  .supplemental_content
+                  .map(c => {
+                    c.category = category.name
+                    return c
+                  })
+                  .forEach(c => content.push(c));
+              category
+                  .sub_categories.forEach( subCategory => {
+                    subCategory
+                    .supplemental_content
+                    .map(c => {
+                      c.category = subCategory.name
+                      return c
+                    })
+                    .forEach(c => content.push(c))
+              })
+            })
+        console.log(content)
+        return content
+      }
+    },
+    methods:{
+      toggleLocations(f){
+        this.show = this.show === f.url ? "":f.url
+      },
+    }
 };
 </script>
 

--- a/solution/ui/prototype/src/components/PDPart/SubpartSupplemental.vue
+++ b/solution/ui/prototype/src/components/PDPart/SubpartSupplemental.vue
@@ -13,7 +13,7 @@
     </div>
 </template>
 <script>
-import { getSupplementalContentNew } from "@/utilities/api";
+import { getSupplementalContentNew, getSectionsForSubPart } from "@/utilities/api";
 import SupplementalContentCategory from "../../../../regulations/js/src/components/SupplementalContentCategory.vue";
 
 export default {
@@ -34,10 +34,11 @@ export default {
     },
     async created() {
         try {
+            const sections = await getSectionsForSubPart(this.part, this.subpart)
             this.supList = await getSupplementalContentNew(
                 this.title,
                 this.part,
-                [],
+                sections,
                 [this.subpart]
             );
         } catch (error) {

--- a/solution/ui/prototype/src/components/PDPart/TabFilters.vue
+++ b/solution/ui/prototype/src/components/PDPart/TabFilters.vue
@@ -2,23 +2,24 @@
     <div>
         <div class="tab-bar">
             <v-tabs v-model="tab">
-                <v-tab v-for="tab in tabs" :key="tab">{{ tab }}</v-tab>
+                <v-tab v-for="tab in tabTitles" :key="tab">{{ tab }} </v-tab>
             </v-tabs>
         </div>
         <v-tabs-items v-model="tab">
-            <v-tab-item
-                ><PartSummary v-bind:title="title" v-bind:part="part"
-            /></v-tab-item>
+            <v-tab-item>
+                <PartSummary v-bind:title="title" v-bind:part="part"/>
+            </v-tab-item>
             <v-tab-item>
                 <SubpartResources v-bind:title="title" v-bind:part="part" />
             </v-tab-item>
             <v-tab-item>
-                <v-container fluid
-                    ><SectionCards
+                <v-container fluid>
+                    <SectionCards
                         v-bind:title="title"
                         v-bind:part="part"
                         v-bind:supList="supList"
-                /></v-container>
+                    />
+                </v-container>
             </v-tab-item>
         </v-tabs-items>
     </div>
@@ -28,6 +29,7 @@ import TabFilters from "./TabFilters.vue";
 import SectionCards from "./SectionCards.vue";
 import PartSummary from "./PartSummary.vue";
 import SubpartResources from "./Subpart.vue";
+import {capitalizeFirstLetter} from "../../utilities/utils";
 export default {
     components: {
         TabFilters,
@@ -40,6 +42,7 @@ export default {
         title: { type: String },
         part: { type: String },
         supList: { type: Array },
+        suggestedTab: {type: String },
     },
     data() {
         return {
@@ -49,7 +52,26 @@ export default {
     },
     computed: {
         subpartList: function () {},
+        tabTitles: function(){
+            const tabList = ["Part", "Subpart"]
+            let count = 0
+            this.supList.forEach( category => {
+              count += category.supplemental_content.length
+              category.sub_categories.forEach( subCategory => {
+                count += subCategory.supplemental_content.length
+              })
+            })
+            tabList.push(this.supList.length ? `Section (${count})` : "section")
+            return tabList
+        }
     },
+    watch: {
+      suggestedTab:{
+          async handler(suggestedTab) {
+            this.tab = this.tabs.indexOf(capitalizeFirstLetter(suggestedTab)) || 5
+          }
+      }
+    }
 };
 </script>
 

--- a/solution/ui/prototype/src/components/node_types/SubjectGroup.vue
+++ b/solution/ui/prototype/src/components/node_types/SubjectGroup.vue
@@ -9,6 +9,9 @@
             <Node 
                 :node="child"
                 :key="child.title"
+                :resource-params-emitter="resourceParamsEmitter"
+                :showResourceButtons="showResourceButtons"
+                :supplementalContentCount="supplementalContentCount"
             />
         </template>
     </div>
@@ -29,6 +32,20 @@ export default {
         node: {
             type: Object,
             required: true,
+        },
+              resourceParamsEmitter: {
+            type: Function,
+            required: false,
+        },
+        showResourceButtons: {
+            type: Boolean,
+            required: false,
+            default: true
+        },
+        supplementalContentCount: {
+            type:Object,
+            required: false,
+            default: () => {}
         },
     },
 

--- a/solution/ui/prototype/src/components/node_types/Subpart.vue
+++ b/solution/ui/prototype/src/components/node_types/Subpart.vue
@@ -96,7 +96,7 @@ export default {
             this.resourceParamsEmitter("subpart", [this.node.label[0]]);
         },
         handleBlueBtnClick() {
-          this.resourceParamsEmitter("sections", this.node.children.map(child => child.label[1]));
+          this.resourceParamsEmitter("subpart", this.node.children.map(child => child.label[1]));
         }
     },
 };

--- a/solution/ui/prototype/src/utilities/api.js
+++ b/solution/ui/prototype/src/utilities/api.js
@@ -421,7 +421,6 @@ const getSectionsForSubPart = async (part, subPart) => {
             })
         }
     })
-    console.log(sections)
     return sections
 
 }

--- a/solution/ui/prototype/src/utilities/api.js
+++ b/solution/ui/prototype/src/utilities/api.js
@@ -409,7 +409,20 @@ const getSectionsForSubPart = async (part, subPart) => {
     const parts = all_parts.map(d => d.name)
     const potentialSubParts = all_parts[parts.indexOf(part)].structure.children[0].children[0].children[0].children
     const parent = potentialSubParts.find(p => p.type === "subpart" && p.identifier[0] === subPart)
-    return parent.children.map(c => c.identifier[1])
+    const sections = []
+    parent.children.forEach(c => {
+        if (c.type === "section"){
+            sections.push(c.identifier[1])
+        }else if (c.children){
+            c.children.forEach( child => {
+                if (child.type === "section"){
+                    sections.push(child.identifier[1])
+                }
+            })
+        }
+    })
+    console.log(sections)
+    return sections
 
 }
 

--- a/solution/ui/prototype/src/utilities/utils.js
+++ b/solution/ui/prototype/src/utilities/utils.js
@@ -414,6 +414,10 @@ const getParagraphDepth = (value) => {
     return depth;
 }
 
+function capitalizeFirstLetter(string) {
+    return string[0].toUpperCase() + string.slice(1);
+}
+
 
 export {
     mapToArray,
@@ -443,5 +447,6 @@ export {
     getKebabLabel,
     getKebabTitle,
     getParagraphDepth,
-    getDisplayName
+    getDisplayName,
+    capitalizeFirstLetter
 };

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -21,6 +21,7 @@
                         :title="title"
                         :part="part"
                         :supList="supList"
+                        :suggestedTab="suggestedTab"
                     />
                 </pane>
             </splitpanes>
@@ -108,6 +109,7 @@ export default {
             partsList: [],
             sections: [],
             supplementalContentCount: {},
+            suggestedTab:"",
         };
     },
     computed: {
@@ -203,6 +205,11 @@ export default {
     },
     methods: {
         async setResourcesParams(payload) {
+            this.suggestedTab = payload["scope"]
+            // skip this for subparts
+            if (payload["scope"] === "subpart"){
+              return
+            }
             try {
                 this.supList = await getSupplementalContentNew(
                     42,
@@ -213,6 +220,7 @@ export default {
                 console.error(error);
             } finally {
                 console.log(this.supList);
+                this.suggestedTab = payload["scope"]
             }
             // Implement response to user choosing a section or subpart here
         },

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -133,11 +133,12 @@ export default {
                             return true
                           } else{
                             return section.children.filter(subSection =>{
-                              return subSection.label[1] === this.section && subSection.node_type === "SECTION"
+                              return subSection.label && subSection.label[1] === this.section && subSection.node_type === "SECTION"
                             }).length
                           }
                         }
                     );
+                    console.log(sections)
                     if (sections[0].node_type === "SECTION"){
                       return [sections[0]]
                     }

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -10,6 +10,7 @@
                         :part="part"
                         :subPart="subPart"
                         :section="section"
+                        :partLabel="partLabel"
                         :structure="partContent"
                         :navigation="navigation"
                         :supplementalContentCount="supplementalContentCount"
@@ -117,7 +118,7 @@ export default {
             return this.structure?.[0];
         },
         partLabel() {
-            return this.structure?.[0].label_description ?? "N/A";
+            return this.structure?.[0] ? this.structure?.[0].label_description ?? "N/A" : null;
         },
         partContent() {
             let results = this.structure?.[1];

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -127,9 +127,24 @@ export default {
                 });
 
                 if (this.section) {
-                    results = results[0].children.filter(
-                        (section) => section.label[1] === this.section
+                    const sections = results[0].children.filter(section => {
+                          if (section.label[1] === this.section && section.node_type === "SECTION"){
+                            return true
+                          } else{
+                            return section.children.filter(subSection =>{
+                              return subSection.label[1] === this.section && subSection.node_type === "SECTION"
+                            }).length
+                          }
+                        }
                     );
+                    if (sections[0].node_type === "SECTION"){
+                      return [sections[0]]
+                    }
+                    else{
+                      return sections[0].children.filter(subSection =>{
+                          return subSection.label[1] === this.section && subSection.node_type === "SECTION"
+                      })
+                    }
                 }
             }
             return results || [];


### PR DESCRIPTION


**Description-**
Prototype cleanup first pass.  Fixes many, but not all issues found in validation.
**This pull request changes...**

Clicking on the blue button next to a section will switch the right side to the section tab and fetch the resources for that section
Section tab title shows the number of pieces of content shown
Clicking on a blue button next to a sub part switches to the subpart tab, but does notexpand any subpart
Subpart resources section works more like the prod site and include content for all sections in that sub part.
Expanding relevant regulations shows a formatted list with links of the other related content
Expanding relevant regulations on one piece of content no longer expands all pieces of content
Entire bottom section of supplemental content card is now clickable to expand it
Filter and sort resources link now hides/shows a filter section.  The filter section could be better.
Reduced size of breadcrumbs and previous/next buttons
Added part title to part level page
Added key to supplemental content cards so switching regulations shows completely collapsed cards
Fixed issue where some regulations don't show properly.
See:

PD/42/435/subPart-B/110
PD/42/440/subPart-A/1

for examples that should both work.
