### PR TITLE
Fix subcategory filtering for option A

### DIFF
--- a/solution/ui/prototype/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/prototype/src/components/resources/ResourcesResults.vue
@@ -50,6 +50,7 @@
 <script>
 import SupplementalContentObject from "legacy/js/src/components/SupplementalContentObject.vue";
 import _uniqBy from "lodash/uniq";
+import _has from "lodash/has";
 
 export default {
     name: "ResourcesResults",
@@ -116,7 +117,12 @@ export default {
                         });
                     } else {
                         category.supplemental_content.forEach((item) => {
-                            item.category = category.name;
+                            if (_has(category, "parent_category")) {
+                                item.category = category.parent_category;
+                                item.sub_category = category.name;
+                            } else {
+                                item.category = category.name;
+                            }                            
                             returnArr.push(item);
                         });
                     }

--- a/solution/ui/prototype/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/prototype/src/components/resources/ResourcesResults.vue
@@ -49,6 +49,7 @@
 
 <script>
 import SupplementalContentObject from "legacy/js/src/components/SupplementalContentObject.vue";
+import _uniqBy from "lodash/uniq";
 
 export default {
     name: "ResourcesResults",
@@ -94,7 +95,7 @@ export default {
 
     computed: {
         sortedContent() {
-            return this.content
+            let x = this.content
                 .filter((category) => {
                     return (
                         category.supplemental_content?.length ||
@@ -122,6 +123,11 @@ export default {
 
                     return returnArr;
                 });
+            //remove duplicates
+            x = _uniqBy(x, (item) => {
+                return item.name;
+            });
+            return x;
         },
     },
 

--- a/solution/ui/prototype/src/views/Resources.vue
+++ b/solution/ui/prototype/src/views/Resources.vue
@@ -219,9 +219,19 @@ export default {
 
                 try {
                     const resultArray = await Promise.all(partPromises);
+                    console.log(resultArray);
+                    //flatten array
+                    let finalArray = [];
+                    for (const category of resultArray.flat()) {
+                        finalArray = finalArray.concat(category);
+                        for (const subcategory of category.sub_categories) {
+                            finalArray = finalArray.concat(subcategory);
+                        }
+                    }
+                    console.log(finalArray);
                     this.supplementalContent = this.queryParams.resourceCategory
-                        ? this.filterCategories(resultArray.flat())
-                        : resultArray.flat();
+                        ? this.filterCategories(finalArray)
+                        : finalArray;
                 } catch (error) {
                     console.error(error);
                     this.supplementalContent = [];

--- a/solution/ui/prototype/src/views/Resources.vue
+++ b/solution/ui/prototype/src/views/Resources.vue
@@ -224,6 +224,7 @@ export default {
                     for (const category of resultArray.flat()) {
                         finalArray = finalArray.concat(category);
                         for (const subcategory of category.sub_categories) {
+                            subcategory.parent_category = category.name;
                             finalArray = finalArray.concat(subcategory);
                         }
                     }

--- a/solution/ui/prototype/src/views/Resources.vue
+++ b/solution/ui/prototype/src/views/Resources.vue
@@ -219,7 +219,6 @@ export default {
 
                 try {
                     const resultArray = await Promise.all(partPromises);
-                    console.log(resultArray);
                     //flatten array
                     let finalArray = [];
                     for (const category of resultArray.flat()) {
@@ -228,7 +227,6 @@ export default {
                             finalArray = finalArray.concat(subcategory);
                         }
                     }
-                    console.log(finalArray);
                     this.supplementalContent = this.queryParams.resourceCategory
                         ? this.filterCategories(finalArray)
                         : finalArray;


### PR DESCRIPTION
**Description-**

Filtering by a subcategory in option A always returns 0 results due to the supplemental content tree not being flat.

**This pull request changes...**

- Flattens supplemental content tree
- Removes duplicate entries (that are created due to tree flattening)

**Steps to manually verify this change...**

1. Visit `/resources` on the prototype and filter by a category, then a subcategory, then both.