### PR TITLE
frdoc_list now returns document_numbers 

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/recent_changes.html
+++ b/solution/backend/regulations/templates/regulations/partials/recent_changes.html
@@ -10,7 +10,7 @@
 
     <h3>Recent Documents for 42 CFR 430-460</h3>
 
-    <supplemental-content class="related-rules" api_url="{% url 'regcore' %}" title="42" part="430" requested_categories="1,2"></supplemental-content>
+    <supplemental-content class="related-rules" api_url="{% url 'regcore' %}" requested_categories="1,2"></supplemental-content>
 
     <p class="see-fr">For more changes, see the <a href="https://www.federalregister.gov/" target="_blank" class="external">Federal Register</a>.</p>
 

--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -305,10 +305,12 @@ class SuppByLocationSerializer(serializers.ModelSerializer):
         model = AbstractLocation
         fields = "__all__"
 
-
+# TODO: for v3, make this into a model
+# e.g. CategoryRule that contains 2 fields: 1 string representing name from parser,
+# 1 one-to-one field linked to an AbstractCategory object
 Category_Map = {
     "Rule": "Final Rules",
-    "Proposed Rule": "NPRMs (Connected to Final Rules)"
+    "Proposed Rule": "Proposed Rules"
 }
 
 

--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -315,12 +315,12 @@ Category_Map = {
 class CreateSupplementalContentSerializer(serializers.Serializer):
     category = serializers.CharField()
     locations = SectionSerializer(many=True, allow_null=True)
-    url = serializers.URLField()
-    description = serializers.CharField()
-    name = serializers.CharField()
+    url = serializers.URLField(allow_blank=True, allow_null=True)
+    description = serializers.CharField(allow_blank=True, allow_null=True)
+    name = serializers.CharField(allow_blank=True, allow_null=True)
     docket_number = serializers.CharField(allow_blank=True, allow_null=True)
     document_number = serializers.CharField(allow_blank=True, allow_null=True)
-    date = serializers.CharField()
+    date = serializers.CharField(allow_blank=True, allow_null=True)
     approved = serializers.BooleanField(required=False, default=False)
     id = serializers.CharField(required=False)
 

--- a/solution/backend/supplemental_content/serializers.py
+++ b/solution/backend/supplemental_content/serializers.py
@@ -305,6 +305,7 @@ class SuppByLocationSerializer(serializers.ModelSerializer):
         model = AbstractLocation
         fields = "__all__"
 
+
 # TODO: for v3, make this into a model
 # e.g. CategoryRule that contains 2 fields: 1 string representing name from parser,
 # 1 one-to-one field linked to an AbstractCategory object

--- a/solution/backend/supplemental_content/v3views.py
+++ b/solution/backend/supplemental_content/v3views.py
@@ -48,4 +48,4 @@ class FRDocListViewSet(viewsets.ModelViewSet):
     serializer_class = StringListSerializer
     queryset = SupplementalContent.objects.\
         filter(url__startswith="https://www.federalregister.gov/documents").\
-        values_list('url', flat=True).distinct()
+        filter(document_number__isnull=False).values_list('document_number', flat=True).distinct()

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -157,7 +157,7 @@ func processPart(ctx context.Context, title int, part string, existingDocs map[s
 	if skip {
 		removed := 0
 		for _, c := range contentList {
-			if existingDocs[c.URL] {
+			if existingDocs[c.DocumentNumber] {
 				removed++
 			} else {
 				content = append(content, c)


### PR DESCRIPTION


**Description-**

change the frdocs_list to return document numbers instead of URL's as they are the most unique identifier we have.

**This pull request changes...**

Just the one endpoint
removed some incorrect code from the NPRM template

**Steps to manually verify this change...**

1. v2/frdocs_list should be document numbers instead of url's
2. 

