### PR TITLE
EREGCSC-1284-B Fix error when creating or updating a Title object

### DIFF
--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -1,22 +1,24 @@
 from rest_framework import serializers
 
+from .models import Title
+
 
 class FlatContentsSerializer(serializers.Serializer):
     type = serializers.CharField()
     label = serializers.CharField()
-    parent = serializers.ListField(child=serializers.CharField())
+    parent = serializers.ListField(child=serializers.CharField(), allow_null=True, allow_empty=True)
     reserved = serializers.BooleanField()
     identifier = serializers.ListField(child=serializers.CharField())
     label_level = serializers.CharField()
-    parent_type = serializers.CharField()
-    descendant_range = serializers.ListField(child=serializers.CharField())
+    parent_type = serializers.CharField(allow_blank=True)
+    descendant_range = serializers.ListField(child=serializers.CharField(), allow_null=True, allow_empty=True)
     label_description = serializers.CharField()
 
 
 class ContentsSerializer(FlatContentsSerializer):
     def get_fields(self):
         fields = super(ContentsSerializer, self).get_fields()
-        fields['children'] = serializers.ListField(child=ContentsSerializer())
+        fields['children'] = serializers.ListField(child=ContentsSerializer(), allow_null=True, allow_empty=True)
         return fields
 
 
@@ -26,11 +28,19 @@ class TitlesSerializer(serializers.Serializer):
     last_updated = serializers.CharField()
 
 
-class TitleSerializer(serializers.Serializer):
+class TitleRetrieveSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     name = serializers.CharField()
     last_updated = serializers.CharField()
     toc = ContentsSerializer()
+
+
+class TitleUploadSerializer(serializers.ModelSerializer):
+    toc = ContentsSerializer()
+
+    class Meta:
+        model = Title
+        fields = ["name", "toc"]
 
 
 class PartsSerializer(serializers.Serializer):

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -13,7 +13,8 @@ from regcore.serializers import (
     FlatContentsSerializer,
     ContentsSerializer,
     TitlesSerializer,
-    TitleSerializer,
+    TitleRetrieveSerializer,
+    TitleUploadSerializer,
     PartsSerializer,
     VersionsSerializer,
 )
@@ -58,11 +59,15 @@ class TitlesViewSet(viewsets.ReadOnlyModelViewSet):
 )
 class TitleViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     queryset = Title.objects.all()
-    serializer_class = TitleSerializer
     lookup_fields = {"name": "title"}
 
     authentication_classes = [SettingsAuthentication]
     permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_serializer_class(self):
+        if self.request.method == "POST" or self.request.method == "PUT":
+            return TitleUploadSerializer
+        return TitleRetrieveSerializer
 
 
 @extend_schema(


### PR DESCRIPTION
Resolves #1284

**Description-**

New serializer structure for Swagger compliance broke posting and putting to `/v3/title/<title>`. Fixed by creating a ModelSerializer for these operations.

**This pull request changes...**

- Parser now works again.

**Steps to manually verify this change...**

1. Start with a clean database or disable "skip versions" and try to run the parser.

