### PR TITLE
EREGCSC-1284 Make Swagger API documentation work again

### DIFF
--- a/solution/backend/regcore/search/urls.py
+++ b/solution/backend/regcore/search/urls.py
@@ -2,6 +2,12 @@ from django.urls import path
 
 from .views import (
     SearchView,
+    SupplementalContentSearchViewSet,
 )
 
-urlpatterns = [path("search", SearchView.as_view()), ]
+urlpatterns = [
+    path("search", SearchView.as_view()),
+    path("supplemental_content/search", SupplementalContentSearchViewSet.as_view({
+        "get": "list",
+    })),
+]

--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -1,10 +1,14 @@
 from datetime import date
-from rest_framework import generics, serializers
+from rest_framework import generics, serializers, viewsets
 from django.db import models
+from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchVector, SearchRank
 
 from regcore.models import Part
 from .models import SearchIndex
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchHeadline
+
+from supplemental_content.models import AbstractSupplementalContent
+from supplemental_content.serializers import FlatSupplementalContentSerializer
 
 
 class SearchViewSerializer(serializers.ModelSerializer):
@@ -37,3 +41,40 @@ class SearchView(generics.ListAPIView):
             )\
             .order_by('-rank')\
             .values("type", "content", "headline", "label", "parent", "part__document__title", "part__title", "part__date")
+
+
+class SupplementalContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = FlatSupplementalContentSerializer
+
+    def get_queryset(self):
+        query = self.request.query_params.get('q')
+        search_type = 'plain'
+        cover_density = False
+        if (query.startswith('"')) and query.endswith('"'):
+            search_type = 'phrase'
+            cover_density = True
+
+        return AbstractSupplementalContent.objects.filter(approved=True).annotate(rank=SearchRank(
+                SearchVector('supplementalcontent__name', weight='A', config='english')
+                + SearchVector('supplementalcontent__description', weight='A', config='english'),
+                SearchQuery(query, search_type=search_type, config='english'), cover_density=cover_density))\
+            .filter(rank__gte=0.2) \
+            .annotate(
+                nameHeadline=SearchHeadline(
+                    "supplementalcontent__name",
+                    SearchQuery(query, search_type=search_type, config='english'),
+                    start_sel='<span class="search-highlight">',
+                    stop_sel='</span>',
+                    config='english'
+                ),
+                descriptionHeadline=SearchHeadline(
+                    "supplementalcontent__description",
+                    SearchQuery(query, search_type=search_type, config='english'),
+                    start_sel='<span class="search-highlight">',
+                    stop_sel='</span>',
+                    config='english'
+                )
+            )\
+            .order_by('-rank') \
+            .prefetch_related('locations')\
+            .prefetch_related('category').select_subclasses("supplementalcontent")

--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -5,7 +5,6 @@ from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchVe
 
 from regcore.models import Part
 from .models import SearchIndex
-from django.contrib.postgres.search import SearchQuery, SearchRank, SearchHeadline
 
 from supplemental_content.models import AbstractSupplementalContent
 from supplemental_content.serializers import FlatSupplementalContentSerializer

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 
 from regcore.models import Title, Part
 
@@ -32,15 +33,16 @@ class TitleSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class PartsSerialier(serializers.ModelSerializer):
+class PartsSerializer(serializers.ModelSerializer):
     class Meta:
         model = Part
         fields = ("id", "name", "date", "last_updated", "depth", "title_object")
 
 
-class VersionsSerializer(serializers.BaseSerializer):
-    def to_representation(self, instance):
-        return instance.date
+class VersionsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Part
+        fields = ("id", "name", "date", "last_updated")
 
 
 # Inherit from this class to return a flat list of specific types of nodes within the part

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -3,9 +3,21 @@ from rest_framework import serializers
 from regcore.models import Title, Part
 
 
