### PR TITLE
EREGCSC-1323 Improve FR parser: skip docs we've already fetched

### DIFF
--- a/solution/backend/regcore/serializers.py
+++ b/solution/backend/regcore/serializers.py
@@ -52,6 +52,6 @@ class PartsSerializer(serializers.Serializer):
     title_object = serializers.IntegerField()
 
 
-class VersionsSerializer(serializers.Serializer):
+class StringListSerializer(serializers.Serializer):
     def to_representation(self, instance):
         return instance

--- a/solution/backend/regcore/v3views.py
+++ b/solution/backend/regcore/v3views.py
@@ -16,7 +16,7 @@ from regcore.serializers import (
     TitleRetrieveSerializer,
     TitleUploadSerializer,
     PartsSerializer,
-    VersionsSerializer,
+    StringListSerializer,
 )
 
 
@@ -101,7 +101,7 @@ class PartsViewSet(viewsets.ReadOnlyModelViewSet):
     responses={(200, "application/json"): {"type": "string"}},
 )
 class VersionsViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = VersionsSerializer
+    serializer_class = StringListSerializer
 
     def get_queryset(self):
         title = self.kwargs.get("title")

--- a/solution/backend/supplemental_content/v3urls.py
+++ b/solution/backend/supplemental_content/v3urls.py
@@ -1,11 +1,15 @@
 from django.urls import path
 
 from .v3views import (
-        SupplementalContentViewSet
+        SupplementalContentViewSet,
+        FRDocListViewSet
 )
 
 supplemental_content_view_set = SupplementalContentViewSet.as_view({'put': 'update'})
+frdoc_list_view_set = FRDocListViewSet.as_view({'get': 'list'})
 
 urlpatterns = [
         path("supplemental_content", supplemental_content_view_set),
+        path("frdoc_list", frdoc_list_view_set),
+
 ]

--- a/solution/backend/supplemental_content/v3views.py
+++ b/solution/backend/supplemental_content/v3views.py
@@ -1,11 +1,12 @@
 from django.http import JsonResponse
-
-from rest_framework import viewsets
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets, serializers
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from .models import SupplementalContent
 from .views import SettingsAuthentication
 from .serializers import CreateSupplementalContentSerializer
+from regcore.serializers import StringListSerializer
 
 
 class SupplementalContentViewSet(viewsets.ModelViewSet):
@@ -37,3 +38,11 @@ class SupplementalContentViewSet(viewsets.ModelViewSet):
             if created:
                 supplemental_content.delete()
             raise e
+
+@extend_schema(
+    description="Retrieve a list of urls for federal register docs that have been previously imported.",
+    responses={(200, "application/json"): {"type": "string"}},
+)
+class FRDocListViewSet(viewsets.ModelViewSet):
+    serializer_class = StringListSerializer
+    queryset = SupplementalContent.objects.filter(url__startswith="https://www.federalregister.gov/documents").values_list('url', flat=True).distinct()

--- a/solution/backend/supplemental_content/v3views.py
+++ b/solution/backend/supplemental_content/v3views.py
@@ -1,6 +1,6 @@
 from django.http import JsonResponse
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets, serializers
+from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from .models import SupplementalContent
@@ -39,10 +39,13 @@ class SupplementalContentViewSet(viewsets.ModelViewSet):
                 supplemental_content.delete()
             raise e
 
+
 @extend_schema(
     description="Retrieve a list of urls for federal register docs that have been previously imported.",
     responses={(200, "application/json"): {"type": "string"}},
 )
 class FRDocListViewSet(viewsets.ModelViewSet):
     serializer_class = StringListSerializer
