### PR TITLE
Bugfix cache rsrcs

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -119,7 +119,7 @@ export default {
             );
             if (partObj.sections) {
                 const partSectionsDict = partObj.sections;
-                parent = partSectionsDict[section]
+                parent = partSectionsDict[section] && partSectionsDict[section] !== "orphan"
                     ? `Subpart-${partSectionsDict[section]}/`
                     : "";
             }

--- a/solution/ui/regulations/eregs-vite/src/views/CacheExplorer.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/CacheExplorer.vue
@@ -47,7 +47,7 @@ import {
     setCacheItem,
 } from "../../../js/api.js";
 
-const formatKey = (key) => key.replace("GET/", "");
+const formatKey = (key) => key.replace("GET", "");
 
 export default {
     name: "CacheExplorer",
@@ -88,7 +88,7 @@ export default {
         addToCache: async function () {
             try {
                 await setCacheItem(
-                    `GET/${this.path}`,
+                    `GET${this.path}`,
                     JSON.parse(this.apiData)
                 );
                 this.path = "";

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -322,10 +322,13 @@ export default {
                         // handle mixed sections and subject_groups
                         const returnArray = subpart.children.map(
                             (subpartChild) => {
+                                const parentValue = _isEmpty(subpartChild.parent)
+                                    ? "orphan"
+                                    : subpartChild.parent[0];
+
                                 if (subpartChild.type === "section") {
                                     return {
-                                        [subpartChild.identifier[1] ?? subpartChild.identifier[0]]:
-                                        subpartChild.parent[0],
+                                        [subpartChild.identifier[1] ?? subpartChild.identifier[0]]: parentValue
                                     };
                                 }
 
@@ -333,8 +336,7 @@ export default {
                                 if (_isEmpty(subpartChild.children)) return [];
 
                                 return subpartChild.children.map((section) => ({
-                                    [section.identifier[1] ?? section.identifier[0]]:
-                                    subpartChild.parent[0],
+                                    [section.identifier[1] ?? section.identifier[0]]: parentValue
                                 }));
                             }
                         );


### PR DESCRIPTION
Resolves bug found when EREGCSC-1300 deployed to prod

**Description**
Certain Parts returned from production v2's `all_parts` endpoint do not have `parent` and `parent_type` fields nested deep in an array of sections in a subpart.  Example: Part 436.

The resources page code was not handling these omissions, and was choking when they were found; these data issues were not present in dev v2's `all_parts` endpoint, which is why this was not caught during development.  As such, a hotfix is needed to handle these prod data omissions, and this PR is it.

Note: v3 endpoints that return the same data (more efficiently) have corrected these data omissions; we will be migrating to v3 in the near future.

**This pull request changes:**

- Adds safeguards to prevent reaching into an `undefined` value as if it were an array, causing the app to choke
- Related Regulations links in the Resources results will link the Part view for orphan sections and any other section that does not contain `parent` data, such as all sections in Part 436 mentioned above.

**Steps to manually verify this change**

To test:
1. Visit https://regulations-pilot.cms.gov/resources/.  Notice that the Parts dropdown stays disabled; open the developer console and notice that there is an error.
2. Visit the deploy experimental site's /resources view.  It should work because dev data does not have the data omission issues of prod.
3. Using the CacheExplorer. replace the `all_parts` response with the response from the prod endpoint
  a. visit https://regulations-pilot.cms.gov/v2/all_parts and copy the unformatted response
  b. visit experimental site's /cache route
  c. find the `GETall_parts` entry in the list of cached responses and click "EDIT"
  d. In the DATA text box, delete all contents and paste in the unformatted response from the prod endpoint (step 3a above).  
  e. Click "ADD TO CACHE"
4. Visit experimental site's /resources route once again
5. Using the response data from the prod endpoint, experimental site's /resources route should now work without any errors
6. Choose part 436 from the Part dropdown, find a link to a Related Resource in section 436 (ex 436.406 in first result) and click the link
7. You should be taken to the PART view for Part 436 due to the data omissions discussed above.
8. All other part links should take you to the SUBPART view for their related section unless they too are orphans or have data issues.