-class ContentsSerializer(serializers.BaseSerializer):
-    def to_representation(self, instance):
-        return instance.toc
+class ContentsSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    label = serializers.CharField()
+    parent = serializers.ListField(child=serializers.CharField())
+    reserved = serializers.BooleanField()
+    identifier = serializers.ListField(child=serializers.CharField())
+    label_level = serializers.CharField()
+    parent_type = serializers.CharField()
+    descendant_range = serializers.ListField(child=serializers.CharField())
+    label_description = serializers.CharField()
+
+    def get_fields(self):
+        fields = super(ContentsSerializer, self).get_fields()
+        fields['children'] = serializers.ListField(child=ContentsSerializer())
+        return fields
 
 
 class TitlesSerializer(serializers.ModelSerializer):

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -39,10 +39,9 @@ class PartsSerializer(serializers.ModelSerializer):
         fields = ("id", "name", "date", "last_updated", "depth", "title_object")
 
 
-class VersionsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Part
-        fields = ("id", "name", "date", "last_updated")
+class VersionsSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        return instance
 
 
 # Inherit from this class to return a flat list of specific types of nodes within the part

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field
 
 from regcore.models import Title, Part
 
@@ -73,12 +72,3 @@ class PartSectionsSerializer(NodeTypeSerializer):
 
 class PartSubpartsSerializer(NodeTypeSerializer):
     node_type = "subpart"
-
-
-class SubpartContentsSerializer(serializers.BaseSerializer):
-    def to_representation(self, instance):
-        toc = instance.toc
-        for node in toc["children"]:
-            if node["type"] == "subpart" and len(node["identifier"]) and node["identifier"][0] == self.context["subpart"]:
-                return node["children"]
-        return []

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -22,22 +22,26 @@ class ContentsSerializer(FlatContentsSerializer):
         return fields
 
 
-class TitlesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Title
-        fields = ("id", "name", "last_updated")
+class TitlesSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    last_updated = serializers.CharField()
 
 
-class TitleSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Title
-        fields = "__all__"
+class TitleSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    last_updated = serializers.CharField()
+    toc = ContentsSerializer()
 
 
-class PartsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Part
-        fields = ("id", "name", "date", "last_updated", "depth", "title_object")
+class PartsSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    date = serializers.CharField()
+    last_updated = serializers.CharField()
+    depth = serializers.IntegerField()
+    title_object = serializers.IntegerField()
 
 
 class VersionsSerializer(serializers.Serializer):

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -67,12 +67,12 @@ urlpatterns = [
         path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
             "get": "retrieve",
         })),
-        # path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
-        # path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
+        path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
+            "get": "retrieve",
+        })),
+        path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
+            "get": "retrieve",
+        })),
         path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
             "get": "retrieve",
         })),

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -47,34 +47,34 @@ urlpatterns = [
         path("toc", ContentsViewSet.as_view({
             "get": "list",
         })),
-        path("titles", TitlesViewSet.as_view({
-            "get": "list",
-        })),
-        path("title/<title>", TitleViewSet.as_view({
-            "get": "retrieve",
-            "post": "create",
-            "put": "update",
-        })),
-        path("title/<title>/toc", TitleContentsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/parts", PartsViewSet.as_view({
-            "get": "list",
-        })),
-        path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
-            "get": "list",
-        })),
-        path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
-            "get": "retrieve",
-        })),
+        # path("titles", TitlesViewSet.as_view({
+        #     "get": "list",
+        # })),
+        # path("title/<title>", TitleViewSet.as_view({
+        #     "get": "retrieve",
+        #     "post": "create",
+        #     "put": "update",
+        # })),
+        # path("title/<title>/toc", TitleContentsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/parts", PartsViewSet.as_view({
+        #     "get": "list",
+        # })),
+        # path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
+        #     "get": "list",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
     ])),
 ]

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -23,6 +23,7 @@ from regcore.v3views import (
     PartSectionsViewSet,
     PartSubpartsViewSet,
     SubpartContentsViewSet,
+    SupplementalContentSearchViewSet
 )
 
 
@@ -75,6 +76,9 @@ urlpatterns = [
         })),
         path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
             "get": "retrieve",
