### PR TITLE
1319 create unknown categories

### DIFF
--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -323,11 +323,13 @@ class CreateSupplementalContentSerializer(serializers.Serializer):
     id = serializers.CharField(required=False)
 
     def validate_category(self, value):
-        category_name = Category_Map.get(value, "")
+        category_name = Category_Map.get(value, value)
         try:
             AbstractCategory.objects.get(name=category_name)
         except AbstractCategory.DoesNotExist:
-            raise serializers.ValidationError("Invalid category")
+            # Just make one that makes sense
+            # can't use get_or_create because it is not abstract
+            Category.objects.create(name=category_name)
         return category_name
 
     def update(self, instance, validated_data):


### PR DESCRIPTION
Resolves #EREGCSC-1319

**Description-**
Creates a category when a piece of federal register content is uploaded that has a type that is not recognized.
 
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. Check the number of categories you have (should be 10)
2. Run make frdata.local 
3. You should have 12 categories instead of the previous 10.

