### PR TITLE
EREGCSC-1284 Make Swagger API documentation work again

### DIFF
--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -5,6 +5,7 @@ from django.db import models
 from regcore.models import Part
 from .models import SearchIndex
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchHeadline
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
 
 
 class SearchViewSerializer(serializers.ModelSerializer):
@@ -18,6 +19,10 @@ class SearchViewSerializer(serializers.ModelSerializer):
         fields = ("type", "content", "headline", "label", "parent", "regulation_title", "title", "date")
 
 
+@extend_schema(
+        parameters=[
+          OpenApiParameter("q", str, OpenApiParameter.QUERY),],
+    )
 class SearchView(generics.ListAPIView):
     serializer_class = SearchViewSerializer
 

--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -5,7 +5,7 @@ from django.db import models
 from regcore.models import Part
 from .models import SearchIndex
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchHeadline
-from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 
 class SearchViewSerializer(serializers.ModelSerializer):
@@ -21,7 +21,7 @@ class SearchViewSerializer(serializers.ModelSerializer):
 
 @extend_schema(
         parameters=[
-          OpenApiParameter("q", str, OpenApiParameter.QUERY),],
+          OpenApiParameter("q", str, OpenApiParameter.QUERY), ],
     )
 class SearchView(generics.ListAPIView):
     serializer_class = SearchViewSerializer

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 
 from regcore.models import Title, Part
 
@@ -32,15 +33,16 @@ class TitleSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class PartsSerialier(serializers.ModelSerializer):
+class PartsSerializer(serializers.ModelSerializer):
     class Meta:
         model = Part
         fields = ("id", "name", "date", "last_updated", "depth", "title_object")
 
 
-class VersionsSerializer(serializers.BaseSerializer):
-    def to_representation(self, instance):
-        return instance.date
+class VersionsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Part
+        fields = ("id", "name", "date", "last_updated")
 
 
 # Inherit from this class to return a flat list of specific types of nodes within the part

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 
-from regcore.models import Title, Part
-
 
 class FlatContentsSerializer(serializers.Serializer):
     type = serializers.CharField()

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -3,9 +3,21 @@ from rest_framework import serializers
 from regcore.models import Title, Part
 
 
-class ContentsSerializer(serializers.BaseSerializer):
-    def to_representation(self, instance):
-        return instance.toc
+class ContentsSerializer(serializers.Serializer):
+    type = serializers.CharField()
+    label = serializers.CharField()
+    parent = serializers.ListField(child=serializers.CharField())
+    reserved = serializers.BooleanField()
+    identifier = serializers.ListField(child=serializers.CharField())
+    label_level = serializers.CharField()
+    parent_type = serializers.CharField()
+    descendant_range = serializers.ListField(child=serializers.CharField())
+    label_description = serializers.CharField()
+
+    def get_fields(self):
+        fields = super(ContentsSerializer, self).get_fields()
+        fields['children'] = serializers.ListField(child=ContentsSerializer())
+        return fields
 
 
 class TitlesSerializer(serializers.ModelSerializer):

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -39,10 +39,9 @@ class PartsSerializer(serializers.ModelSerializer):
         fields = ("id", "name", "date", "last_updated", "depth", "title_object")
 
 
-class VersionsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Part
-        fields = ("id", "name", "date", "last_updated")
+class VersionsSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        return instance
 
 
 # Inherit from this class to return a flat list of specific types of nodes within the part

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field
 
 from regcore.models import Title, Part
 
@@ -73,12 +72,3 @@ class PartSectionsSerializer(NodeTypeSerializer):
 
 class PartSubpartsSerializer(NodeTypeSerializer):
     node_type = "subpart"
-
-
-class SubpartContentsSerializer(serializers.BaseSerializer):
-    def to_representation(self, instance):
-        toc = instance.toc
-        for node in toc["children"]:
-            if node["type"] == "subpart" and len(node["identifier"]) and node["identifier"][0] == self.context["subpart"]:
-                return node["children"]
-        return []

--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -22,22 +22,26 @@ class ContentsSerializer(FlatContentsSerializer):
         return fields
 
 