+        })),
+        path("supplemental_content/search", SupplementalContentSearchViewSet.as_view({
+            "get": "list",
         })),
     ])),
 ]

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -47,23 +47,23 @@ urlpatterns = [
         path("toc", ContentsViewSet.as_view({
             "get": "list",
         })),
-        # path("titles", TitlesViewSet.as_view({
-        #     "get": "list",
-        # })),
-        # path("title/<title>", TitleViewSet.as_view({
-        #     "get": "retrieve",
-        #     "post": "create",
-        #     "put": "update",
-        # })),
-        # path("title/<title>/toc", TitleContentsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
-        # path("title/<title>/parts", PartsViewSet.as_view({
-        #     "get": "list",
-        # })),
-        # path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
-        #     "get": "list",
-        # })),
+        path("titles", TitlesViewSet.as_view({
+            "get": "list",
+        })),
+        path("title/<title>", TitleViewSet.as_view({
+            "get": "retrieve",
+            "post": "create",
+            "put": "update",
+        })),
+        path("title/<title>/toc", TitleContentsViewSet.as_view({
+            "get": "retrieve",
+        })),
+        path("title/<title>/parts", PartsViewSet.as_view({
+            "get": "list",
+        })),
+        path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
+            "get": "list",
+        })),
         # path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
         #     "get": "retrieve",
         # })),

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -23,7 +23,6 @@ from regcore.v3views import (
     PartSectionsViewSet,
     PartSubpartsViewSet,
     SubpartContentsViewSet,
-    SupplementalContentSearchViewSet
 )
 
 
@@ -76,9 +75,6 @@ urlpatterns = [
         })),
         path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
             "get": "retrieve",
-        })),
-        path("supplemental_content/search", SupplementalContentSearchViewSet.as_view({
-            "get": "list",
         })),
     ])),
 ]

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -73,8 +73,8 @@ urlpatterns = [
         # path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
         #     "get": "retrieve",
         # })),
-        # path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
+        path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
+            "get": "retrieve",
+        })),
     ])),
 ]

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -64,9 +64,9 @@ urlpatterns = [
         path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
             "get": "list",
         })),
-        # path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
+        path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
+            "get": "retrieve",
+        })),
         # path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
         #     "get": "retrieve",
         # })),

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import get_object_or_404
 
 from rest_framework import viewsets
+from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from drf_spectacular.utils import extend_schema, inline_serializer
 
 from regcore.models import Title, Part
 from regcore.views import SettingsAuthentication
@@ -10,7 +12,7 @@ from regcore.serializers import (
     ContentsSerializer,
     TitlesSerializer,
     TitleSerializer,
-    PartsSerialier,
+    PartsSerializer,
     VersionsSerializer,
     PartSectionsSerializer,
     PartSubpartsSerializer,
@@ -54,13 +56,13 @@ class TitleViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
 
 
 class TitleContentsViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewSet):
-    queryset = Title.objects.all()
+    queryset = Title.objects.all().values_list("toc", flat=True)
     serializer_class = ContentsSerializer
     lookup_fields = {"name": "title"}
 
 
 class PartsViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = PartsSerialier
+    serializer_class = PartsSerializer
 
     def get_queryset(self):
         title = self.kwargs.get("title")

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -35,7 +35,7 @@ class MultipleFieldLookupMixin(object):
 
 
 class ContentsViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Title.objects.all()
+    queryset = Title.objects.all().values_list("toc", flat=True)
     serializer_class = ContentsSerializer
 
 

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -1,3 +1,4 @@
+from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchVector, SearchRank
 from django.shortcuts import get_object_or_404
 
 from rest_framework import viewsets
@@ -16,6 +17,9 @@ from regcore.serializers import (
     PartSubpartsSerializer,
     SubpartContentsSerializer,
 )
+
+from supplemental_content.models import AbstractSupplementalContent
+from supplemental_content.serializers import FlatSupplementalContentSerializer
 
 
 class MultipleFieldLookupMixin(object):
@@ -106,3 +110,40 @@ class SubpartContentsViewSet(PartPropertiesViewSet):
         context = super().get_serializer_context()
         context["subpart"] = self.kwargs.get("subpart")
         return context
