### PR TITLE
EREGCSC-1243 [Prototype] Adjust homepage copy

### DIFF
--- a/solution/ui/prototype/src/components/homepage/Hero.vue
+++ b/solution/ui/prototype/src/components/homepage/Hero.vue
@@ -1,7 +1,8 @@
 <template>
     <div class="hero-banner">
         <div class="site-container hero-content">
-            <p class="hero-text">
+            <h3 class="hero-header">eRegulations organizes together regulations, subregulatory guidance, and other related policy materials.</h3>
+            <p class="hero-text">    
                 Explore this site as a supplement to existing policy tools.
                 <router-link :to="{ name: 'about', hash: '#automated-updates' }">
                     How this tool is updated.
@@ -21,4 +22,8 @@ export default {
 };
 </script>
 
-<style></style>
+<style>
+    .hero-header {
+        width: 50%;
+    }
+</style>


### PR DESCRIPTION
Resolves #1243

**Description-**

In order to help us get good feedback testers who end up on the eRegs prototype homepage, we should have some reasonably realistic copy that they can react to, rather than just a small bit of text.

**This pull request changes...**

- Homepage hero now has text "eRegulations organizes together regulations, subregulatory guidance, and other related policy materials."

**Steps to manually verify this change...**

1. Visit prototype homepage and verify hero looks correct with new header text.

