### PR TITLE
making URL for robots.txt https and removing no index meta tag from base template.

### DIFF
--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -19,7 +19,6 @@ CSS/Javascript etc., should inherit from this template.
     </script>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=11; IE=EDGE">
-        <meta name="robots" content="noindex">
         {% comment %} Tag for bing and google to show that I control the site. {% endcomment %}
         <meta name="msvalidate.01" content="2564ADEFA9801CDF3DD1287C2109D2A9" />
         <meta name="google-site-verification" content="iNAu2rAPdykHG6aKtClENiu_fRheE-TBM4drtyCVlWk" />

--- a/solution/backend/regulations/templates/robots.txt
+++ b/solution/backend/regulations/templates/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: http://{{request.META.HTTP_HOST}}/sitemap.xml
+Sitemap: https://{{request.META.HTTP_HOST}}/sitemap.xml


### PR DESCRIPTION

Resolves #EREGCSC-1240

**Description-**

Makes robots.txt use https (it would forward, but explicit https is better).  Removes noindex meta tag from base template.
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. go to /robots.txt and see it use an https link
2. view source on any page and look for the absence of the robots meta tag.

