### PR TITLE
updating pipeline for storybook and vite environment variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy
 
 on:
+  # Remove this before committing to main
+  pull_request:
+    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
   push:
     branches:
@@ -11,7 +14,9 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev", "val", "prod"]
+        # revert this before committing to main.
+        # environment: ["dev", "val", "prod"]
+        environment: ["dev",]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
@@ -40,7 +45,6 @@ jobs:
           VITE_ENV: ${{ matrix.environment }}
         run: |
           pushd solution
-          make regulations
           cd backend
           python manage.py collectstatic --noinput
           cd ..
@@ -68,6 +72,25 @@ jobs:
           serverless invoke --function reg_core_migrate --stage ${{ matrix.environment }}
           serverless invoke --function create_su --stage ${{ matrix.environment }}
           echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"
+          popd
+      # vite needs the .env file in order to
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v1.3
+        with:
+          envkey_VITE_API_URL: ${{ steps.deploy-regulations-site-server.outputs.url }}
+          directory: solution/ui/regulations/eregs-vite
+          file_name: .env
+
+      - name: build-vue-assets
+        id: build-vue-assets
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          pushd solution
+          make regulations
+          popd
+          serverless deploy --stage ${{ matrix.environment }}
           popd
       - uses: actions/setup-go@v2
         with:
@@ -108,6 +131,14 @@ jobs:
           npm ci
           npm install serverless -g
           npm run build
+          popd
+          pushd solution/ui/regulations
+          npm ci
+          npm run build-storybook
+          mkdir ../prototype/dist/storybook/
+          cp storybook-static/* ../prototype/dist/storybook/
+          popd
+          pushd solution/ui/prototype
           serverless deploy --stage ${{ matrix.environment }}
           echo "::set-output name=url::$(serverless info --stage ${{ matrix.environment }} --verbose | grep StaticURL | cut -c 12-)"
           popd

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy
 
 on:
-  # Remove this before committing to main
   workflow_dispatch:
   push:
     branches:
@@ -69,7 +68,7 @@ jobs:
           serverless invoke --function create_su --stage ${{ matrix.environment }}
           echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"
           popd
-      # vite needs the .env file in order to
+      # vite needs the .env file in order to know the URL of the api.
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,7 @@ jobs:
           pushd solution
           make regulations
           popd
+          pushd solution/static-assets
           serverless deploy --stage ${{ matrix.environment }}
           popd
       - uses: actions/setup-go@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,6 @@ name: Deploy
 
 on:
   # Remove this before committing to main
-  pull_request:
-    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
   push:
     branches:
@@ -14,9 +12,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        # revert this before committing to main.
-        # environment: ["dev", "val", "prod"]
-        environment: ["dev",]
+        environment: ["dev", "val", "prod"]
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -1,6 +1,5 @@
 <template>
     <div id="app" class="resources-view">
-        {{apiPath}}
         <ResourcesNav :aboutUrl="aboutUrl">
             <form class="search-resources-form" @submit.prevent="executeSearch">
                 <v-text-field
@@ -89,7 +88,6 @@ export default {
 
     data() {
         return {
-            apiPath: import.meta.env.VITE_API_URL,
             isLoading: false,
             queryParams: this.$route.query,
             partsLastUpdated: {},

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -1,5 +1,6 @@
 <template>
     <div id="app" class="resources-view">
+        {{apiPath}}
         <ResourcesNav :aboutUrl="aboutUrl">
             <form class="search-resources-form" @submit.prevent="executeSearch">
                 <v-text-field
@@ -88,6 +89,7 @@ export default {
 
     data() {
         return {
+            apiPath: import.meta.env.VITE_API_URL,
             isLoading: false,
             queryParams: this.$route.query,
             partsLastUpdated: {},


### PR DESCRIPTION
Resolves #

**Description-**

**This pull request changes...**

- Makes .env file available for Vite building to have the correct URL for the desired environment.
- Build Vite resources after Django site is deployed
- Build and deploy storybook to protoype site

**Steps to manually verify this change...**

1. Pipeline needs to run successfully
2. prototype.site/storybook/index.html should work
3. resources page should access API via the right URL (once PR #430 is merged in)

