### PR TITLE
fixing ordering of filters to return correct results.

### DIFF
--- a/solution/backend/supplemental_content/views.py
+++ b/solution/backend/supplemental_content/views.py
@@ -63,17 +63,23 @@ class SupplementalContentView(generics.ListAPIView):
         subjgrp_list = self.request.GET.getlist("subjectgroups")
         start = int(self.request.GET.get("start", 0))
         maxResults = int(self.request.GET.get("max_results", 1000))
-        query = AbstractSupplementalContent.objects.filter(
-            approved=True,
-            category__isnull=False,
-            locations__title=title,
-            locations__part=part,
-        )
+
         if len(section_list) > 0 or len(subpart_list) > 0 or len(subjgrp_list) > 0:
-            query = query.filter(
+            query = AbstractSupplementalContent.objects.filter(
                 Q(locations__section__section_id__in=section_list) |
                 Q(locations__subpart__subpart_id__in=subpart_list) |
-                Q(locations__subjectgroup__subject_group_id__in=subjgrp_list)
+                Q(locations__subjectgroup__subject_group_id__in=subjgrp_list),
+                approved=True,
+                category__isnull=False,
+                locations__title=title,
+                locations__part=part
+            )
+        else:
+            query = AbstractSupplementalContent.objects.filter(
+                approved=True,
+                category__isnull=False,
+                locations__title=title,
+                locations__part=part,
             )
 
         query = query.prefetch_related(


### PR DESCRIPTION
Resolves #

**Description-**

Q Queries were not being applied in the correct order. As a result the output contained additional items that did not belong.  

**This pull request changes...**
reorders the Q queries when fetchign supplemental content

**Steps to manually verify this change...**

1. Go to http://localhost:8000/v2/title/42/part/441/supplemental_content?&sections=15&start=0&max_results=10000  If you get 25 results that is wrong.  If you get 9, that is correct.

