### PR TITLE
EREGCSC-1253 Create additional table of contents endpoints

### DIFF
--- a/solution/backend/regcore/models.py
+++ b/solution/backend/regcore/models.py
@@ -46,14 +46,12 @@ class Part(models.Model):
         # TODO: add once /v2/title/X/existing is removed, the following line breaks it for some reason
         # ordering = ("title", "name", "-date")
 
-    def get_part_level(self, data):
-        for _ in range(self.depth):
-            data = data['children'][0]
-        return data
-
     @property
     def toc(self):
-        return self.get_part_level(self.structure)
+        structure = self.structure
+        for _ in range(self.depth):
+            structure = structure["children"][0]
+        return structure
 
 
 class ParserConfiguration(SingletonModel):

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -46,7 +46,7 @@ class NodeTypeSerializer(serializers.BaseSerializer):
         return nodes
 
     def to_representation(self, instance):
-        nodes = self.find_nodes(instance.get_part_level(instance.structure))
+        nodes = self.find_nodes(instance.toc)
         for node in nodes:
             for field in self.remove_fields + ["children", "type"]:
                 del node[field]

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -66,6 +66,6 @@ class SubpartContentsSerializer(serializers.BaseSerializer):
     def to_representation(self, instance):
         toc = instance.toc
         for node in toc["children"]:
-            if node["type"] == "subpart" and node["identifier"][0] == self.context["subpart"]:
+            if node["type"] == "subpart" and len(node["identifier"]) and node["identifier"][0] == self.context["subpart"]:
                 return node["children"]
         return []

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -60,3 +60,12 @@ class PartSectionsSerializer(NodeTypeSerializer):
 
 class PartSubpartsSerializer(NodeTypeSerializer):
     node_type = "subpart"
+
+
+class SubpartContentsSerializer(serializers.BaseSerializer):
+    def to_representation(self, instance):
+        toc = instance.toc
+        for node in toc["children"]:
+            if node["type"] == "subpart" and node["identifier"][0] == self.context["subpart"]:
+                return node["children"]
+        return []

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -16,6 +16,7 @@ from regcore.v3views import (
     ContentsViewSet,
     TitlesViewSet,
     TitleViewSet,
+    TitleContentsViewSet,
     PartsViewSet,
     VersionsViewSet,
     PartContentsViewSet,
@@ -53,6 +54,9 @@ urlpatterns = [
             "get": "retrieve",
             "post": "create",
             "put": "update",
+        })),
+        path("title/<title>/toc", TitleContentsViewSet.as_view({
+            "get": "retrieve",
         })),
         path("title/<title>/parts", PartsViewSet.as_view({
             "get": "list",

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -21,6 +21,7 @@ from regcore.v3views import (
     PartContentsViewSet,
     PartSectionsViewSet,
     PartSubpartsViewSet,
+    SubpartContentsViewSet,
 )
 
 
@@ -66,6 +67,9 @@ urlpatterns = [
             "get": "retrieve",
         })),
         path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
+            "get": "retrieve",
+        })),
+        path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
             "get": "retrieve",
         })),
     ])),

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -53,6 +53,12 @@ class TitleViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
 
+class TitleContentsViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewSet):
+    queryset = Title.objects.all()
+    serializer_class = ContentsSerializer
+    lookup_fields = {"name": "title"}
+
+
 class PartsViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PartsSerialier
 

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -14,6 +14,7 @@ from regcore.serializers import (
     VersionsSerializer,
     PartSectionsSerializer,
     PartSubpartsSerializer,
+    SubpartContentsSerializer,
 )
 
 
@@ -90,3 +91,12 @@ class PartSectionsViewSet(PartPropertiesViewSet):
 
 class PartSubpartsViewSet(PartPropertiesViewSet):
     serializer_class = PartSubpartsSerializer
+
+
+class SubpartContentsViewSet(PartPropertiesViewSet):
+    serializer_class = SubpartContentsSerializer
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["subpart"] = self.kwargs.get("subpart")
+        return context


### PR DESCRIPTION
Resolves #1253

**Description-**

As a developer it is necessary to retrieve a table of contents for titles, parts, and more. Ideally we want to retrieve only the data necessary to facilitate this.

**This pull request changes...**

The following new V3 endpoints exist:
- `/v3/title/<title>/toc`
  Retrieve table of contents for one title only (extension of /v3/title/<title>)
- `/v3/title/<title>/part/<part>/version/<date>/subpart/<subpart>/toc`
  Retrieve table of contents for a specific subpart down to the section level

**This pull request does NOT change...**

Originally a `/v3/title/<title>/part/<part>/version/<date>/section/<section>/toc` endpoint was planned, but this was done under the incorrect assumption that the `structure` field contains data down to the paragraph level. It doesn't, so to implement this would require a change in the parser to populate this information, or a complex algorithm to fill in this data from the `document` field.

Given that this level of granular detail is probably not necessary for a table of contents endpoint, I'm leaving it out for now. If we decide we want paragraphs in the tables of contents, I suggest we make another ticket to account for the extra complexity of modifying the parser.

**Steps to manually verify this change...**

1. Visit each of the endpoints listed above, substituting correct variables (e.g. `title=42`, `part=433`, `date=2021-03-01`, and `subpart=A` and verify the correct data is returned.