-    queryset = SupplementalContent.objects.filter(url__startswith="https://www.federalregister.gov/documents").values_list('url', flat=True).distinct()
+    queryset = SupplementalContent.objects.\
+        filter(url__startswith="https://www.federalregister.gov/documents").\
+        values_list('url', flat=True).distinct()

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -156,7 +156,7 @@ func processPart(ctx context.Context, title int, part string, existingDocs map[s
 	var content []*fedreg.FRDoc
 	if skip {
 		removed := 0
-		log.Debug("[main] Removing content that has already been processed for title ", title, " part ", part)
+		log.Debug("[main] Skipping content that has already been processed for title ", title, " part ", part)
 		for _, c := range contentList {
 			if existingDocs[c.URL] {
 				removed++
@@ -164,7 +164,7 @@ func processPart(ctx context.Context, title int, part string, existingDocs map[s
 				content = append(content, c)
 			}
 		}
-		log.Debug("[main] Removed ", removed, " documents")
+		log.Debug("[main] Skipped ", removed, "/", len(contentList), " documents")
 	} else {
 		content = contentList
 	}

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -120,16 +120,20 @@ func start() error {
 	}
 
 	log.Debug("[main] Retrieving list of processed content")
-	_, err = eregs.FetchDocumentList(ctx)
+	existingDocsList, err := eregs.FetchDocumentList(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve list of already processed documents: %+v", err)
+	}
+	existingDocs := make(map[string]bool)
+	for _, i := range existingDocsList {
+		existingDocs[i] = true
 	}
 
 	for _, title := range config.Titles {
 		log.Info("[main] Retrieving content for title ", title.Title)
 		parts := getPartsListFunc(ctx, title)
 		for _, part := range parts {
-			if err := processPartFunc(ctx, title.Title, part); err != nil {
+			if err := processPartFunc(ctx, title.Title, part, existingDocs, config.SkipVersions); err != nil {
 				log.Error("[main] Failed to process title ", title.Title, " part ", part, ": ", err)
 			}
 		}
@@ -141,17 +145,28 @@ func start() error {
 var fetchContentFunc = fedreg.FetchContent
 var processDocumentFunc = processDocument
 
-func processPart(ctx context.Context, title int, part string) error {
+func processPart(ctx context.Context, title int, part string, existingDocs map[string]bool, skip bool) error {
 	log.Debug("[main] Retrieving list of content for title ", title, " part ", part)
-	content, err := fetchContentFunc(ctx, title, part)
+	contentList, err := fetchContentFunc(ctx, title, part)
 	if err != nil {
 		return fmt.Errorf("Fetch content failed: %+v", err)
 	}
 
-	// log.Debug("[main] Removing content that has already been processed for title ", title, " part ", part)
-	// for _, c := range content {
-
-	// }
+	var content []*fedreg.FRDoc
+	if skip {
+		removed := 0
+		log.Debug("[main] Removing content that has already been processed for title ", title, " part ", part)
+		for _, c := range contentList {
+			if existingDocs[c.URL] {
+				removed++
+			} else {
+				content = append(content, c)
+			}
+		}
+		log.Debug("[main] Removed ", removed, " documents")
+	} else {
+		content = contentList
+	}
 
 	log.Debug("[main] Processing content for title ", title, " part ", part)
 	for _, c := range content {

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -109,6 +109,7 @@ func getPartsList(ctx context.Context, t *ecfrEregs.TitleConfig) []string {
 var loadConfigFunc = loadConfig
 var getPartsListFunc = getPartsList
 var processPartFunc = processPart
+var fetchDocumentListFunc = eregs.FetchDocumentList
 
 func start() error {
 	ctx, cancel := context.WithTimeout(context.Background(), TIMELIMIT)
@@ -120,7 +121,7 @@ func start() error {
 	}
 
 	log.Debug("[main] Retrieving list of processed content")
-	existingDocsList, err := eregs.FetchDocumentList(ctx)
+	existingDocsList, err := fetchDocumentListFunc(ctx)
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve list of already processed documents: %+v", err)
 	}

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -156,7 +156,6 @@ func processPart(ctx context.Context, title int, part string, existingDocs map[s
 	var content []*fedreg.FRDoc
 	if skip {
 		removed := 0
-		log.Debug("[main] Skipping content that has already been processed for title ", title, " part ", part)
 		for _, c := range contentList {
 			if existingDocs[c.URL] {
 				removed++
@@ -164,7 +163,7 @@ func processPart(ctx context.Context, title int, part string, existingDocs map[s
 				content = append(content, c)
 			}
 		}
-		log.Debug("[main] Skipped ", removed, "/", len(contentList), " documents")
+		log.Debug("[main] Skipped ", removed, "/", len(contentList), " documents for title ", title, " part ", part)
 	} else {
 		content = contentList
 	}

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -119,6 +119,12 @@ func start() error {
 		return fmt.Errorf("Failed to retrieve configuration: %+v", err)
 	}
 
+	log.Debug("[main] Retrieving list of processed content")
+	_, err = eregs.FetchDocumentList(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve list of already processed documents: %+v", err)
+	}
+
 	for _, title := range config.Titles {
 		log.Info("[main] Retrieving content for title ", title.Title)
 		parts := getPartsListFunc(ctx, title)
@@ -141,6 +147,11 @@ func processPart(ctx context.Context, title int, part string) error {
 	if err != nil {
 		return fmt.Errorf("Fetch content failed: %+v", err)
 	}
+
+	// log.Debug("[main] Removing content that has already been processed for title ", title, " part ", part)
+	// for _, c := range content {
+
+	// }
 
 	log.Debug("[main] Processing content for title ", title, " part ", part)
 	for _, c := range content {


### PR DESCRIPTION
Resolves #1323

**Description-**

To improve parser runtime we want to skip docs that we have already fetched and processed.

**This pull request changes...**

- Parser fetches a list of URLs of processed content from eRegs
- All content retrieved from Federal Register that is in that list is skipped from processing

**Steps to manually verify this change...**

1. Make sure "Skip versions" is disabled in your parser configuration
2. Run `make frdocs.local`.
3. If this is the first time you've run the above, run it again. Runtime should be significantly lower.

