### PR TITLE
New routing for url for section and part search

### DIFF
--- a/solution/ui/prototype/src/components/custom_elements/SectionList.vue
+++ b/solution/ui/prototype/src/components/custom_elements/SectionList.vue
@@ -5,7 +5,7 @@
                 v-for="item in listItems"
                 :key="item.identifier"
                 @click="clickMethod"
-                :data-value="item.identifier"
+                :data-value="item.part + '-' + item.identifier"
                 class="section-list-item"
             >
                 <span class="section-number">{{ item.label }} </span>

--- a/solution/ui/prototype/src/components/custom_elements/SubpartList.vue
+++ b/solution/ui/prototype/src/components/custom_elements/SubpartList.vue
@@ -5,7 +5,7 @@
                 v-for="item in listItems"
                 :key="item.identifier"
                 @click="clickMethod"
-                :data-value="item.identifier"
+                :data-value="item.part + '-' + item.identifier"
                 class="subpart-list-item"
             >
                 <div>

--- a/solution/ui/prototype/src/components/resources/ResourcesSelections.vue
+++ b/solution/ui/prototype/src/components/resources/ResourcesSelections.vue
@@ -1,5 +1,8 @@
 <template>
-    <div v-if="filterParams.part || filterParams.resourceCategory" class="selections-container">
+    <div
+        v-if="filterParams.part || filterParams.resourceCategory"
+        class="selections-container"
+    >
         <div class="selections-content">
             <template v-for="(array, name, idx) in splitParams">
                 <div
@@ -105,10 +108,12 @@ export default {
                     return `Part ${value}`;
                     break;
                 case "subpart":
-                    return `Subpart ${value}`;
+                    const part = value.match(/^\d+/)[0];
+                    const subpart = value.match(/\w+$/)[0];
+                    return `Part ${part} Subpart ${subpart}`;
                     break;
                 case "section":
-                    return `§ ${value}`;
+                    return `§ ${value.replace("-", ".")}`;
                     break;
                 case "resourceCategory":
                     return `${value}`;
@@ -116,7 +121,7 @@ export default {
                 default:
                     return `${name} ${value}`;
             }
-        }
+        },
     },
 };
 </script>

--- a/solution/ui/prototype/src/utilities/api.js
+++ b/solution/ui/prototype/src/utilities/api.js
@@ -473,9 +473,11 @@ const getSubPartsForPart = async (part) => {
         all_parts[parts.indexOf(part)].structure.children[0].children[0]
             .children[0].children;
     const subParts = potentialSubParts.filter((p) => p.type === "subpart");
+
     return subParts.map((s) => {
         return {
             label: s.label,
+            part: s.parent[0],
             identifier: s.identifier[0],
             range: s.descendant_range,
         };
@@ -529,9 +531,11 @@ const getSectionObjects = async (part, subPart) => {
             (p) => p.type === "subpart" && p.identifier[0] === subPart
         );
         return parent.children.map((c) => {
+      
             return {
                 identifier: c.identifier[1],
                 label: c.label_level,
+                part: part,
                 description: c.label_description,
             };
         });
@@ -543,6 +547,7 @@ const getSectionObjects = async (part, subPart) => {
                     return {
                         identifier: c.identifier[1],
                         label: c.label_level,
+                        part:part,
                         description: c.label_description,
                     };
                 })

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -199,8 +199,8 @@ export default {
         routeToResources() {
             const identifiers = this.selectedIdentifier.reduce((acc, item) => {
                 acc[this.selectedScope]
-                    ? (acc[this.selectedScope] += `,${item}`)
-                    : (acc[this.selectedScope] = `${item}`);
+                    ? (acc[this.selectedScope] += `,${this.part}-${item}`)
+                    : (acc[this.selectedScope] = `${this.part}-${item}`);
                 return acc;
             }, {});
 

--- a/solution/ui/prototype/src/views/Resources.vue
+++ b/solution/ui/prototype/src/views/Resources.vue
@@ -77,7 +77,7 @@ import {
     getCategories,
     getSectionObjects,
     getSubPartsForPart,
-    getSupplementalContentNew
+    getSupplementalContentNew,
 } from "@/utilities/api";
 
 export default {
@@ -140,7 +140,7 @@ export default {
                 },
             },
             supplementalContent: [],
-            searchInputValue: ""
+            searchInputValue: "",
         };
     },
 
@@ -268,7 +268,7 @@ export default {
                 const parts = queryParamsObj.part.split(",");
                 queryParamsObj.part = queryParamsObj.part.split(",");
                 let partDict = {};
-                for (let x in parts) {
+                for (const x in parts) {
                     partDict[parts[x]] = { sections: [], subparts: [] };
                 }
 
@@ -279,21 +279,21 @@ export default {
                             part: x.match(/^\d+/)[0],
                             section: x.match(/\d+$/)[0],
                         }));
-                    for (let section in sections) {
+                    for (const section in sections) {
                         partDict[sections[section].part].sections.push(
                             sections[section].section
                         );
                     }
                 }
                 if (queryParamsObj.subpart) {
-                    let subparts = queryParamsObj.subpart
+                    const subparts = queryParamsObj.subpart
                         .split(",")
                         .map((x) => ({
                             part: x.match(/^\d+/)[0],
                             subparts: x.match(/\w+$/)[0],
                         }));
 
-                    for (let subpart in subparts) {
+                    for (const subpart in subparts) {
                         partDict[subparts[subpart].part].subparts.push(
                             subparts[subpart].subparts
                         );
@@ -320,7 +320,7 @@ export default {
                         resultArray,
                         true
                     );
-                    
+
                     this.supplementalContent = this.queryParams.resourceCategory
                         ? this.filterCategories(transformedResults)
                         : transformedResults;


### PR DESCRIPTION
Resolves # EREGCSC-1333, EREGCSC-1324

**Description-**

**This pull request changes...**

- expected change 1
The query string for searching for supplemental content.  New version prevents selected sections and subparts are tied to a part.

Also modifies chip to a new format display part and subparts correctly.

**Steps to manually verify this change...**

1. steps to view and verify change

V1. Click on the resources page on prototypes, select a couple filters, will update the query string and results. 

V2.  Select a part on from the prototype.  Click a view resources box.  Click view all resources.