+
+class SupplementalContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = FlatSupplementalContentSerializer
+
+    def get_queryset(self):
+        query = self.request.query_params.get('q')
+        search_type = 'plain'
+        cover_density = False
+        if (query.startswith('"')) and query.endswith('"'):
+            search_type = 'phrase'
+            cover_density = True
+
+        return AbstractSupplementalContent.objects.filter(approved=True).annotate(rank=SearchRank(
+                SearchVector('supplementalcontent__name', weight='A', config='english')
+                + SearchVector('supplementalcontent__description', weight='A', config='english'),
+                SearchQuery(query, search_type=search_type, config='english'), cover_density=cover_density))\
+            .filter(rank__gte=0.2) \
+            .annotate(
+                nameHeadline=SearchHeadline(
+                    "supplementalcontent__name",
+                    SearchQuery(query, search_type=search_type, config='english'),
+                    start_sel='<span class="search-highlight">',
+                    stop_sel='</span>',
+                    config='english'
+                ),
+                descriptionHeadline=SearchHeadline(
+                    "supplementalcontent__description",
+                    SearchQuery(query, search_type=search_type, config='english'),
+                    start_sel='<span class="search-highlight">',
+                    stop_sel='</span>',
+                    config='english'
+                )
+            )\
+            .order_by('-rank') \
+            .prefetch_related('locations')\
+            .prefetch_related('category').select_subclasses("supplementalcontent")
+

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -1,4 +1,3 @@
-from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchVector, SearchRank
 from django.shortcuts import get_object_or_404
 
 from rest_framework import viewsets
@@ -17,9 +16,6 @@ from regcore.serializers import (
     PartSubpartsSerializer,
     SubpartContentsSerializer,
 )
-
-from supplemental_content.models import AbstractSupplementalContent
-from supplemental_content.serializers import FlatSupplementalContentSerializer
 
 
 class MultipleFieldLookupMixin(object):
@@ -110,40 +106,3 @@ class SubpartContentsViewSet(PartPropertiesViewSet):
         context = super().get_serializer_context()
         context["subpart"] = self.kwargs.get("subpart")
         return context
-
-class SupplementalContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = FlatSupplementalContentSerializer
-
-    def get_queryset(self):
-        query = self.request.query_params.get('q')
-        search_type = 'plain'
-        cover_density = False
-        if (query.startswith('"')) and query.endswith('"'):
-            search_type = 'phrase'
-            cover_density = True
-
-        return AbstractSupplementalContent.objects.filter(approved=True).annotate(rank=SearchRank(
-                SearchVector('supplementalcontent__name', weight='A', config='english')
-                + SearchVector('supplementalcontent__description', weight='A', config='english'),
-                SearchQuery(query, search_type=search_type, config='english'), cover_density=cover_density))\
-            .filter(rank__gte=0.2) \
-            .annotate(
-                nameHeadline=SearchHeadline(
-                    "supplementalcontent__name",
-                    SearchQuery(query, search_type=search_type, config='english'),
-                    start_sel='<span class="search-highlight">',
-                    stop_sel='</span>',
-                    config='english'
-                ),
-                descriptionHeadline=SearchHeadline(
-                    "supplementalcontent__description",
-                    SearchQuery(query, search_type=search_type, config='english'),
-                    start_sel='<span class="search-highlight">',
-                    stop_sel='</span>',
-                    config='english'
-                )
-            )\
-            .order_by('-rank') \
-            .prefetch_related('locations')\
-            .prefetch_related('category').select_subclasses("supplementalcontent")
-

--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -259,11 +259,11 @@ class FlatSupplementalContentSerializer(serializers.Serializer):
     def get_nameHeadline(self, obj):
         try:
             return obj.nameHeadline
-        except:
+        except Exception:
             return None
 
     def get_descriptionHeadline(self, obj):
         try:
             return obj.descriptionHeadline
-        except:
+        except Exception:
             return None

--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -238,3 +238,32 @@ class SupplementalContentSerializer(serializers.Serializer):
     class Meta:
         model = SupplementalContent
         list_serializer_class = ApplicableSupplementalContentSerializer
