### PR TITLE
Fix Go linting in Github Actions

### DIFF
--- a/.github/workflows/ecfr-parser-checks.yml
+++ b/.github/workflows/ecfr-parser-checks.yml
@@ -39,7 +39,7 @@ jobs:
     # Run lint on the code
     - name: Run lint
       run: |
-        go get golang.org/x/lint/golint
+        go install golang.org/x/lint/golint
         pushd solution/parser/ecfr-parser
         golint -set_exit_status ./...
         popd

--- a/.github/workflows/ecfr-parser-checks.yml
+++ b/.github/workflows/ecfr-parser-checks.yml
@@ -39,7 +39,7 @@ jobs:
     # Run lint on the code
     - name: Run lint
       run: |
-        go install golang.org/x/lint/golint
+        go install golang.org/x/lint/golint@latest
         pushd solution/parser/ecfr-parser
         golint -set_exit_status ./...
         popd

--- a/solution/parser/ecfr-parser/main.go
+++ b/solution/parser/ecfr-parser/main.go
@@ -96,8 +96,6 @@ func main() {
 }
 
 func start() error {
-	log.Info("This is a test to make the linter run on GHA")
-	
 	log.Info("[main] Loading configuration...")
 	var err error
 	config, _, err = eregs.RetrieveConfig()

--- a/solution/parser/ecfr-parser/main.go
+++ b/solution/parser/ecfr-parser/main.go
@@ -96,6 +96,8 @@ func main() {
 }
 
 func start() error {
+	log.Info("This is a test to make the linter run on GHA")
+	
 	log.Info("[main] Loading configuration...")
 	var err error
 	config, _, err = eregs.RetrieveConfig()


### PR DESCRIPTION
Resolves #

**Description-**

"go get" is deprecated in more recent versions of Go. We used "go get" to install the linter used in Github Actions.

**This pull request changes...**

- We now "go install" the linter

**Steps to manually verify this change...**

1. Make sure the linter successfully runs on this PR. No other checks need to be run.

