### PR TITLE
EREGCSC-1289 - Highlight search query in document name

### DIFF
--- a/solution/backend/regcore/search/models.py
+++ b/solution/backend/regcore/search/models.py
@@ -40,6 +40,11 @@ class SearchIndexQuerySet(models.QuerySet):
                     stop_sel='</span>',
                     config='english'
                 ),
+                parentHeadline=SearchHeadline(
+                    "parent__title",
+                    SearchQuery(query, search_type=search_type, config='english'),
+                    config='english',
+                ),
             )\
             .order_by('-rank')\
             .prefetch_related('part')

--- a/solution/backend/regcore/search/models.py
+++ b/solution/backend/regcore/search/models.py
@@ -43,7 +43,10 @@ class SearchIndexQuerySet(models.QuerySet):
                 parentHeadline=SearchHeadline(
                     "parent__title",
                     SearchQuery(query, search_type=search_type, config='english'),
+                    start_sel="<span class='search-highlight'>",
+                    stop_sel="</span>",
                     config='english',
+                    highlight_all=True
                 ),
             )\
             .order_by('-rank')\

--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -34,6 +34,10 @@ class SearchView(generics.ListAPIView):
                     start_sel='<span class="search-highlight">',
                     stop_sel='</span>',
                 ),
+                parentHeadline=SearchHeadline(
+                    "parent__title",
+                    SearchQuery(q),
+                ),
             )\
             .order_by('-rank')\
             .values("type", "content", "headline", "label", "parent", "part__document__title", "part__title", "part__date")

--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -37,6 +37,8 @@ class SearchView(generics.ListAPIView):
                 parentHeadline=SearchHeadline(
                     "parent__title",
                     SearchQuery(q),
+                    start_sel="<span class='search-highlight'>",
+                    stop_sel='</span>',
                 ),
             )\
             .order_by('-rank')\

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -42,7 +42,7 @@
                             <div class="result">
                                 <!--{{ result.rank }}-->
                                 <div class="results-part">{{ result.part.document.title | title}}</div>
-                                <div class="results-section"><a href="{% url 'reader_view' result.part.title result.label.0 result.label.1 result.part.date %}#{{ result.label | join:'-' }}">{{ result.parent.title }}</a></div>
+                                <div class="results-section"><a href="{% url 'reader_view' result.part.title result.label.0 result.label.1 result.part.date %}#{{ result.label | join:'-' }}">{{ result.parentHeadline | safe }}</a></div>
                                 <div class="results-preview">{{ result.headline | safe }}</div>
                             </div>
                             {% endif %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -1,5 +1,6 @@
 {% extends "regulations/base.html" %}
 {% load static %}
+{% load string_formatters %}
 
 {% block title %}Search for {{ q }} | Medicaid & CHIP eRegulations{% endblock %}
 
@@ -42,7 +43,11 @@
                             <div class="result">
                                 <!--{{ result.rank }}-->
                                 <div class="results-part">{{ result.part.document.title | title}}</div>
-                                <div class="results-section"><a href="{% url 'reader_view' result.part.title result.label.0 result.label.1 result.part.date %}#{{ result.label | join:'-' }}">{{ result.parentHeadline | safe }}</a></div>
+                                <div class="results-section">
+                                    <a href="{% url 'reader_view' result.part.title result.label.0 result.label.1 result.part.date %}#{{ result.label | join:'-' }}">
+                                        {{ result.parentHeadline | stripSurroundingQuotes | safe }}
+                                    </a>
+                                </div>
                                 <div class="results-preview">{{ result.headline | safe }}</div>
                             </div>
                             {% endif %}

--- a/solution/backend/regulations/templatetags/string_formatters.py
+++ b/solution/backend/regulations/templatetags/string_formatters.py
@@ -53,3 +53,11 @@ def paragraph_formatter(title, node_label):
 def appendix_formatter(title, node_label):
     citation = " ".join(node_label)
     return strip_tags(f"{title} CFR {citation}")
+
+
+@register.filter
+def stripSurroundingQuotes(quotedString):
+    if quotedString.startswith('"') and quotedString.endswith('"'):
+        return quotedString[1:-1]
+    else:
+        return quotedString


### PR DESCRIPTION
Resolves [EREGCCS-1289](https://jiraent.cms.gov/browse/EREGCSC-1289)

**Description**

In search results, highlight terms when they are in document names.

**This pull request changes:**

- Adds new annotation to SearchIndex object that highlights the search query in the Section title

**Steps to manually verify this change:**

1. Visit experimental deployment's [Search page](https://xmuylu2ao4.execute-api.us-east-1.amazonaws.com/dev-403/search/) 
2. Search for a term or quoted phrase
  a. example: "therapy"
3. Notice that the search query will be emphasized in the section name if present
4. Compare same search query against pilot site to see that the query is not emphasized in the section name if present 

