### PR TITLE
updating UI to show users when quoted search might help.

### DIFF
--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -27,9 +27,22 @@
                             <i class="fa fa-search"></i>
                         </button>
                     </form>
+
+                    {% if  unquoted_search %}
+                        <div class="search-suggestion">
+                            Didn't find what you were looking for? Try searching for
+                            <a href="{% url 'search' %}?q=%22{{ query }}%22">"{{ query }}"</a>
+                        </div>
+                    {% endif %}
+
                     {% if synonym.filtered_synonyms.count %}
                         <div class="search-suggestion">
-                            Similar terms:
+                            {% if unquoted_search %}
+                                Or search
+                            {% else %}
+                                Search
+                            {% endif %}
+                            for similar terms:
                             {% for syn in synonym.filtered_synonyms %}
                                 <a href="{% url 'search' %}?q=%22{{ syn }}%22">{{ syn }}</a>{% if not forloop.last %},{% endif %}
                             {% endfor %}

--- a/solution/backend/regulations/views/search.py
+++ b/solution/backend/regulations/views/search.py
@@ -27,5 +27,7 @@ class SearchView(TemplateView):
             'toc': structure,
             'results': results,
             'synonym': synonym,
+            'unquoted_search': not query.startswith('"') and not query.endswith('"') and len(query.split(" ")) > 1,
+            'query': query,
         }
         return {**context, **c, **self.request.GET.dict()}

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -56,9 +56,8 @@
         }
     }
     .search-suggestion{
-        margin: $spacer-2 0;
+        margin: 0px;
         font-size: $font-size-sm;
-
     }
 
 


### PR DESCRIPTION
Resolves #EREGCSC-1279

**Description-**

Showing users how they might be able to improve their results with quoted search

**This pull request changes...**

- added 2 variables to the search template context
- updated template to show desired words about quoted search

**Steps to manually verify this change...**

1. if a search has 2 or more words and is NOT quoted the page should show "Didn't find ..."  
2. If there are synonyms it should say "Or search..."
3. All other searches should be unchanged.