-class TitlesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Title
-        fields = ("id", "name", "last_updated")
+class TitlesSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    last_updated = serializers.CharField()
 
 
-class TitleSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Title
-        fields = "__all__"
+class TitleSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    last_updated = serializers.CharField()
+    toc = ContentsSerializer()
 
 
-class PartsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Part
-        fields = ("id", "name", "date", "last_updated", "depth", "title_object")
+class PartsSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    date = serializers.CharField()
+    last_updated = serializers.CharField()
+    depth = serializers.IntegerField()
+    title_object = serializers.IntegerField()
 
 
 class VersionsSerializer(serializers.Serializer):

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -67,12 +67,12 @@ urlpatterns = [
         path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
             "get": "retrieve",
         })),
-        # path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
-        # path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
+        path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
+            "get": "retrieve",
+        })),
+        path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
+            "get": "retrieve",
+        })),
         path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
             "get": "retrieve",
         })),

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -47,34 +47,34 @@ urlpatterns = [
         path("toc", ContentsViewSet.as_view({
             "get": "list",
         })),
-        path("titles", TitlesViewSet.as_view({
-            "get": "list",
-        })),
-        path("title/<title>", TitleViewSet.as_view({
-            "get": "retrieve",
-            "post": "create",
-            "put": "update",
-        })),
-        path("title/<title>/toc", TitleContentsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/parts", PartsViewSet.as_view({
-            "get": "list",
-        })),
-        path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
-            "get": "list",
-        })),
-        path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
-            "get": "retrieve",
-        })),
-        path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
-            "get": "retrieve",
-        })),
+        # path("titles", TitlesViewSet.as_view({
+        #     "get": "list",
+        # })),
+        # path("title/<title>", TitleViewSet.as_view({
+        #     "get": "retrieve",
+        #     "post": "create",
+        #     "put": "update",
+        # })),
+        # path("title/<title>/toc", TitleContentsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/parts", PartsViewSet.as_view({
+        #     "get": "list",
+        # })),
+        # path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
+        #     "get": "list",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
+        # path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
+        #     "get": "retrieve",
+        # })),
     ])),
 ]

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -47,23 +47,23 @@ urlpatterns = [
         path("toc", ContentsViewSet.as_view({
             "get": "list",
         })),
-        # path("titles", TitlesViewSet.as_view({
-        #     "get": "list",
-        # })),
-        # path("title/<title>", TitleViewSet.as_view({
-        #     "get": "retrieve",
-        #     "post": "create",
-        #     "put": "update",
-        # })),
-        # path("title/<title>/toc", TitleContentsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
-        # path("title/<title>/parts", PartsViewSet.as_view({
-        #     "get": "list",
-        # })),
-        # path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
-        #     "get": "list",
-        # })),
+        path("titles", TitlesViewSet.as_view({
+            "get": "list",
+        })),
+        path("title/<title>", TitleViewSet.as_view({
+            "get": "retrieve",
+            "post": "create",
+            "put": "update",
+        })),
+        path("title/<title>/toc", TitleContentsViewSet.as_view({
+            "get": "retrieve",
+        })),
+        path("title/<title>/parts", PartsViewSet.as_view({
+            "get": "list",
+        })),
+        path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
+            "get": "list",
+        })),
         # path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
         #     "get": "retrieve",
         # })),

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -73,8 +73,8 @@ urlpatterns = [
         # path("title/<title>/part/<part>/version/<version>/subparts", PartSubpartsViewSet.as_view({
         #     "get": "retrieve",
         # })),
-        # path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
+        path("title/<title>/part/<part>/version/<version>/subpart/<subpart>/toc", SubpartContentsViewSet.as_view({
+            "get": "retrieve",
+        })),
     ])),
 ]

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -64,9 +64,9 @@ urlpatterns = [
         path("title/<title>/part/<part>/versions", VersionsViewSet.as_view({
             "get": "list",
         })),
-        # path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
-        #     "get": "retrieve",
-        # })),
+        path("title/<title>/part/<part>/version/<version>/toc", PartContentsViewSet.as_view({
+            "get": "retrieve",
+        })),
         # path("title/<title>/part/<part>/version/<version>/sections", PartSectionsViewSet.as_view({
         #     "get": "retrieve",
         # })),

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import get_object_or_404
 
 from rest_framework import viewsets
+from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from drf_spectacular.utils import extend_schema, inline_serializer
 
 from regcore.models import Title, Part
 from regcore.views import SettingsAuthentication
@@ -10,7 +12,7 @@ from regcore.serializers import (
     ContentsSerializer,
     TitlesSerializer,
     TitleSerializer,
-    PartsSerialier,
+    PartsSerializer,
     VersionsSerializer,
     PartSectionsSerializer,
     PartSubpartsSerializer,
@@ -54,13 +56,13 @@ class TitleViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
 
 
 class TitleContentsViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewSet):
-    queryset = Title.objects.all()
+    queryset = Title.objects.all().values_list("toc", flat=True)
     serializer_class = ContentsSerializer
     lookup_fields = {"name": "title"}
 
 
 class PartsViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = PartsSerialier
+    serializer_class = PartsSerializer
 
     def get_queryset(self):
         title = self.kwargs.get("title")

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -35,7 +35,7 @@ class MultipleFieldLookupMixin(object):
 
 
 class ContentsViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Title.objects.all()
+    queryset = Title.objects.all().values_list("toc", flat=True)
     serializer_class = ContentsSerializer
 
 

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django.http import Http404
 
-from rest_framework import viewsets, serializers
+from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from drf_spectacular.utils import extend_schema

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -68,7 +68,7 @@ class PartsViewSet(viewsets.ReadOnlyModelViewSet):
         return Part.objects.filter(title=title).order_by("name", "-date").distinct("name")
 
 
-@extend_schema(responses=serializers.ListField(child=serializers.CharField()))
+@extend_schema(responses={(200, "application/json"): {"type": "string"}})
 class VersionsViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = VersionsSerializer
 

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -19,8 +19,8 @@ from regcore.serializers import (
 )
 
 
-def OpenApiPathParameter(name, description):
-    return OpenApiParameter(name=name, description=description, required=True, type=str, location=OpenApiParameter.PATH)
+def OpenApiPathParameter(name, description, type):
+    return OpenApiParameter(name=name, description=description, required=True, type=type, location=OpenApiParameter.PATH)
 
 
 class MultipleFieldLookupMixin(object):
@@ -54,7 +54,7 @@ class TitlesViewSet(viewsets.ReadOnlyModelViewSet):
 
 @extend_schema(
     description="Retrieve, create, or update a specific Title object.",
-    parameters=[OpenApiPathParameter("title", "Title of interest, e.g. 42.")],
+    parameters=[OpenApiPathParameter("title", "Title of interest, e.g. 42.", int)],
 )
 class TitleViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     queryset = Title.objects.all()
@@ -67,7 +67,7 @@ class TitleViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
 
 @extend_schema(
     description="Retrieve the table of contents for a specific Title, with detail down to the Part level.",
-    parameters=[OpenApiPathParameter("title", "Title of interest, e.g. 42.")],
+    parameters=[OpenApiPathParameter("title", "Title of interest, e.g. 42.", int)],
 )
 class TitleContentsViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Title.objects.all().values_list("toc", flat=True)
@@ -77,7 +77,7 @@ class TitleContentsViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewS
 
 @extend_schema(
     description="Retrieve a list of the latest version of each Part contained within a specific Title, in numerical order.",
-    parameters=[OpenApiPathParameter("title", "Title to retrieve Parts from, e.g. 42.")],
+    parameters=[OpenApiPathParameter("title", "Title to retrieve Parts from, e.g. 42.", int)],
 )
 class PartsViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PartsSerializer
@@ -90,8 +90,8 @@ class PartsViewSet(viewsets.ReadOnlyModelViewSet):
 @extend_schema(
     description="Retrieve a list of versions of a specific Part within a specific Title. Response is a simple list of strings.",
     parameters=[
-        OpenApiPathParameter("title", "Title where Part is contained, e.g. 42."),
-        OpenApiPathParameter("part", "Part of interest, e.g. 433."),
+        OpenApiPathParameter("title", "Title where Part is contained, e.g. 42.", int),
+        OpenApiPathParameter("part", "Part of interest, e.g. 433.", int),
     ],
     responses={(200, "application/json"): {"type": "string"}},
 )
@@ -108,10 +108,10 @@ class VersionsViewSet(viewsets.ReadOnlyModelViewSet):
 # You must specify a serializer_class
 @extend_schema(
     parameters=[
-        OpenApiPathParameter("title", "Title where Part is contained, e.g. 42."),
-        OpenApiPathParameter("part", "Part of interest, e.g. 433."),
+        OpenApiPathParameter("title", "Title where Part is contained, e.g. 42.", int),
+        OpenApiPathParameter("part", "Part of interest, e.g. 433.", int),
         OpenApiPathParameter("version", "Version of the Part. Must be in YYYY-MM-DD format (e.g. 2021-01-31), "
-                             "or \"latest\" to retrieve the most recent version."),
+                             "or \"latest\" to retrieve the most recent version.", str),
     ],
 )
 class PartPropertiesViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyModelViewSet):
