### PR TITLE
Explicitly setting the search config to english and allowing quoted search terms

### DIFF
--- a/solution/backend/regcore/search/models.py
+++ b/solution/backend/regcore/search/models.py
@@ -38,6 +38,7 @@ class SearchIndexQuerySet(models.QuerySet):
                     SearchQuery(query, search_type=search_type, config='english'),
                     start_sel='<span class="search-highlight">',
                     stop_sel='</span>',
+                    config='english'
                 ),
             )\
             .order_by('-rank')\

--- a/solution/backend/regcore/search/models.py
+++ b/solution/backend/regcore/search/models.py
@@ -18,18 +18,18 @@ class SearchIndexQuerySet(models.QuerySet):
     def search(self, query):
         return self\
             .annotate(rank=SearchRank(
-                SearchVector('label', weight='A')
-                + SearchVector(models.functions.Concat('label__0', models.Value('.'), 'label__1'), weight='A')
-                + SearchVector('parent__title', weight='A')
-                + SearchVector('part__document__title', weight='B')
-                + SearchVector('content', weight='B'),
-                SearchQuery(query))
+                SearchVector('label', weight='A', config='english')
+                + SearchVector(models.functions.Concat('label__0', models.Value('.'), 'label__1'), weight='A', config='english')
+                + SearchVector('parent__title', weight='A', config='english')
+                + SearchVector('part__document__title', weight='B', config='english')
+                + SearchVector('content', weight='B', config='english'),
+                SearchQuery(query, search_type='phrase', config='english'))
             )\
             .filter(rank__gte=0.2)\
             .annotate(
                 headline=SearchHeadline(
                     "content",
-                    SearchQuery(query),
+                    SearchQuery(query, search_type='phrase', config='english'),
                     start_sel='<span class="search-highlight">',
                     stop_sel='</span>',
                 ),


### PR DESCRIPTION
Resolves #1094

**Description-**

Explicitly adds an english config to the search queries.

**This pull request changes...**

- Stemming, search vector creation and highlighting should all be different now.

**Steps to manually verify this change...**

1. Searching for "State Medicaid Manual" with and without the quotes.  With quotes should be more specific and return fewer results
2. Search for:    
    Application, applications
    Demonstration, demonstrations
    Authority, authorities
    Disability, disabilities 
3. you should see similar results for both terms.  Search results should be more inclusive of the highlights.  For example Disability should include "Disabled" as a highlighted word in the results indicating it was in fact searched for.
