### PR TITLE
EREGCSC-1322 Improve FR parser: don't try to fetch documents that don't exist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,8 +71,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.16' # The Go version to download (if necessary) and use.
-      - name: deploy parsers
-        id: deploy-parsers
+      - name: deploy and run eCFR parser
+        id: deploy-run-ecfr-parser
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -80,10 +80,11 @@ jobs:
           pushd solution/parser
           npm install serverless -g
           npm install
-          serverless deploy --stage ${{ matrix.environment }}
+          serverless deploy --stage ${{ matrix.environment }} --config ./serverless-ecfr.yml
+          AWS_CLIENT_TIMEOUT=360000 serverless invoke --function ecfr_parser --stage ${{ matrix.environment }} --config ./serverless-ecfr.yml
           popd
-      - name: run eCFR parser
-        id: run-ecfr-parser
+      - name: deploy and run FR parser
+        id: deploy-run-fr-parser
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -91,18 +92,8 @@ jobs:
           pushd solution/parser
           npm install serverless -g
           npm install
-          AWS_CLIENT_TIMEOUT=360000 serverless invoke --function ecfr_parser --stage ${{ matrix.environment }}
-          popd
-      - name: run Federal Register parser
-        id: run-fr-parser
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          pushd solution/parser
-          npm install serverless -g
-          npm install
-          AWS_CLIENT_TIMEOUT=360000 serverless invoke --function fr_parser --stage ${{ matrix.environment }}
+          serverless deploy --stage ${{ matrix.environment }} --config ./serverless-fr.yml
+          AWS_CLIENT_TIMEOUT=360000 serverless invoke --function fr_parser --stage ${{ matrix.environment }} --config ./serverless-fr.yml
           popd
       # build the static assets for the prototype website
       - name: build static assets and deploy prototype

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      # Remove the parser lambda
-      - name: remove parser
+      # Remove the eCFR parser lambda
+      - name: remove eCFR parser
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -38,7 +38,19 @@ jobs:
           pushd solution/parser
           npm install serverless -g
           npm install
-          serverless remove --stage dev-${PR}
+          serverless remove --stage dev-${PR} --config ./serverless-ecfr.yml
+          popd
+      # Remove the FR parser lambda
+      - name: remove FR parser
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          PR: ${{ github.event.number }}
+        run: |
+          pushd solution/parser
+          npm install serverless -g
+          npm install
+          serverless remove --stage dev-${PR} --config ./serverless-fr.yml
           popd
       # remove the regulations site
       - name: remove experimental regulations site server

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      # Remove the eCFR parser lambda
-      - name: remove eCFR parser
+      # Remove parsers
+      - name: remove parsers
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -39,17 +39,6 @@ jobs:
           npm install serverless -g
           npm install
           serverless remove --stage dev-${PR} --config ./serverless-ecfr.yml
-          popd
-      # Remove the FR parser lambda
-      - name: remove FR parser
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          PR: ${{ github.event.number }}
-        run: |
-          pushd solution/parser
-          npm install serverless -g
-          npm install
           serverless remove --stage dev-${PR} --config ./serverless-fr.yml
           popd
       # remove the regulations site

--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -319,6 +319,7 @@ class CreateSupplementalContentSerializer(serializers.Serializer):
     docket_number = serializers.CharField(allow_blank=True, allow_null=True)
     document_number = serializers.CharField(allow_blank=True, allow_null=True)
     date = serializers.CharField()
+    approved = serializers.BooleanField(required=False, default=False)
     id = serializers.CharField(required=False)
 
     def validate_category(self, value):
@@ -337,7 +338,7 @@ class CreateSupplementalContentSerializer(serializers.Serializer):
         instance.docket_number = validated_data.get('docket_number', instance.docket_number)
         instance.document_number = validated_data.get('document_number', instance.document_number)
         instance.date = validated_data.get('date', instance.date)
-        instance.approved = True if instance.approved else False
+        instance.approved = validated_data.get('approved', instance.approved)
         # This will work because it was validated above
         category = AbstractCategory.objects.get(name=validated_data["category"])
         instance.category = category

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -16,7 +16,7 @@ import (
 )
 
 // FedRegContentURL is the Federal Register API endpoint to retrieve a list of documents from