@@ -165,7 +165,7 @@ class PartSubpartsViewSet(PartStructureNodesViewSet):
 @extend_schema(
     description="Retrieve a table of contents for a specific Subpart contained within a Part, "
                 "with detail down to the Section level.",
-    parameters=[OpenApiPathParameter("subpart", "The Subpart of interest, e.g. A.")],
+    parameters=[OpenApiPathParameter("subpart", "The Subpart of interest, e.g. A.", str)],
 )
 class SubpartContentsViewSet(PartPropertiesViewSet):
     serializer_class = ContentsSerializer

--- a/solution/backend/regcore/views.py
+++ b/solution/backend/regcore/views.py
@@ -4,7 +4,7 @@ from rest_framework import generics, serializers
 from django.conf import settings
 from django.contrib.postgres.aggregates import StringAgg
 
-from regcore.models import Part, ParserConfiguration, TitleConfiguration
+from regcore.models import Part, ParserConfiguration
 
 from rest_framework.response import Response
 

--- a/solution/backend/regcore/views.py
+++ b/solution/backend/regcore/views.py
@@ -145,10 +145,10 @@ class EffectivePartTocView(EffectivePartView):
     serializer_class = ListEffectivePartTocSerializer
 
 
-class TitleConfigurationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = TitleConfiguration
-        fields = ("title", "subchapters", "parts")
+class TitleConfigurationSerializer(serializers.Serializer):
+    title = serializers.IntegerField()
+    subchapters = serializers.CharField()
+    parts = serializers.CharField()
 
 
 class ParserConfigurationSerializer(serializers.ModelSerializer):

