### PR TITLE
go button should keep you in the same "version" of the site

### DIFF
--- a/solution/ui/prototype/src/components/JumpTo.vue
+++ b/solution/ui/prototype/src/components/JumpTo.vue
@@ -49,7 +49,7 @@
                 />
             </div>
 
-            <input class="submit" type="submit" value="Go" />
+            <input class="submit" v-bind:class="{active: isActive}" type="submit" value="Go" />
         </form>
     </div>
 </template>
@@ -85,12 +85,23 @@ export default {
             console.error(error);
         }
     },
-
+    computed: {
+      isActive(){
+        return this.selectedTitle && this.selectedPart
+      }
+    },
     methods: {
         formSubmit() {
+            const resourcesDisplay = window.location.pathname.indexOf('sidebar') >= 0 ? "sidebar" : "drawer"
+            const name = window.location.pathname.indexOf('PD') >= 0 ? "PDpart" : "part"
+
             this.$router.push({
-                name: "part",
-                params: { title: this.selectedTitle, part: this.selectedPart },
+                name,
+                params: {
+                  title: this.selectedTitle,
+                  part: this.selectedPart,
+                  resourcesDisplay
+                },
             });
         },
     },
@@ -118,6 +129,12 @@ export default {
     border: solid 1px #d6d7d9;
     color: #a3a3a3;
     background-color: white;
+}
+
+.jump-to input.submit.active {
+    border: solid 1px #046791;
+    color: #FFFFFF;
+    background-color: #046791;
 }
 
 .jump-to .number-box {


### PR DESCRIPTION
Resolves #1246

**Description-**

"activates" the go button in the Jump To section to turn blue when title and part are selected
Go button keeps you in the same "version" for PD vs non PD and drawer vs sidebar.

**This pull request changes...**

Go button in the header turns blue when title and part are selected
The navigation when clicking Go to keep you in the right version.

**Steps to manually verify this change...**

1. select a title and part, see the button turn blue
2. in the PD view choose a title and part and click Go, you should stay in the PD version
3. In the sidebar version select a title and part and click go, stay in the sidebar version
4. repeat above for the drawer version

