### PR TITLE
EREGCSC-1259 Add middleware to render API responses as HTML so Django Debug Toolbar works

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -60,6 +60,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'regulations.middleware.json_errors.JsonErrors',
+    'regcore.middleware.html_api.HtmlApi',
 ]
 
 REST_FRAMEWORK = {

--- a/solution/backend/regcore/middleware/html_api.py
+++ b/solution/backend/regcore/middleware/html_api.py
@@ -1,0 +1,20 @@
+import json
+
+from django.http.response import HttpResponse
+from django.shortcuts import render
+
+
+class HtmlApi:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if "html_api" in request.GET:
+            response = view_func(request, view_args, view_kwargs)
+            data = json.dumps(response.data, indent=4)
+            return render(request, "response.html", context={'data': data})
+        else:
+            return None

--- a/solution/backend/regcore/middleware/html_api.py
+++ b/solution/backend/regcore/middleware/html_api.py
@@ -12,7 +12,10 @@ class HtmlApi:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if "html_api" in request.GET:
-            response = view_func(request, *view_args, **view_kwargs)
-            data = json.dumps(response.data, indent=4)
-            return render(request, "response.html", context={'data': data})
+            try:
+                response = view_func(request, *view_args, **view_kwargs)
+                data = json.dumps(response.data, indent=4)
+                return render(request, "response.html", context={'data': data})
+            except:
+                pass
         return None

--- a/solution/backend/regcore/middleware/html_api.py
+++ b/solution/backend/regcore/middleware/html_api.py
@@ -13,8 +13,7 @@ class HtmlApi:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if "html_api" in request.GET:
-            response = view_func(request, view_args, view_kwargs)
+            response = view_func(request, *view_args, **view_kwargs)
             data = json.dumps(response.data, indent=4)
             return render(request, "response.html", context={'data': data})
-        else:
-            return None
+        return None

--- a/solution/backend/regcore/middleware/html_api.py
+++ b/solution/backend/regcore/middleware/html_api.py
@@ -1,6 +1,5 @@
 import json
 
-from django.http.response import HttpResponse
 from django.shortcuts import render
 
 

--- a/solution/backend/regcore/middleware/html_api.py
+++ b/solution/backend/regcore/middleware/html_api.py
@@ -8,14 +8,8 @@ class HtmlApi:
         self.get_response = get_response
 
     def __call__(self, request):
-        return self.get_response(request)
-
-    def process_view(self, request, view_func, view_args, view_kwargs):
-        if "html_api" in request.GET:
-            try:
-                response = view_func(request, *view_args, **view_kwargs)
-                data = json.dumps(response.data, indent=4)
-                return render(request, "response.html", context={'data': data})
-            except:
-                pass
-        return None
+        response = self.get_response(request)
+        if "html_api" in request.GET and response.get("Content-Type", None) == "application/json":
+            data = json.dumps(json.loads(response.content.decode("utf-8")), indent=4)
+            return render(request, "response.html", context={'data': data})
+        return response

--- a/solution/backend/regcore/templates/response.html
+++ b/solution/backend/regcore/templates/response.html
@@ -1,0 +1,1 @@
+<html><body><pre><code>{{ data }}</code></pre></body></html>


### PR DESCRIPTION
Resolves #1259

**Description-**

As a developer I need to be able to debug API endpoints quickly and effectively. Although we have the ability to use Django Debug Toolbar for frontend pages, it won't work on backend pages because those responses are in JSON.

**This pull request changes...**

- Adding `?html_api` to the end of any API call returns the JSON response as basic HTML. (Changed from `?debug` to be more precise.)

**Steps to manually verify this change...**

1. Visit any API page, e.g. `/v3/title/42/part/433/version/2021-03-01/toc` and append `?html_api` (`/v3/title/42/part/433/version/2021-03-01/toc?html_api`)
2. Verify that the JSON content returned is correct, and view page source to verify that it is wrapped in HTML tags
3. Verify that Django Debug Toolbar appears as expected