--- a/solution/backend/supplemental_content/views.py
+++ b/solution/backend/supplemental_content/views.py
@@ -103,6 +103,7 @@ class SupplementalContentView(generics.ListAPIView):
 
         return Response(serializer.data)
 
+
 @extend_schema(
         parameters=[
           OpenApiParameter("start", int, OpenApiParameter.QUERY),

--- a/solution/backend/supplemental_content/views.py
+++ b/solution/backend/supplemental_content/views.py
@@ -9,7 +9,11 @@ from django.db.models import Prefetch, Q, Count
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework import authentication
 from rest_framework import exceptions
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiParameter,
+    OpenApiTypes,
+)
 
 from .models import (
     AbstractSupplementalContent,
@@ -99,7 +103,12 @@ class SupplementalContentView(generics.ListAPIView):
 
         return Response(serializer.data)
 
-
+@extend_schema(
+        parameters=[
+          OpenApiParameter("start", int, OpenApiParameter.QUERY),
+          OpenApiParameter("max_results", int, OpenApiParameter.QUERY)
+        ],
+    )
 class AllSupplementalContentView(APIView):
     def get(self, *args, **kwargs):
         start = int(self.request.GET.get("start", 0))
@@ -155,6 +164,12 @@ class SupplementalContentSectionsView(generics.CreateAPIView):
 
 
 class SupplementalContentByPartView(APIView):
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("part", str, OpenApiParameter.QUERY), ],
+        responses={
+            (200, 'application/json'): OpenApiTypes.OBJECT}
+    )
     def get(self, request, format=None):
         part = request.GET.get('part', '')
         results = AbstractLocation.objects.filter(part=part).annotate(

--- a/solution/ui/e2e/cypress/integration/swagger.spec.js
+++ b/solution/ui/e2e/cypress/integration/swagger.spec.js
@@ -1,0 +1,16 @@
+describe("Swagger View", () => {
+
+    it("loads the swagger page", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/api/swagger/");
+        cy.contains("CMCS eRegulations API").should(
+            "be.visible"
+        );
+        cy.contains("/api/schema/").should(
+            "be.visible"
+        );
+        cy.contains("Schemas").should(
+            "be.visible"
+        );
+    });
+})


### PR DESCRIPTION
Resolves #1284

**Description-**

New V3 serializers broke Swagger because fields must be explicitly defined for Swagger to work.

**This pull request changes...**

- ViewSets and Serializers are rewritten so that Swagger works.
- Additionally, endpoint and parameter descriptions have been added for all V3 endpoints.

**Steps to manually verify this change...**

1. Visit `/api/swagger` and verify the page loads and endpoints have proper parameters and response templates.
2. Verify that V3 endpoints have correct endpoint and parameter descriptions.

