### PR TITLE
EREGCSC-1385 -- Section (and Subpart) picker

### DIFF
--- a/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
+++ b/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
@@ -52,7 +52,7 @@ export default {
 
     computed: {
         btnTypeClass() {
-            return this.type === "splitTab" ? "split-tab-btn" : "select-btn";
+            return this.type === "splitTab" ? "split-tab-btn" : "select-btn ds-c-field";
         },
         containerClass() {
             return this.type === "splitTab" ? "split-tab-container" : "";

--- a/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
+++ b/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
@@ -1,17 +1,22 @@
 <template>
-    <div class="fancy-container">
+    <div class="fancy-container" :class="containerClass">
         <v-menu offset-y max-width="240" max-height="460">
             <template v-slot:activator="{ on, attrs }">
-                <label :for="buttonId">{{ label }}</label>
+                <label v-if="label" :for="buttonId">{{ label }}</label>
                 <v-btn
                     :id="buttonId"
-                    class="ds-c-field select-btn"
+                    class="ds-c-field"
+                    :class="btnTypeClass"
                     v-bind="attrs"
                     v-on="on"
                     depressed
                     :disabled="disabled"
                 >
                     {{ buttonTitle }}
+                    <i
+                        v-if="type === 'splitTab'"
+                        class="fa fa-chevron-down"
+                    ></i>
                 </v-btn>
             </template>
             <slot></slot>
@@ -39,6 +44,19 @@ export default {
         disabled: {
             type: Boolean,
             default: false,
+        },
+        type: {
+            type: String,
+            required: false,
+        },
+    },
+
+    computed: {
+        btnTypeClass() {
+            return this.type === "splitTab" ? "split-tab-btn" : "select-btn";
+        },
+        containerClass() {
+            return this.type === "splitTab" ? "split-tab-container" : "";
         },
     },
 };
@@ -73,28 +91,44 @@ $eregs-image-path: "~legacy-static/images";
         font-size: 14px;
     }
 
-    button.v-btn.select-btn {
-        background-color: #fff;
-        background-image: url(#{$eregs-image-path}/arrow-both.svg);
-        background-position: right 10px center;
-        border: 1px solid $light_gray;
-        height: 36px;
-        border-radius: 3px;
-        padding: 0 0 0 10px;
+    &.split-tab-container {
+        margin: 0;
+    }
 
-        span.v-btn__content {
-            font-size: 14px;
-            display: flex;
-            flex-direction: row;
-            justify-content: flex-start;
-            letter-spacing: initial;
-            color: $dark_gray;
-            text-transform: capitalize;
+    button.v-btn {
+        &.select-btn {
+            background-color: #fff;
+            background-image: url(#{$eregs-image-path}/arrow-both.svg);
+            background-position: right 10px center;
+            border: 1px solid $light_gray;
+            height: 36px;
+            border-radius: 3px;
+            padding: 0 0 0 10px;
 
-            i.v-icon {
-                color: $mid_gray;
-                margin-right: 5px;
+            span.v-btn__content {
+                font-size: 14px;
+                display: flex;
+                flex-direction: row;
+                justify-content: flex-start;
+                letter-spacing: initial;
+                color: $dark_gray;
+                text-transform: capitalize;
+
+                i.v-icon {
+                    color: $mid_gray;
+                    margin-right: 5px;
+                }
             }
+        }
+
+        &.split-tab-btn {
+            border: none;
+            background-color: transparent;
+            padding: 0;
+            margin: 0;
+            height: 48px;
+            min-width: 35px;
+
         }
     }
 }

--- a/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
+++ b/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
@@ -121,13 +121,18 @@ $eregs-image-path: "~legacy-static/images";
         }
 
         &.split-tab-btn {
+            border-radius: 0;
             border: none;
             background-color: transparent;
             padding: 0;
-            margin: 0;
+            margin: 0 0 0 10px;
             height: 48px;
             min-width: 35px;
 
+            .v-btn__content {
+                height: 60%;
+                border-left: 1px solid #9D9D9D;
+            }
         }
     }
 }

--- a/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
+++ b/solution/ui/prototype/src/components/custom_elements/FancyDropdown.vue
@@ -5,7 +5,6 @@
                 <label v-if="label" :for="buttonId">{{ label }}</label>
                 <v-btn
                     :id="buttonId"
-                    class="ds-c-field"
                     :class="btnTypeClass"
                     v-bind="attrs"
                     v-on="on"

--- a/solution/ui/prototype/src/components/custom_elements/SubpartList.vue
+++ b/solution/ui/prototype/src/components/custom_elements/SubpartList.vue
@@ -71,7 +71,7 @@ $eregs-image-path: "~legacy-static/images";
 
 @import "legacy/css/scss/main.scss";
 
-.subpart-list-item {
+.subpart-list-item-group .v-list-item.subpart-list-item {
     display: inline-block;
     min-height: unset;
     padding-top: 5px;

--- a/solution/ui/prototype/src/components/part/PartNav.vue
+++ b/solution/ui/prototype/src/components/part/PartNav.vue
@@ -91,10 +91,18 @@ $eregs-image-path: "~legacy-static/images";
                 letter-spacing: 0.02em;
                 font-size: 18px;
 
+                .split-tab-container .split-tab-btn {
+                    color: $mid_gray;
+                }
+
                 &.v-tab--active {
                     color: $teal_blue;
                     letter-spacing: 0.01em;
                     font-weight: 600;
+
+                    .split-tab-container .split-tab-btn {
+                        color: $teal_blue;
+                    }
                 }
             }
 

--- a/solution/ui/prototype/src/components/part/PartSection.vue
+++ b/solution/ui/prototype/src/components/part/PartSection.vue
@@ -1,0 +1,53 @@
+<template>
+    <h1>PartSection</h1>
+</template>
+
+<script>
+export default {
+    name: "PartSection",
+
+    components: {},
+
+    props: {},
+
+    beforeCreate() {},
+
+    created() {},
+
+    beforeMount() {},
+
+    mounted() {},
+
+    beforeUpdate() {},
+
+    updated() {},
+
+    beforeDestroy() {},
+
+    destroyed() {},
+
+    data() {
+        return {
+            dataProp: "value",
+        }
+    },
+
+    computed: {
+        computedProp() {
+            return this.dataProp.toUpperCase();
+        },
+    },
+
+    methods: {
+        methodName() {
+            console.log("method has been invoked");
+        },
+    },
+
+}
+</script>
+
+<style>
+
+</style>
+

--- a/solution/ui/prototype/src/components/part/PartSubpart.vue
+++ b/solution/ui/prototype/src/components/part/PartSubpart.vue
@@ -1,0 +1,53 @@
+<template>
+    <h1>PartSubpart</h1>
+</template>
+
+<script>
+export default {
+    name: "PartSubpart",
+
+    components: {},
+
+    props: {},
+
+    beforeCreate() {},
+
+    created() {},
+
+    beforeMount() {},
+
+    mounted() {},
+
+    beforeUpdate() {},
+
+    updated() {},
+
+    beforeDestroy() {},
+
+    destroyed() {},
+
+    data() {
+        return {
+            dataProp: "value",
+        }
+    },
+
+    computed: {
+        computedProp() {
+            return this.dataProp.toUpperCase();
+        },
+    },
+
+    methods: {
+        methodName() {
+            console.log("method has been invoked");
+        },
+    },
+
+}
+</script>
+
+<style>
+
+</style>
+

--- a/solution/ui/prototype/src/components/resources/ResourcesSelections.vue
+++ b/solution/ui/prototype/src/components/resources/ResourcesSelections.vue
@@ -17,6 +17,7 @@
                         close-icon="mdi-close"
                         text-color="#046791"
                         @click:close="handleClose(value, name)"
+                        class="selection-chip"
                     >
                         {{ value | formatChipLabel(name) }}
                     </v-chip>
@@ -151,10 +152,13 @@ $eregs-image-path: "~legacy-static/images";
             color: $mid_blue;
             font-size: 15px;
             font-weight: 600;
-            background: $lightest_blue;
             border: 1px solid #c0eaf8;
             margin-right: 10px;
             margin-bottom: 10px;
+
+            &.selection-chip {
+                background: $lightest_blue;
+            }
 
             &.v-chip--outlined.clear-all-chip {
                 text-transform: uppercase;

--- a/solution/ui/prototype/src/router/index.js
+++ b/solution/ui/prototype/src/router/index.js
@@ -40,7 +40,7 @@ const routes = [
         component: PDPart,
     },
     {
-        path: "/:title/:part/:resourcesDisplay?", // resourcesDisplay will be "drawer" or "sidebar"
+        path: "/:title/:part/:tab?", // tab will be "toc", "subpart", or "section". default: "part"
         name: "part",
         component: Part,
     },

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -44,6 +44,7 @@
             <div class="content-container content-container-sidebar">
                 <v-tabs-items v-model="tab">
                     <v-tab-item
+                        :transition="false"
                         v-for="(item, key, index) in tabsShape"
                         :key="index"
                     >

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -292,6 +292,30 @@ export default {
             this.part,
             this.queryParams.subpart
         );
+
+        if (_isEmpty(this.queryParams)) {
+            let paramsToSet = {};
+            if (this.tabParam == "subpart") {
+                paramsToSet = {
+                    subpart: this.tabsShape.subpart.listItems[0].identifier,
+                };
+            }
+            if (this.tabParam == "section") {
+                paramsToSet = {
+                    subpart: this.tabsShape.subpart.listItems[0].identifier,
+                    section: this.tabsShape.section.listItems[0].identifier,
+                };
+            }
+            this.$router.push({
+                name: "part",
+                params: {
+                    title: this.title,
+                    part: this.part,
+                    tab: this.tabParam,
+                },
+                query: paramsToSet,
+            });
+        }
     },
 
     methods: {
@@ -313,7 +337,6 @@ export default {
             const valueToSet = payload.selectedIdentifier.split("-")[1];
             let updatedQueryParams = {};
             // get associated subpart for section
-            // TODO make method if keeping this
             if (payload.scope == "section") {
                 const sectionSubpart = this.tabsShape.section.listItems.find(
                     (item) => {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -6,7 +6,7 @@
                 :title="title"
                 :part="part"
                 :partLabel="partLabel"
-                :resourcesDisplay="resourcesDisplay"
+                resourcesDisplay="sidebar"
             >
                 <v-tabs
                     slider-size="5"
@@ -24,8 +24,7 @@
                 </v-tabs>
             </PartNav>
             <div
-                class="content-container"
-                :class="contentContainerResourcesClass"
+                class="content-container content-container-sidebar"
             >
                 <v-tabs-items v-model="tab">
                     <v-tab-item v-for="(item, index) in tabsShape" :key="index">
@@ -34,7 +33,7 @@
                             :structure="tabsContent[index]"
                             :title="title"
                             :part="part"
-                            :resourcesDisplay="resourcesDisplay"
+                            resourcesDisplay="sidebar"
                             :selectedIdentifier="selectedIdentifier"
                             :selectedScope="selectedScope"
                             :supplementalContentCount="supplementalContentCount"
@@ -42,7 +41,7 @@
                         ></component>
                     </v-tab-item>
                 </v-tabs-items>
-                <div class="sidebar" v-show="resourcesDisplay === 'sidebar'">
+                <div class="sidebar" v-show="tabParam !== 'toc'">
                     <SectionResourcesSidebar
                         :title="title"
                         :part="part"
@@ -52,15 +51,6 @@
                     />
                 </div>
             </div>
-            <SectionResources
-                v-if="resourcesDisplay === 'drawer' && selectedIdentifier"
-                :title="title"
-                :part="part"
-                :selectedIdentifier="selectedIdentifier"
-                :selectedScope="selectedScope"
-                :routeToResources="routeToResources"
-                @close="clearResourcesParams"
-            />
             <Footer />
         </div>
     </body>
@@ -73,14 +63,12 @@ import Header from "@/components/Header.vue";
 import PartContent from "@/components/part/PartContent.vue";
 import PartNav from "@/components/part/PartNav.vue";
 import PartToc from "@/components/part/PartToc.vue";
-import SectionResources from "@/components/SectionResources.vue";
 import SectionResourcesSidebar from "@/components/SectionResourcesSidebar.vue";
 
 import { getPart, getSupplementalContentCountForPart } from "@/utilities/api";
 
 export default {
     components: {
-        SectionResources,
         SectionResourcesSidebar,
         FlashBanner,
         Footer,
@@ -97,7 +85,6 @@ export default {
             title: this.$route.params.title,
             part: this.$route.params.part,
             tabParam: this.$route.params.tab,
-            resourcesDisplay: "drawer",
             structure: null,
             sections: [],
             tabsShape: [
@@ -207,9 +194,6 @@ export default {
         tabsContent() {
             return [this.tocContent, this.partContent, null, null];
         },
-        contentContainerResourcesClass() {
-            return `content-container-${this.resourcesDisplay}`;
-        },
     },
 
     async created() {
@@ -266,13 +250,8 @@ export default {
                 return acc;
             }, {});
 
-            const routeName =
-                this.resourcesDisplay === "sidebar"
-                    ? "resources-sidebar"
-                    : "resources";
-
             this.$router.push({
-                name: routeName,
+                name: "resources",
                 query: {
                     title: this.title,
                     part: this.part,
@@ -317,10 +296,6 @@ $sidebar-top-margin: 40px;
 .content-container {
     display: flex;
     flex-direction: row;
-}
-
-.content-container-drawer {
-    justify-content: center;
 }
 
 .content-container-sidebar {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -96,8 +96,8 @@ export default {
         return {
             title: this.$route.params.title,
             part: this.$route.params.part,
-            resourcesDisplay: "drawer",
             tabParam: this.$route.params.tab,
+            resourcesDisplay: "drawer",
             structure: null,
             sections: [],
             tabsShape: [
@@ -135,20 +135,65 @@ export default {
     },
 
     computed: {
-        tab() {
-            console.log("this.tabParam", this.tabParam);
-            switch(this.tabParam) {
-                case "toc":
-                    return 0;
-                case "part":
-                    return 1;
-                case "subpart":
-                    return 2;
-                case "section":
-                    return 3;
-                default:
-                    return 1;
-            }
+        tab: {
+            get() {
+                switch (this.tabParam) {
+                    case "toc":
+                        return 0;
+                    case "part":
+                        return 1;
+                    case "subpart":
+                        return 2;
+                    case "section":
+                        return 3;
+                    default:
+                        return 1;
+                }
+            },
+            set(value) {
+                switch (value) {
+                    case 0:
+                        this.$router.push({
+                            name: "part",
+                            params: {
+                                title: this.title,
+                                part: this.part,
+                                tab: "toc",
+                            },
+                        });
+                        break;
+                    case 1:
+                        this.$router.push({
+                            name: "part",
+                            params: {
+                                title: this.title,
+                                part: this.part,
+                                tab: "part",
+                            },
+                        });
+                        break;
+                    case 2:
+                        this.$router.push({
+                            name: "part",
+                            params: {
+                                title: this.title,
+                                part: this.part,
+                                tab: "subpart",
+                            },
+                        });
+                        break;
+                    case 3:
+                        this.$router.push({
+                            name: "part",
+                            params: {
+                                title: this.title,
+                                part: this.part,
+                                tab: "section",
+                            },
+                        });
+                        break;
+                }
+            },
         },
         tocContent() {
             return this.structure?.[0];
@@ -172,13 +217,15 @@ export default {
             () => this.$route.params,
             (toParams, previousParams) => {
                 // react to route changes...
+                if (toParams.tab !== previousParams.tab) {
+                    this.tabParam = toParams.tab;
+                }
+
                 if (toParams.part !== previousParams.part) {
                     this.structure = null;
                     this.clearResourcesParams();
                     this.title = toParams.title;
                     this.part = toParams.part;
-                    this.resourcesDisplay =
-                        toParams.resourcesDisplay || "drawer";
                 }
             }
         );
@@ -200,8 +247,8 @@ export default {
         },
         setResourcesParams(payload) {
             console.log("payload", payload);
-            if (payload.scope === "rendered"){
-              return
+            if (payload.scope === "rendered") {
+                return;
             }
             this.selectedIdentifier = payload.identifier;
             this.selectedScope = payload.scope;

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -20,7 +20,12 @@
                         :disabled="item.disabled"
                     >
                         {{ item.label }}
-                        <template v-if="item.value === 'subpart' || item.value === 'section'">
+                        <template
+                            v-if="
+                                item.value === 'subpart' ||
+                                item.value === 'section'
+                            "
+                        >
                             <FancyDropdown
                                 label=""
                                 buttonTitle=""
@@ -28,15 +33,14 @@
                             >
                                 <component
                                     :is="item.listType"
+                                    :listItems="item.listItems"
                                 ></component>
                             </FancyDropdown>
                         </template>
                     </v-tab>
                 </v-tabs>
             </PartNav>
-            <div
-                class="content-container content-container-sidebar"
-            >
+            <div class="content-container content-container-sidebar">
                 <v-tabs-items v-model="tab">
                     <v-tab-item v-for="(item, index) in tabsShape" :key="index">
                         <component
@@ -79,7 +83,11 @@ import SectionResourcesSidebar from "@/components/SectionResourcesSidebar.vue";
 import SubpartList from "@/components/custom_elements/SubpartList.vue";
 import SectionList from "@/components/custom_elements/SectionList.vue";
 
-import { getPart, getSupplementalContentCountForPart } from "@/utilities/api";
+import {
+    getPart,
+    getSubPartsForPart,
+    getSupplementalContentCountForPart,
+} from "@/utilities/api";
 
 export default {
     components: {
@@ -125,6 +133,7 @@ export default {
                     listType: "SubpartList",
                     type: "dropdown",
                     disabled: false,
+                    listItems: [],
                 },
                 {
                     label: "Section",
@@ -132,6 +141,7 @@ export default {
                     listType: "SectionList",
                     type: "dropdown",
                     disabled: false,
+                    listItems: [],
                 },
             ],
             selectedIdentifier: null,
@@ -234,6 +244,7 @@ export default {
         );
 
         await this.getPartStructure();
+        await this.getFormattedSubpartsList(this.part);
     },
 
     methods: {
@@ -277,6 +288,13 @@ export default {
                     ...identifiers,
                 },
             });
+        },
+        async getFormattedSubpartsList(part) {
+            const formattedSubpartsList = await getSubPartsForPart(part);
+            const tabIndex = this.tabsShape.findIndex(
+                (tab) => tab.value === "subpart"
+            );
+            this.tabsShape[tabIndex].listItems = formattedSubpartsList;
         },
     },
 

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -402,18 +402,30 @@ export default {
         "$route.query": {
             async handler(toQueries, previousQueries) {
                 this.queryParams = toQueries;
-                for (const key of Object.keys(toQueries)) {
-                    if (key == "subpart") {
-                        this.tabLabels[key] = this.formatTabLabel(key);
-                    } else if (key == "section") {
-                        this.tabLabels[key] = this.formatTabLabel(key);
-                    }
-                }
                 if (toQueries.subpart !== previousQueries.subpart) {
+                    this.tabLabels.subpart = this.formatTabLabel("subpart");
                     await this.getFormattedSectionsList(
                         this.part,
                         toQueries.subpart
                     );
+
+                    if (!_isUndefined(previousQueries.subpart)) {
+                        this.$router.push({
+                            name: "part",
+                            params: {
+                                title: this.title,
+                                part: this.part,
+                                tab: this.tabParam,
+                            },
+                            query: {
+                                subpart: toQueries.subpart,
+                            },
+                        });
+                    }
+                }
+
+                if (toQueries.section !== previousQueries.section) {
+                    this.tabLabels.section = this.formatTabLabel("section");
                 }
             },
         },

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -95,6 +95,7 @@ import {
     getSupplementalContentCountForPart,
 } from "@/utilities/api";
 
+import _isEmpty from "lodash/isEmpty";
 import _isUndefined from "lodash/isUndefined";
 
 export default {
@@ -223,6 +224,23 @@ export default {
                         });
                         break;
                     case "section":
+                        const subpartSelection = _isEmpty(qParams)
+                            ? {
+                                  subpart:
+                                      this.tabsShape.subpart.listItems[0]
+                                          .identifier,
+                              }
+                            : {};
+
+                        const sectionSelection = _isUndefined(
+                            qParams[valueType]
+                        )
+                            ? {
+                                  section:
+                                      this.tabsShape.section.listItems[0]
+                                          .identifier,
+                              }
+                            : {};
                         this.$router.push({
                             name: "part",
                             params: {
@@ -232,9 +250,8 @@ export default {
                             query: _isUndefined(qParams[valueType])
                                 ? {
                                       ...qParams,
-                                      [valueType]:
-                                          this.tabsShape[valueType].listItems[0]
-                                              .identifier,
+                                      ...subpartSelection,
+                                      ...sectionSelection,
                                   }
                                 : qParams,
                         });

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -279,12 +279,12 @@ export default {
     },
 
     async created() {
-        for (const key of Object.keys(this.queryParams)) {
-            if (key == "subpart") {
-                this.tabLabels[key] = this.formatTabLabel(key);
-            } else if (key == "section") {
-                this.tabLabels[key] = this.formatTabLabel(key);
-            }
+        if (this.queryParams.subpart) {
+            this.tabLabels.subpart = this.formatTabLabel("subpart");
+        }
+
+        if (this.queryParams.section) {
+            this.tabLabels.section = this.formatTabLabel("section");
         }
         await this.getPartStructure();
         await this.getFormattedSubpartsList(this.part);

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -19,7 +19,7 @@
                         :key="item.label"
                         :disabled="item.disabled"
                     >
-                        {{ tabLabels[index] }}
+                        {{ tabLabels[key] }}
                         <template
                             v-if="
                                 item.value === 'subpart' ||
@@ -154,7 +154,12 @@ export default {
                     listItems: [],
                 },
             },
-            tabLabels: ["Table of Contents", "Part", "Subpart", "Section"],
+            tabLabels: {
+                toc: "Table of Contents",
+                part: "Part",
+                subpart: "Subpart",
+                section: "Section",
+            },
             selectedIdentifier: null,
             selectedScope: null,
             supplementalContentCount: {},
@@ -276,9 +281,9 @@ export default {
     async created() {
         for (const key of Object.keys(this.queryParams)) {
             if (key == "subpart") {
-                this.tabLabels[2] = this.formatTabLabel(key);
+                this.tabLabels[key] = this.formatTabLabel(key);
             } else if (key == "section") {
-                this.tabLabels[3] = this.formatTabLabel(key);
+                this.tabLabels[key] = this.formatTabLabel(key);
             }
         }
         await this.getPartStructure();
@@ -399,9 +404,9 @@ export default {
                 this.queryParams = toQueries;
                 for (const key of Object.keys(toQueries)) {
                     if (key == "subpart") {
-                        this.tabLabels[2] = this.formatTabLabel(key);
+                        this.tabLabels[key] = this.formatTabLabel(key);
                     } else if (key == "section") {
-                        this.tabLabels[3] = this.formatTabLabel(key);
+                        this.tabLabels[key] = this.formatTabLabel(key);
                     }
                 }
                 if (toQueries.subpart !== previousQueries.subpart) {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -84,6 +84,8 @@ import Header from "@/components/Header.vue";
 import PartContent from "@/components/part/PartContent.vue";
 import PartNav from "@/components/part/PartNav.vue";
 import PartToc from "@/components/part/PartToc.vue";
+import PartSubpart from "@/components/part/PartSubpart.vue";
+import PartSection from "@/components/part/PartSection.vue";
 import SectionResourcesSidebar from "@/components/SectionResourcesSidebar.vue";
 import SubpartList from "@/components/custom_elements/SubpartList.vue";
 import SectionList from "@/components/custom_elements/SectionList.vue";
@@ -108,6 +110,8 @@ export default {
         PartContent,
         PartNav,
         PartToc,
+        PartSubpart,
+        PartSection,
         SubpartList,
         SectionList,
     },
@@ -142,6 +146,7 @@ export default {
                     value: "subpart",
                     listType: "SubpartList",
                     type: "dropdown",
+                    component: "PartSubpart",
                     disabled: false,
                     listItems: [],
                 },
@@ -150,6 +155,7 @@ export default {
                     value: "section",
                     listType: "SectionList",
                     type: "dropdown",
+                    component: "PartSection",
                     disabled: false,
                     listItems: [],
                 },

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -331,6 +331,9 @@ export default {
                         ? `§ ${this.part}.${this.queryParams.section}`
                         : "Section";
                     break;
+                default:
+                    return "N/A";
+                    break;
             }
         },
         setQueryParam(payload) {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -15,11 +15,11 @@
                     ref="tabs"
                 >
                     <v-tab
-                        v-for="item in tabsShape"
+                        v-for="(item, key, index) in tabsShape"
                         :key="item.label"
                         :disabled="item.disabled"
                     >
-                        {{ item.label }}
+                        {{ tabLabels[index] }}
                         <template
                             v-if="
                                 item.value === 'subpart' ||
@@ -151,6 +151,12 @@ export default {
                     listItems: [],
                 },
             },
+            tabLabels: [
+                "Table of Contents",
+                "Part",
+                "Subpart",
+                "Section",
+            ],
             selectedIdentifier: null,
             selectedScope: null,
             supplementalContentCount: {},
@@ -237,8 +243,12 @@ export default {
     },
 
     async created() {
-        for (const [key, value] of Object.entries(this.queryParams)) {
-            this.tabsShape[key].label = this.formatTabLabel(key);
+        for (const key of Object.keys(this.queryParams)) {
+            if (key == "subpart") {
+                this.tabLabels[2] = this.formatTabLabel(key);
+            } else if (key == "section") {
+                this.tabLabels[3] = this.formatTabLabel(key);
+            }
         }
         await this.getPartStructure();
         await this.getFormattedSubpartsList(this.part);
@@ -266,7 +276,7 @@ export default {
                 params: {
                     title: this.title,
                     part: this.part,
-                    tab: this.tabParam,
+                    tab: payload.scope,
                 },
                 query: {
                     ...this.queryParams,
@@ -353,8 +363,12 @@ export default {
         "$route.query": {
             async handler(toQueries, previousQueries) {
                 this.queryParams = toQueries;
-                for (const [key, value] of Object.entries(toQueries)) {
-                    this.tabsShape[key].label = this.formatTabLabel(key);
+                for (const key of Object.keys(toQueries)) {
+                    if (key == "subpart") {
+                        this.tabLabels[2] = this.formatTabLabel(key);
+                    } else if (key == "section") {
+                        this.tabLabels[3] = this.formatTabLabel(key);
+                    }
                 }
                 if (toQueries.subpart !== previousQueries.subpart) {
                     await this.getFormattedSectionsList(this.part, toQueries.subpart);

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -96,17 +96,17 @@ export default {
         return {
             title: this.$route.params.title,
             part: this.$route.params.part,
-            resourcesDisplay: this.$route.params.resourcesDisplay || "drawer",
+            resourcesDisplay: "drawer",
+            tabParam: this.$route.params.tab,
             structure: null,
             sections: [],
-            tab: 1, // index 1, "Part"
             tabsShape: [
                 {
                     label: "Table of Contents",
                     value: "tocContent",
                     type: "button",
                     component: "PartToc",
-                    disabled: true,
+                    disabled: false,
                 },
                 {
                     label: "Part",
@@ -119,13 +119,13 @@ export default {
                     label: "Subpart",
                     value: "subpart",
                     type: "dropdown",
-                    disabled: true,
+                    disabled: false,
                 },
                 {
                     label: "Section",
                     value: "section",
                     type: "dropdown",
-                    disabled: true,
+                    disabled: false,
                 },
             ],
             selectedIdentifier: null,
@@ -135,6 +135,21 @@ export default {
     },
 
     computed: {
+        tab() {
+            console.log("this.tabParam", this.tabParam);
+            switch(this.tabParam) {
+                case "toc":
+                    return 0;
+                case "part":
+                    return 1;
+                case "subpart":
+                    return 2;
+                case "section":
+                    return 3;
+                default:
+                    return 1;
+            }
+        },
         tocContent() {
             return this.structure?.[0];
         },

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -84,6 +84,7 @@ import SubpartList from "@/components/custom_elements/SubpartList.vue";
 import SectionList from "@/components/custom_elements/SectionList.vue";
 
 import {
+    getAllSections,
     getPart,
     getSubPartsForPart,
     getSupplementalContentCountForPart,
@@ -245,6 +246,7 @@ export default {
 
         await this.getPartStructure();
         await this.getFormattedSubpartsList(this.part);
+        await this.getFormattedSectionsList(this.part, this.subpart);
     },
 
     methods: {
@@ -295,6 +297,32 @@ export default {
                 (tab) => tab.value === "subpart"
             );
             this.tabsShape[tabIndex].listItems = formattedSubpartsList;
+        },
+        async getFormattedSectionsList() {
+            const allSections = await getAllSections();
+
+            let finalsSections = [];
+            let sectionList = [];
+            console.log("allSections", allSections);
+            const filteredSections = allSections.filter(
+                (section) =>
+                    section.part === this.part &&
+                    !section.identifier.includes("-")
+            );
+            console.log("filteredSections", filteredSections);
+            const tabIndex = this.tabsShape.findIndex(
+                (tab) => tab.value === "section"
+            );
+            this.tabsShape[tabIndex].listItems = filteredSections;
+            /*this.filters.section.listItems = finalsSections.sort((a, b) =>*/
+                /*a.part > b.part*/
+                    /*? 1*/
+                    /*: a.part == b.part*/
+                    /*? parseInt(a.identifier) > parseInt(b.identifier)*/
+                        /*? 1*/
+                        /*: -1*/
+                    /*: -1*/
+            /*);*/
         },
     },
 

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -343,9 +343,10 @@ export default {
                         return item.identifier == valueToSet;
                     }
                 ).subpart;
+                const subpartToSet = sectionSubpart == "none" ? {} : { subpart: sectionSubpart };
                 updatedQueryParams = {
                     ...this.queryParams,
-                    subpart: sectionSubpart,
+                    ...subpartToSet,
                     section: valueToSet,
                 };
             } else {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -178,7 +178,6 @@ export default {
                     title: this.title,
                     part: this.part,
                 };
-                console.log("tabValue", value);
                 switch (value) {
                     case 0:
                         this.$router.push({
@@ -243,7 +242,7 @@ export default {
         }
         await this.getPartStructure();
         await this.getFormattedSubpartsList(this.part);
-        await this.getFormattedSectionsList(this.part, this.subpart);
+        await this.getFormattedSectionsList(this.part, this.queryParams.subpart);
     },
 
     methods: {
@@ -287,7 +286,6 @@ export default {
             }
         },
         setResourcesParams(payload) {
-            console.log("payload", payload);
             if (payload.scope === "rendered") {
                 return;
             }
@@ -320,26 +318,19 @@ export default {
             const formattedSubpartsList = await getSubPartsForPart(part);
             this.tabsShape.subpart.listItems = formattedSubpartsList;
         },
-        async getFormattedSectionsList() {
+        async getFormattedSectionsList(part, subpart) {
             const allSections = await getAllSections();
 
             let finalsSections = [];
             let sectionList = [];
-            const filteredSections = allSections.filter(
-                (section) =>
-                    section.part === this.part &&
+            const filteredSections = allSections.filter((section) => {
+                return (
+                    section.part == part &&
+                    (subpart ? section.subpart == subpart : true) &&
                     !section.identifier.includes("-")
-            );
+                );
+            });
             this.tabsShape.section.listItems = filteredSections;
-            /*this.filters.section.listItems = finalsSections.sort((a, b) =>*/
-            /*a.part > b.part*/
-            /*? 1*/
-            /*: a.part == b.part*/
-            /*? parseInt(a.identifier) > parseInt(b.identifier)*/
-            /*? 1*/
-            /*: -1*/
-            /*: -1*/
-            /*);*/
         },
     },
 
@@ -364,6 +355,9 @@ export default {
                 this.queryParams = toQueries;
                 for (const [key, value] of Object.entries(toQueries)) {
                     this.tabsShape[key].label = this.formatTabLabel(key);
+                }
+                if (toQueries.subpart !== previousQueries.subpart) {
+                    await this.getFormattedSectionsList(this.part, toQueries.subpart);
                 }
             },
         },

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -95,6 +95,8 @@ import {
     getSupplementalContentCountForPart,
 } from "@/utilities/api";
 
+import _isUndefined from "lodash/isUndefined";
+
 export default {
     components: {
         SectionResourcesSidebar,
@@ -151,12 +153,7 @@ export default {
                     listItems: [],
                 },
             },
-            tabLabels: [
-                "Table of Contents",
-                "Part",
-                "Subpart",
-                "Section",
-            ],
+            tabLabels: ["Table of Contents", "Part", "Subpart", "Section"],
             selectedIdentifier: null,
             selectedScope: null,
             supplementalContentCount: {},
@@ -184,45 +181,62 @@ export default {
                     title: this.title,
                     part: this.part,
                 };
-                switch (value) {
-                    case 0:
+                const qParams = { ...this.queryParams };
+                const valueType = Object.keys(this.tabsShape)[value];
+
+                switch (valueType) {
+                    case "toc":
                         this.$router.push({
                             name: "part",
                             params: {
                                 ...urlParams,
                                 tab: "toc",
                             },
-                            query: this.queryParams,
+                            query: qParams,
                         });
                         break;
-                    case 1:
+                    case "part":
                         this.$router.push({
                             name: "part",
                             params: {
                                 ...urlParams,
                                 tab: "part",
                             },
-                            query: this.queryParams,
+                            query: qParams,
                         });
                         break;
-                    case 2:
+                    case "subpart":
                         this.$router.push({
                             name: "part",
                             params: {
                                 ...urlParams,
                                 tab: "subpart",
                             },
-                            query: this.queryParams,
+                            query: _isUndefined(qParams[valueType])
+                                ? {
+                                      ...qParams,
+                                      [valueType]:
+                                          this.tabsShape[valueType].listItems[0]
+                                              .identifier,
+                                  }
+                                : qParams,
                         });
                         break;
-                    case 3:
+                    case "section":
                         this.$router.push({
                             name: "part",
                             params: {
                                 ...urlParams,
                                 tab: "section",
                             },
-                            query: this.queryParams,
+                            query: _isUndefined(qParams[valueType])
+                                ? {
+                                      ...qParams,
+                                      [valueType]:
+                                          this.tabsShape[valueType].listItems[0]
+                                              .identifier,
+                                  }
+                                : qParams,
                         });
                         break;
                 }
@@ -252,7 +266,10 @@ export default {
         }
         await this.getPartStructure();
         await this.getFormattedSubpartsList(this.part);
-        await this.getFormattedSectionsList(this.part, this.queryParams.subpart);
+        await this.getFormattedSectionsList(
+            this.part,
+            this.queryParams.subpart
+        );
     },
 
     methods: {
@@ -371,7 +388,10 @@ export default {
                     }
                 }
                 if (toQueries.subpart !== previousQueries.subpart) {
-                    await this.getFormattedSectionsList(this.part, toQueries.subpart);
+                    await this.getFormattedSectionsList(
+                        this.part,
+                        toQueries.subpart
+                    );
                 }
             },
         },

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -310,6 +310,28 @@ export default {
             }
         },
         setQueryParam(payload) {
+            const valueToSet = payload.selectedIdentifier.split("-")[1];
+            let updatedQueryParams = {};
+            // get associated subpart for section
+            // TODO make method if keeping this
+            if (payload.scope == "section") {
+                const sectionSubpart = this.tabsShape.section.listItems.find(
+                    (item) => {
+                        return item.identifier == valueToSet;
+                    }
+                ).subpart;
+                updatedQueryParams = {
+                    ...this.queryParams,
+                    subpart: sectionSubpart,
+                    section: valueToSet,
+                };
+            } else {
+                updatedQueryParams = {
+                    ...this.queryParams,
+                    [payload.scope]: valueToSet,
+                };
+            }
+
             this.$router.push({
                 name: "part",
                 params: {
@@ -317,10 +339,7 @@ export default {
                     part: this.part,
                     tab: payload.scope,
                 },
-                query: {
-                    ...this.queryParams,
-                    [payload.scope]: payload.selectedIdentifier.split("-")[1],
-                },
+                query: updatedQueryParams,
             });
         },
         async getPartStructure() {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -237,6 +237,9 @@ export default {
     },
 
     async created() {
+        for (const [key, value] of Object.entries(this.queryParams)) {
+            this.tabsShape[key].label = this.formatTabLabel(key);
+        }
         await this.getPartStructure();
         await this.getFormattedSubpartsList(this.part);
         await this.getFormattedSectionsList(this.part, this.subpart);

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -20,6 +20,17 @@
                         :disabled="item.disabled"
                     >
                         {{ item.label }}
+                        <template v-if="item.value === 'subpart' || item.value === 'section'">
+                            <FancyDropdown
+                                label=""
+                                buttonTitle=""
+                                type="splitTab"
+                            >
+                                <component
+                                    :is="item.listType"
+                                ></component>
+                            </FancyDropdown>
+                        </template>
                     </v-tab>
                 </v-tabs>
             </PartNav>
@@ -57,6 +68,7 @@
 </template>
 
 <script>
+import FancyDropdown from "@/components/custom_elements/FancyDropdown.vue";
 import FlashBanner from "@/components/FlashBanner.vue";
 import Footer from "@/components/Footer.vue";
 import Header from "@/components/Header.vue";
@@ -64,18 +76,23 @@ import PartContent from "@/components/part/PartContent.vue";
 import PartNav from "@/components/part/PartNav.vue";
 import PartToc from "@/components/part/PartToc.vue";
 import SectionResourcesSidebar from "@/components/SectionResourcesSidebar.vue";
+import SubpartList from "@/components/custom_elements/SubpartList.vue";
+import SectionList from "@/components/custom_elements/SectionList.vue";
 
 import { getPart, getSupplementalContentCountForPart } from "@/utilities/api";
 
 export default {
     components: {
         SectionResourcesSidebar,
+        FancyDropdown,
         FlashBanner,
         Footer,
         Header,
         PartContent,
         PartNav,
         PartToc,
+        SubpartList,
+        SectionList,
     },
 
     name: "Part",
@@ -105,12 +122,14 @@ export default {
                 {
                     label: "Subpart",
                     value: "subpart",
+                    listType: "SubpartList",
                     type: "dropdown",
                     disabled: false,
                 },
                 {
                     label: "Section",
                     value: "section",
+                    listType: "SectionList",
                     type: "dropdown",
                     disabled: false,
                 },


### PR DESCRIPTION
Resolves [EREGCSC-1384](https://jiraent.cms.gov/browse/EREGCSC-1384) and [EREGCSC-1385](https://jiraent.cms.gov/browse/EREGCSC-1385)

**Description**
Implements Part-view tab behavior in the Part view of the prototype for the Multi-View Nav concept.  See Figma [here](https://www.figma.com/proto/OI3yDAbymYvHU3L7gTkhxR/eRegs-Multi-View-Nav-%26-View-Switching?page-id=2701%3A3601&node-id=2701%3A4567&viewport=-855%2C1864%2C0.07&scaling=scale-down&starting-point-node-id=2701%3A3615).

**This pull request changes:**

- Enables TOC/Part/Subpart/Section tab navigation on the Part view of the prototype
- Adds "split-tab" button functionality to Subpart and Section tabs
   - Extends the existing FancyDropdown component to be used as split tab button with chevron label
   - Clicking the down chevron on the subpart and section tabs will open associated list of subparts or sections
- Refactors Part view's `path` in Vue Router to remove `resourcesDisplay` param and add `tab` optional param to select a tab on load
- Adds `subpart` and `section` query parameters to set seleted subpart and section
   - these query params control the Subpart and Section tab labels, and will ultimately control the content of the Subpart and Section  
- Handles orphan edge cases in some ways (test with 433.1)
> **Note**
> Not all orphan edge cases are handled; there shouldn't be any errors, but it's possible that the Subpart tab label may show a labeled subpart (e.g. "Subpart A") even though the orphan is not in a subpart.

**Steps to manually verify this change:**

1. Visit the JIRA stories linked above to get an idea of the correct tab behavior.
2. Visit prototype deployment [here](https://d2rrgccs0ftamw.cloudfront.net/) and visit any part
3. Click the TOC/Part/Subpart/Tabs and see how they react.
4. Click the split tab button (the chevron) and make sure the subpart and section lists behave as per the tab behavior outlined in the stories above