-var FedRegContentURL = "https://www.federalregister.gov/api/v1/documents.json?fields[]=type&fields[]=citation&fields[]=docket_id&fields[]=document_number&fields[]=html_url&fields[]=publication_date&fields[]=title&order=newest&conditions[cfr][title]=%d&conditions[cfr][part]=%s"
+var FedRegContentURL = "https://www.federalregister.gov/api/v1/documents.json?fields[]=type&fields[]=full_text_xml_url&fields[]=citation&fields[]=docket_id&fields[]=document_number&fields[]=html_url&fields[]=publication_date&fields[]=title&order=newest&conditions[cfr][title]=%d&conditions[cfr][part]=%s"
 
 // FedRegDocumentURL is the Federal Register API endpoint to retrieve the full text of a document from
 var FedRegDocumentURL = "https://www.federalregister.gov/documents/full_text/xml/%s/%s/%s/%s.xml"
@@ -30,6 +30,7 @@ type FRDoc struct {
 	Date string `json:"publication_date"`
 	DocketNumber string `json:"docket_id"`
 	DocumentNumber string `json:"document_number"`
+	FullTextURL string `json:"full_text_xml_url"`
 }
 
 // FRDocPage represents a page containing many documents. NextPageURL is optional and points to the next page of docs, if one exists

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -17,9 +17,6 @@ import (
 // FedRegContentURL is the Federal Register API endpoint to retrieve a list of documents from
 var FedRegContentURL = "https://www.federalregister.gov/api/v1/documents.json?fields[]=type&fields[]=full_text_xml_url&fields[]=citation&fields[]=docket_id&fields[]=document_number&fields[]=html_url&fields[]=publication_date&fields[]=title&order=newest&conditions[cfr][title]=%d&conditions[cfr][part]=%s"
 
-// FedRegDocumentURL is the Federal Register API endpoint to retrieve the full text of a document from
-var FedRegDocumentURL = "https://www.federalregister.gov/documents/full_text/xml/%s/%s/%s/%s.xml"
-
 // FRDoc is the Federal Register's representation of a document
 type FRDoc struct {
 	Name string `json:"citation"`

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"io"
-	"strings"
 	"regexp"
 
 	"github.com/cmsgov/cmcs-eregulations/ecfr-parser/network"
@@ -92,9 +91,8 @@ type XMLQuery struct {
 }
 
 // FetchSections pulls the full document from the Federal Register and extracts all SECTNO tags
-func FetchSections(ctx context.Context, date string, id string) ([]string, error) {
-	dateParts := strings.Split(date, "-")
-	reader, err := fetch(ctx, fmt.Sprintf(FedRegDocumentURL, dateParts[0], dateParts[1], dateParts[2], id))
+func FetchSections(ctx context.Context, path string) ([]string, error) {
+	reader, err := fetch(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +116,7 @@ func FetchSections(ctx context.Context, date string, id string) ([]string, error
 				}
 				section, err := extractSection(l.Loc)
 				if err != nil {
-					log.Error("[fedreg] Failed to extract section from doc ID \"", id, "\" identifier \"", l.Loc, "\"")
+					log.Error("[fedreg] Failed to extract section from identifier \"", l.Loc, "\"")
 				} else {
 					sections = append(sections, section)
 				}

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -16,7 +16,7 @@ import (
 )
 
 // FedRegContentURL is the Federal Register API endpoint to retrieve a list of documents from
-var FedRegContentURL = "https://www.federalregister.gov/api/v1/documents.json?fields[]=type&fields[]=abstract&fields[]=citation&fields[]=correction_of&fields[]=action&fields[]=dates&fields[]=docket_id&fields[]=docket_ids&fields[]=document_number&fields[]=effective_on&fields[]=html_url&fields[]=publication_date&fields[]=regulation_id_number_info&fields[]=regulation_id_numbers&fields[]=title&order=newest&conditions[cfr][title]=%d&conditions[cfr][part]=%s"
+var FedRegContentURL = "https://www.federalregister.gov/api/v1/documents.json?fields[]=type&fields[]=citation&fields[]=docket_id&fields[]=document_number&fields[]=html_url&fields[]=publication_date&fields[]=title&order=newest&conditions[cfr][title]=%d&conditions[cfr][part]=%s"
 
 // FedRegDocumentURL is the Federal Register API endpoint to retrieve the full text of a document from
 var FedRegDocumentURL = "https://www.federalregister.gov/documents/full_text/xml/%s/%s/%s/%s.xml"

--- a/solution/parser/fr-parser/fedreg/fedreg_test.go
+++ b/solution/parser/fr-parser/fedreg/fedreg_test.go
@@ -333,13 +333,12 @@ func TestFetchSections(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				w.Write(tc.InputXML)
 			}))
-			FedRegDocumentURL = server.URL + "/%s/%s/%s/%s"
 			defer server.Close()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1 * time.Second)
 			defer cancel()
 
-			output, err := FetchSections(ctx, "2021-01-31", "2021-12345")
+			output, err := FetchSections(ctx, server.URL)
 			if err != nil && !tc.Error {
 				t.Errorf("expected no error, received (%+v)", err)
 			} else if err == nil && tc.Error {

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -174,6 +174,8 @@ func processDocument(ctx context.Context, title int, part string, content *fedre
 		} else {
 			doc.Locations = eregs.CreateSections(fmt.Sprintf("%d", title), sections)
 		}
+	} else {
+		log.Warn("[main] No list of sections available for FR doc ", content.DocumentNumber)
 	}
 
 	log.Trace("[main] Sending title ", title, " part ", part, " doc ID ", content.DocumentNumber, " to eRegs")

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -166,12 +166,14 @@ func processDocument(ctx context.Context, title int, part string, content *fedre
 		DocumentNumber: content.DocumentNumber,
 	}
 
-	log.Trace("[main] Retrieving list of associated sections for title ", title, " part ", part, " doc ID ", content.DocumentNumber)
-	sections, err := fetchSectionsFunc(ctx, content.Date, content.DocumentNumber)
-	if err != nil {
-		log.Error("[main] Failed to fetch list of sections for FR doc ", content.DocumentNumber, ": ", err)
-	} else {
-		doc.Locations = eregs.CreateSections(fmt.Sprintf("%d", title), sections)
+	if content.FullTextURL != "" {
+		log.Trace("[main] Retrieving list of associated sections for title ", title, " part ", part, " doc ID ", content.DocumentNumber)
+		sections, err := fetchSectionsFunc(ctx, content.FullTextURL)
+		if err != nil {
+			log.Error("[main] Failed to fetch list of sections for FR doc ", content.DocumentNumber, ": ", err)
+		} else {
+			doc.Locations = eregs.CreateSections(fmt.Sprintf("%d", title), sections)
+		}
 	}
 
 	log.Trace("[main] Sending title ", title, " part ", part, " doc ID ", content.DocumentNumber, " to eRegs")

--- a/solution/parser/fr-parser/main_test.go
+++ b/solution/parser/fr-parser/main_test.go
@@ -368,13 +368,13 @@ func TestProcessPart(t *testing.T) {
 func TestProcessDocument(t *testing.T) {
 	testTable := []struct {
 		Name string
-		FetchSectionsFunc func (context.Context, string, string) ([]string, error)
+		FetchSectionsFunc func (context.Context, string) ([]string, error)
 		SendDocumentFunc func (context.Context, *eregs.FRDoc) error
 		Error bool
 	}{
 		{
 			Name: "test-send",
-			FetchSectionsFunc: func(ctx context.Context, date string, doc string) ([]string, error) {
+			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, error) {
 				return []string{"433.12", "12.1", "1.1"}, nil
 			},
 			SendDocumentFunc: func(ctx context.Context, doc *eregs.FRDoc) error {
@@ -384,7 +384,7 @@ func TestProcessDocument(t *testing.T) {
 		},
 		{
 			Name: "test-fetch-sections-failure",
-			FetchSectionsFunc: func(ctx context.Context, date string, doc string) ([]string, error) {
+			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, error) {
 				return nil, fmt.Errorf("this is expected")
 			},
 			SendDocumentFunc: func(ctx context.Context, doc *eregs.FRDoc) error {
@@ -397,7 +397,7 @@ func TestProcessDocument(t *testing.T) {
 		},
 		{
 			Name: "test-send-document-failure",
-			FetchSectionsFunc: func(ctx context.Context, date string, doc string) ([]string, error) {
+			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, error) {
 				return []string{"433.12", "12.1", "1.1"}, nil
 			},
 			SendDocumentFunc: func(ctx context.Context, doc *eregs.FRDoc) error {
@@ -423,6 +423,7 @@ func TestProcessDocument(t *testing.T) {
 				Date: "2021-01-31",
 				DocketNumber: "CMS-0000-F2",
 				DocumentNumber: "2021-12345",
+				FullTextURL: "http://test.gov/some/xml/url",
 			}
 
 			err := processDocument(ctx, 42, "433", &doc)


### PR DESCRIPTION
Resolves #1322

**Description-**

In order to improve runtime of the new FR parser, we need to cut out as many requests as possible. The parser currently fetches full text XML to extract sections, however many older documents have no such documents and the request returns 404.

**This pull request changes...**

- Added `&fields[]=full_text_xml_url` to the federalregister.gov API request
- Only attempt to fetch XML if `full_text_xml_url` is a string of non-zero length

**Steps to manually verify this change...**

1. Run `make frdocs.local` and look for logs indicating `[main] No list of sections available for FR doc [document number]`

