### PR TITLE
EREGCSC-1092 - Extra space at bottom of right sidebar

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -9,12 +9,12 @@ aside.right-sidebar {
     padding-bottom: $spacer-5;
     max-width: 400px;
     position: sticky;
-    height: calc(100vh - #{$header_height_mobile} - #{$spacer-5} - #{$spacer-5});
+    height: calc(100vh - #{$header_height_mobile} - #{$spacer-5});
     overflow-y: scroll;
     overflow-x: auto;
 
     @include screen-lg {
-        height: calc(100vh - #{$header_height_mobile} - #{$spacer-5} - #{$spacer-5});
+        height: calc(100vh - #{$header_height_mobile} - #{$spacer-5});
     }
 
     h2 {

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -6,9 +6,10 @@
 
 aside.right-sidebar {
     padding-top: $spacer-5;
+    padding-bottom: $spacer-5;
     max-width: 400px;
     position: sticky;
-    height: calc(100vh - #{$header_height_mobile} - #{$spacer-5});
+    height: calc(100vh - #{$header_height_mobile} - #{$spacer-5} - #{spacer-5});
     overflow-y: scroll;
     overflow-x: auto;
 

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -9,7 +9,7 @@ aside.right-sidebar {
     padding-bottom: $spacer-5;
     max-width: 400px;
     position: sticky;
-    height: calc(100vh - #{$header_height_mobile} - #{$spacer-5} - #{spacer-5});
+    height: calc(100vh - #{$header_height_mobile} - #{$spacer-5} - #{$spacer-5});
     overflow-y: scroll;
     overflow-x: auto;
 

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -14,7 +14,7 @@ aside.right-sidebar {
     overflow-x: auto;
 
     @include screen-lg {
-        height: calc(100vh - #{$header_height} - #{$spacer-5});
+        height: calc(100vh - #{$header_height_mobile} - #{$spacer-5} - #{$spacer-5});
     }
 
     h2 {

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -14,7 +14,7 @@ aside.right-sidebar {
     overflow-x: auto;
 
     @include screen-lg {
-        height: calc(100vh - #{$header_height_mobile} - #{$spacer-5});
+        height: calc(100vh - #{$header_height} - #{$spacer-5});
     }
 
     h2 {


### PR DESCRIPTION
Resolves [EREGCSC-1092](https://jiraent.cms.gov/browse/EREGCSC-1092)

**Description**
We want to add a little extra space below the last item in the sidebar.

**This pull request changes**

- Changes right sidebar bottom padding from 16px to 40px
- Shortens right sidebar height by 40px

**Steps to manually verify this change**

1. Visit the reader view for any subpart and expand some supplemental content so that the right sidebar content is taller than the container.  
    - example: [42 CFR 435 Subpart A experimental deploy](https://01fzvhvqfh.execute-api.us-east-1.amazonaws.com/dev-386/42/435/Subpart-A/2019-05-06/) 
    - vs [42 CFR 435 Subpart A on the Pilot Site](https://regulations-pilot.cms.gov/42/435/Subpart-A/2019-05-06/)
2. Scroll to bottom of right sidebar content.  
3. There should be some additional spacing there when compared to the Pilot site. The difference is especially pronounced if you leave the final group "Terms" unexpanded.