+
+
+class FlatSupplementalContentSerializer(serializers.Serializer):
+    created_at = serializers.DateTimeField()
+    updated_at = serializers.DateTimeField()
+    approved = serializers.BooleanField()
+    category = SimpleCategorySerializer()
+    locations = SimpleLocationSerializer(many=True)
+    url = serializers.URLField()
+    description = serializers.CharField()
+    name = serializers.CharField()
+    date = serializers.CharField()
+    nameHeadline = serializers.SerializerMethodField()
+    descriptionHeadline = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AbstractSupplementalContent
+
+    def get_nameHeadline(self, obj):
+        try:
+            return obj.nameHeadline
+        except:
+            return None
+
+    def get_descriptionHeadline(self, obj):
+        try:
+            return obj.descriptionHeadline
+        except:
+            return None

--- a/solution/ui/prototype/src/components/PDPart/SectionCard.vue
+++ b/solution/ui/prototype/src/components/PDPart/SectionCard.vue
@@ -10,10 +10,11 @@
             {{
                 f.category
             }}
-        </v-card-subtitle><v-card-text>
-            <a :href="f.url">
+        </v-card-subtitle><v-card-text :class="$style['search-highlight']">
+            <a :href="f.url" v-if="!usingSearch">
                 {{ f.description }}
             </a>
+            <a :href="f.url" v-if="usingSearch" v-html="f.descriptionHeadline" />
         </v-card-text>
         <v-card-actions
           @click="showLocation = !showLocation"
