### PR TITLE
Fix: Resources deploy properly to dev/val environments on Prod deployment

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           STATIC_URL: http://localhost:8888/
           STATIC_ROOT: ../static-assets/regulations
-          VITE_PR: dev-${{ steps.findPr.outputs.pr }}
+          VITE_ENV: dev-${{ steps.findPr.outputs.pr }}
         run: |
           pushd solution
           make regulations

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
           STATIC_ROOT: ../static-assets/regulations
           # This isn't at all accurate, but it doesn't matter; Django just needs it to run collectstatic
           STATIC_URL: http://localhost:8888/
+          VITE_ENV: ${{ matrix.environment }}
         run: |
           pushd solution
           make regulations

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -98,9 +98,10 @@ export default {
             // Thankfully v3 will add "latest" for date
             // and will better provide parent subpart in resource locations array.
             let parent = "";
-            const base = import.meta.env.VITE_ENV
-                ? `/${import.meta.env.VITE_ENV}`
-                : "";
+            const base =
+                import.meta.env.VITE_ENV && import.meta.env.VITE_ENV !== "prod"
+                    ? `/${import.meta.env.VITE_ENV}`
+                    : "";
             const partDate = `${partsLastUpdated[value.part]}/`;
 
             // early return if related regulation is a subpart and not a section
@@ -119,9 +120,11 @@ export default {
             );
             if (partObj.sections) {
                 const partSectionsDict = partObj.sections;
-                parent = partSectionsDict[section] && partSectionsDict[section] !== "orphan"
-                    ? `Subpart-${partSectionsDict[section]}/`
-                    : "";
+                parent =
+                    partSectionsDict[section] &&
+                    partSectionsDict[section] !== "orphan"
+                        ? `Subpart-${partSectionsDict[section]}/`
+                        : "";
             }
             const hash = `#${partAndSection.replace(/\./g, "-")}`;
             return `${base}/42/${value.part}/${parent}${partDate}${hash}`;

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -98,8 +98,8 @@ export default {
             // Thankfully v3 will add "latest" for date
             // and will better provide parent subpart in resource locations array.
             let parent = "";
-            const base = import.meta.env.VITE_PR
-                ? `/${import.meta.env.VITE_PR}`
+            const base = import.meta.env.VITE_ENV
+                ? `/${import.meta.env.VITE_ENV}`
                 : "";
             const partDate = `${partsLastUpdated[value.part]}/`;
 

--- a/solution/ui/regulations/eregs-vite/src/router/index.js
+++ b/solution/ui/regulations/eregs-vite/src/router/index.js
@@ -22,7 +22,7 @@ const routes = [
 const router = new VueRouter({
     mode: "history",
     routes,
-    base: import.meta.env.VITE_PR || "/",
+    base: import.meta.env.VITE_ENV || "/",
     scrollBehavior(to) {
         if (to.hash) {
             return {

--- a/solution/ui/regulations/eregs-vite/src/router/index.js
+++ b/solution/ui/regulations/eregs-vite/src/router/index.js
@@ -17,12 +17,15 @@ const routes = [
         name: "resources",
         component: Resources,
     },
-]
+];
 
 const router = new VueRouter({
     mode: "history",
     routes,
-    base: import.meta.env.VITE_ENV || "/",
+    base:
+        import.meta.env.VITE_ENV && import.meta.env.VITE_ENV !== "prod"
+            ? import.meta.env.VITE_ENV
+            : "/",
     scrollBehavior(to) {
         if (to.hash) {
             return {


### PR DESCRIPTION
Resolves issue where Vue Router and Related Resources links do not work with dev/val URLs on deployment, e.g. https://qavc1ytrff.execute-api.us-east-1.amazonaws.com/dev and ./val

**Description**
When deploying eRegs to production, the production-ready code is also deployed to the `dev` and `val` environments.  The URLs for these deployments have "dev" and "val" subdirectories, which is not handled by the code and the Vue router does not work.  This means that the Resources page and the Cache Explorer do not load when visiting the `dev` and `val` URLs.

Mirroring the work down for deploying the experimental site, a `VITE_ENV` variable will be passed in to the Vue/Vite app and used where necessary for the router to direct the user to the proper route.

**This pull request changes**

- `VITE_PR` is renamed to `VITE_ENV` to reflect broader use than just to pass in a formatted string based on Pull Request number
- `VITE_ENV` will be used as the Vue router base and for the Related Resources links.  This will work for Experimental Deployments (where `VITE_ENV` will be `dev-XXX`) and for prod deployments will either be `dev` or `val` depending on the environment
- The `prod` environment variable will be ignored for now; the [CMS domain URL](https://regulations-pilot.cms.gov/) does not have subdirectories and `/` will be used as the Vue Router base.

**Steps to manually verify this change**

1. Visit the Deploy Experimental site below, visit `/cache` and `/resources` to ensure they still work as expected
2. Merge this branch into main to trigger the prod deployment script and then test the `dev` and `val` URLs to see if `/resources` and `/cache` work as expected

