### PR TITLE
EREGCSC-1255 Make "latest" work as a valid date string for V3 API calls

### DIFF
--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -26,7 +26,7 @@ class MultipleFieldLookupMixin(object):
             if param == "version" and value == "latest":
                 latest_field = field
             elif value:
-                filter[field] = self.kwargs[self.lookup_fields[field]]
+                filter[field] = value
         return queryset.filter(**filter).latest(latest_field) if latest_field else get_object_or_404(queryset, **filter)
 
 

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -20,8 +20,7 @@ class MultipleFieldLookupMixin(object):
         queryset = self.filter_queryset(queryset)
         filter = {}
         latest_field = None
-        for field in self.lookup_fields:
-            param = self.lookup_fields[field]
+        for field, param in self.lookup_fields.items():
             value = self.kwargs.get(param, None)
             if param == "version" and value == "latest":
                 latest_field = field

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -54,8 +54,6 @@ class VersionsViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class PartContentsViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewSet):
-    # TODO: modify so ".../version/latest/..." returns the latest version
-    # best accomplished after ordering can be set on Parts
     queryset = Part.objects.all()
     serializer_class = ContentsSerializer
     lookup_fields = {

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -19,10 +19,15 @@ class MultipleFieldLookupMixin(object):
         queryset = self.get_queryset()
         queryset = self.filter_queryset(queryset)
         filter = {}
+        latest_field = None
         for field in self.lookup_fields:
-            if self.kwargs.get(self.lookup_fields[field], None):
+            param = self.lookup_fields[field]
+            value = self.kwargs.get(param, None)
+            if param == "version" and value == "latest":
+                latest_field = field
+            elif value:
                 filter[field] = self.kwargs[self.lookup_fields[field]]
-        return get_object_or_404(queryset, **filter)
+        return queryset.filter(**filter).latest(latest_field) if latest_field else get_object_or_404(queryset, **filter)
 
 
 class ContentsViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Resolves #1255

**Description-**

As a user I want all pages of eRegs to load as fast as possible. Currently, we need to determine the most recent version of the regulations from a list of versions before requesting content for that version.

**This pull request changes...**

- /v3/title/<title>/part/<part>/version/<version>/toc accepts "latest" as <version>

**Steps to manually verify this change...**

1. Visit /v3/title/42/part/433/version/latest/toc and verify the correct data is returned