@@ -100,7 +101,8 @@
 export default {
   name: "SectionCard",
   props: {
-    f: {type: Object}
+    f: {type: Object},
+    usingSearch: {type: Boolean},
   },
   data: () => ({
     showLocation: false,
@@ -132,6 +134,9 @@ export default {
 }
 </script>
 
-<style scoped>
-
+<style module>
+.search-highlight span {
+    font-style: italic;
+    font-weight: bold;
+}
 </style>

--- a/solution/ui/prototype/src/components/ResourcesPage/SectionSide.vue
+++ b/solution/ui/prototype/src/components/ResourcesPage/SectionSide.vue
@@ -2,7 +2,9 @@
     <div class="section-display">
     <div class="flex-parent-element">
     <div class="flex-child-element">
-            <h2>{{supList.length}} Results</h2></div>
+            <h2 v-bind:class="{ 'search-header': usingSearch }">{{supList.length}} Results</h2>
+            <p class="search-subtitle" v-if="usingSearch">For "{{searchQuery}}".</p>
+            </div>
          
             <div> <v-select v-model="sortBy" label="Sort By" :items='sortList'></v-select>
             </div></div>
@@ -19,7 +21,7 @@ import SectionCard from "../PDPart/SectionCard.vue"
 
 export default {
     name: "SectionPane",
-    props: ["supList"],
+    props: ["supList", "usingSearch", "searchQuery"],
     data: () =>({
         sortList:['Relevance', 'Most recent', 'Regulation hieracry', 'Resource type'],
         sortBy: 'Relevance'
@@ -53,5 +55,13 @@ padding-top:10px;
 }
 .flex-child-element:first-child {
   margin-left: 20px;
+}
+.search-header {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+.search-subtitle {
+  margin-top: 0;
+  padding-top: 0;
 }
 </style>

--- a/solution/ui/prototype/src/components/ResourcesPage/SectionSide.vue
+++ b/solution/ui/prototype/src/components/ResourcesPage/SectionSide.vue
@@ -10,7 +10,7 @@
             </div></div>
             <div class="section-cards">
             <div class="section-cards" v-for="content in supList" :key="content.name">
-        <SectionCard v-bind:f="content" /></div></div>
+        <SectionCard v-bind:f="content" v-bind:usingSearch="usingSearch" /></div></div>
 
     </div>
     

--- a/solution/ui/prototype/src/utilities/api.js
+++ b/solution/ui/prototype/src/utilities/api.js
@@ -645,6 +645,18 @@ const getSupplementalContentCountForPart = async (part) => {
     return result;
 };
 
+/**
+ *
+ * @param query {string} - a query string to search supplemental content
+ * @returns {Object<string:number>} - a list containing unstructured supplemental content search results
+ */
+const getSupplementalContentSearchResults = async (query) => {
+    const result = await httpApiGet(
+        `supplemental_content/search?q=${query}`
+    );
+    return result;
+};
+
 // API Functions Insertion Point (do not change this text, it is being used by hygen cli)
 
 export {
@@ -672,6 +684,7 @@ export {
     getCategories,
     getPartsDetails,
     getSubPartsandSections,
-    getAllSupplementalContentByPieces
+    getAllSupplementalContentByPieces,
+    getSupplementalContentSearchResults
     // API Export Insertion Point (do not change this text, it is being used by hygen cli)
 };

--- a/solution/ui/prototype/src/views/ResourcePage.vue
+++ b/solution/ui/prototype/src/views/ResourcePage.vue
@@ -4,6 +4,9 @@
             <Header />
             <div class="searchpane">
                 <v-text-field
+                    v-on:click:append="search"
+                    v-on:keydown="search"
+                    @change="searchQuery = $event"
                     flat
                     solo
                     clearable
@@ -12,6 +15,7 @@
                     type="text"
                     append-icon="mdi-magnify"
                     hide-details
+                    ref="search"
                 />
             </div>
             <splitpanes>
@@ -38,7 +42,7 @@ import FlashBanner from "@/components/FlashBanner.vue";
 import Footer from "@/components/Footer.vue";
 import Header from "@/components/Header.vue";
 import { Splitpanes, Pane } from "splitpanes";
-import { getSupplementalContentNew, getAllSupplementalContentByPieces } from "../utilities/api";
+import { getSupplementalContentNew, getAllSupplementalContentByPieces, getSupplementalContentSearchResults } from "../utilities/api";
 import "splitpanes/dist/splitpanes.css";
 import ResourceFilters from "../components/ResourcesPage/ResourceFilters.vue";
 import SectionPane from "../components/ResourcesPage/SectionSide.vue";
@@ -58,13 +62,12 @@ export default {
         singleSupList: [],
         sortedSupList: [],
         preSelectedSections:[],
-        preSelectedParts: []
-
-
+        preSelectedParts: [],
+        searchQuery: "",
+        usingSearch: false,
     }),
     async created() {
         try {
-
             const urlParams = new URLSearchParams(window.location.search);
             const part = urlParams.get('part')
             if (part){
@@ -99,6 +102,24 @@ export default {
         }
     },
     methods: {
+        async search(event) {
+            if ((event.type === "keydown" && event.key === "Enter") || event.type === "click") {
+                this.supList = [];
+                this.singleSupList = [];
+                this.sortedSupList = [];
+                this.supList.push(await getSupplementalContentSearchResults(this.searchQuery));
+                for (let sup of this.supList) {
+                    for (let content of sup) {
+                        let clone = JSON.parse(JSON.stringify(content));
+                        clone.category = clone.category.name;
+                        this.singleSupList.push(clone);
+                        this.sortedSupList.push(clone);
+                    }
+                }
+                this.sortedSupList.filter(content => content.name)
+                this.usingSearch = true;
+            }
+        },
         setResourcesParams(payload) {
             this.filters = payload;
 

--- a/solution/ui/prototype/src/views/ResourcePage.vue
+++ b/solution/ui/prototype/src/views/ResourcePage.vue
@@ -29,7 +29,7 @@
                     </div>
                 </pane>
                 <pane min-size="30">
-                    <SectionPane v-bind:supList="sortedSupList" />
+                    <SectionPane v-bind:supList="sortedSupList" v-bind:usingSearch="usingSearch" v-bind:searchQuery="searchQuery"/>
                 </pane>
             </splitpanes>
             <Footer />
@@ -161,6 +161,7 @@ export default {
             }
         },
         async getSupContent() {
+            this.usingSearch = false;
             this.singleSupList = [];
             console.log(this.filters)
             try {


### PR DESCRIPTION
Resolves #1284

**Description-**

New V3 serializers broke Swagger because fields must be explicitly defined for Swagger to work.

**This pull request changes...**

- ViewSets and Serializers are rewritten so that Swagger works.

**Steps to manually verify this change...**

1. Visit `/api/swagger` and verify the page loads and endpoints have proper parameters and response templates.

