### PR TITLE
Search by location and add chips

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -15,8 +15,9 @@
                         type="text"
                         class="search-field"
                         append-icon="mdi-magnify"
-                        hide-details
                         dense
+                        hint="Search resources using keywords or citations."
+                        persistent-hint
                         v-model="searchInputValue"
                         @click:append="executeSearch"
                         @click:clear="clearSearchQuery"
@@ -181,7 +182,7 @@ export default {
                     selectedIdentifier: this.searchInputValue.replace(".", "-"),
                     searchSection: true,
                 };
-                this.updateFilters(payload);
+                return this.updateFilters(payload);
             }
             this.$router.push({
                 name: "resources",
@@ -366,8 +367,8 @@ export default {
             const parts = dataQueryParams.part.split(",");
             const newPartDict = {};
 
-            parts.forEach((x) => {
-                newPartDict[x] = {
+            parts.forEach((part) => {
+                newPartDict[part] = {
                     title: "42",
                     sections: [],
                     subparts: [],

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -21,7 +21,6 @@
                         @click:append="executeSearch"
                         @click:clear="clearSearchQuery"
                     />
-
                 </form>
             </ResourcesNav>
             <div
@@ -62,10 +61,8 @@
 </template>
 
 <script>
-
 import _isEmpty from "lodash/isEmpty";
 import _uniq from "lodash/uniq";
-
 
 import ResourcesNav from "@/components/resources/ResourcesNav.vue";
 import ResourcesFilters from "@/components/resources/ResourcesFilters.vue";
@@ -80,8 +77,7 @@ import {
     getTOC,
     getPartTOC,
     getSectionsForPart,
-    getSubpartTOC
-
+    getSubpartTOC,
 } from "../utilities/api";
 
 export default {
@@ -142,7 +138,7 @@ export default {
             },
             supplementalContent: [],
             searchInputValue: "",
-            URL: import.meta.env.VITE_API_URL
+            URL: import.meta.env.VITE_API_URL,
         };
     },
 
@@ -177,6 +173,16 @@ export default {
 
     methods: {
         executeSearch() {
+            const sectionRegex = /^\d{2,3}\.(\d{1,4})$/;
+
+            if (sectionRegex.test(this.searchInputValue)) {
+                let payload = {
+                    scope: "section",
+                    selectedIdentifier: this.searchInputValue.replace(".", "-"),
+                    searchSection: true,
+                };
+                this.updateFilters(payload);
+            }
             this.$router.push({
                 name: "resources",
                 query: {
@@ -205,6 +211,7 @@ export default {
                 query: { ...this.filterParams },
             });
         },
+
         removeChip(payload) {
             const newQueryParams = { ...this.queryParams };
             const scopeVals = newQueryParams[payload.scope].split(",");
@@ -251,27 +258,65 @@ export default {
 
         async updateFilters(payload) {
             let newQueryParams = { ...this.queryParams };
+            const splitSection = payload.selectedIdentifier.split("-");
 
-            if (newQueryParams[payload.scope]) {
-                const scopeVals = newQueryParams[payload.scope].split(",");
-                scopeVals.push(payload.selectedIdentifier);
-                const uniqScopeVals = _uniq(scopeVals);
-                newQueryParams[payload.scope] = uniqScopeVals.sort().join(",");
-            } else {
-                newQueryParams.title = "42"; // hard coding for now
-                newQueryParams[payload.scope] = payload.selectedIdentifier;
+            //Checks that the part in the query is valid or is a resource category
+            if ((await this.checkPart(splitSection, payload.scope)) || payload.scope == "resourceCategory") {
+                if (newQueryParams[payload.scope]) {
+                    if (payload.searchSection) {
+                        if (!newQueryParams.part.includes(splitSection[0])) {
+                            newQueryParams.part =
+                                newQueryParams.part + "," + splitSection[0];
+                        }
+                    }
+                    const scopeVals = newQueryParams[payload.scope].split(",");
+                    scopeVals.push(payload.selectedIdentifier);
+                    const uniqScopeVals = _uniq(scopeVals);
+                    newQueryParams[payload.scope] = uniqScopeVals
+                        .sort()
+                        .join(",");
+                } else {
+                    newQueryParams.title = "42"; // hard coding for now
+                    if (payload.scope === "section") {
+                        if (newQueryParams.part) {
+                            newQueryParams.part =
+                                newQueryParams.part + "," + splitSection[0];
+                        } else {
+                            newQueryParams.part = splitSection[0];
+                        }
+                    }
+                    newQueryParams[payload.scope] = payload.selectedIdentifier;
+                }
+
+                if (payload.scope === "subpart") {
+                      newQueryParams = await this.combineSections(
+                        payload.selectedIdentifier,
+                        newQueryParams
+                    );
+                }
+
+                if (payload.searchSection) {
+                    newQueryParams.q = "";
+                    this.searchInputValue = "";
+                }
+
+                this.getPartDict(newQueryParams)
+
+                this.$router.push({
+                    name: "resources",
+                    query: newQueryParams,
+                });
             }
-            if (payload.scope === "subpart") {
-                newQueryParams = await this.combineSections(
-                    payload.selectedIdentifier,
-                    newQueryParams
-                );
-                this.getPartDict(newQueryParams);
+        },
+
+        async checkPart(payload, scope) {
+            const partExist = this.filters.part.listItems.filter((part) => part.name == payload[0]).length > 0;
+
+            if (partExist && scope === "section") {
+                const sectionList = await getSectionsForPart(42, payload[0]);
+                return sectionList.filter((section) => section.identifier[1] == payload[1]).length >0;
             }
-            this.$router.push({
-                name: "resources",
-                query: newQueryParams,
-            });
+            return partExist;
         },
 
         async combineSections(subpart, queryParams) {
@@ -287,14 +332,20 @@ export default {
         },
         async getSectionsBySubpart(subpart) {
             const splitSubpart = subpart.split("-");
-            const allSections = await getSubpartTOC(42, splitSubpart[0], splitSubpart[1])
+            const allSections = await getSubpartTOC(
+                42,
+                splitSubpart[0],
+                splitSubpart[1]
+            );
             const sectionList = allSections
-                .filter(sec => sec.type === "section")
+                .filter((sec) => sec.type === "section")
                 .map((sec) => `${sec.identifier[0]}-${sec.identifier[1]}`);
             return sectionList;
         },
         filterCategories(resultArray) {
-            return  resultArray.filter((item) => this.queryParams.resourceCategory.includes(item.name));
+            return resultArray.filter((item) =>
+                this.queryParams.resourceCategory.includes(item.name)
+            );
         },
         transformResults(results, flatten) {
             const arrayToTransform = flatten ? results.flat() : results;
@@ -311,53 +362,47 @@ export default {
             return returnArr;
         },
         getPartDict(dataQueryParams) {
-
             const parts = dataQueryParams.part.split(",");
-            const newPartDict = {}
+            const newPartDict = {};
 
-            parts.forEach(x => {
+            parts.forEach((x) => {
                 newPartDict[x] = {
                     title: "42",
                     sections: [],
                     subparts: [],
                 };
-            })
+            });
 
-            this.partDict = newPartDict
+            this.partDict = newPartDict;
 
             if (dataQueryParams.section) {
-
                 const sections = dataQueryParams.section
                     .split(",")
-                    .filter(x =>
-                        x.match(/^\d+/) && x.match(/\d+$/)
-                    )
+                    .filter((x) => x.match(/^\d+/) && x.match(/\d+$/))
                     .map((x) => ({
-                      part: x.match(/^\d+/)[0],
-                      section: x.match(/\d+$/)[0],
-                }));
-                Object.keys(sections).forEach(section => {
+                        part: x.match(/^\d+/)[0],
+                        section: x.match(/\d+$/)[0],
+                    }));
+                Object.keys(sections).forEach((section) => {
                     this.partDict[sections[section].part].sections.push(
                         sections[section].section
                     );
-                })
+                });
             }
             if (dataQueryParams.subpart) {
                 const subparts = dataQueryParams.subpart
                     .split(",")
-                    .filter(x =>
-                        x.match(/^\d+/) && x.match(/\w+$/)
-                    )
+                    .filter((x) => x.match(/^\d+/) && x.match(/\w+$/))
                     .map((x) => ({
                         part: x.match(/^\d+/)[0],
                         subparts: x.match(/\w+$/)[0],
                     }));
 
-                Object.keys(subparts).forEach(subpart => {
+                Object.keys(subparts).forEach((subpart) => {
                     this.partDict[subparts[subpart].part].subparts.push(
                         subparts[subpart].subparts
                     );
-                })
+                });
             }
         },
 
@@ -365,17 +410,17 @@ export default {
             this.isLoading = true;
 
             if (dataQueryParams.resourceCategory) {
-               this.categories = dataQueryParams.resourceCategory.split(",");
-            } else{
-              this.categories = []
+                this.categories = dataQueryParams.resourceCategory.split(",");
+            } else {
+                this.categories = [];
             }
             if (dataQueryParams?.part) {
                 this.getPartDict(dataQueryParams);
                 // map over parts and return promises to put in Promise.all
                 const partPromises = await getSupplementalContentV3({
-                  partDict:this.partDict,
-                  categories: this.categories,
-                  q: searchQuery,
+                    partDict: this.partDict,
+                    categories: this.categories,
+                    q: searchQuery,
                 });
 
                 try {
@@ -389,10 +434,10 @@ export default {
             } else if (searchQuery) {
                 try {
                     const searchResults = await getSupplementalContentV3({
-                      partDict: "all", // titles
-                      categories: this.categories, // subcategories
-                      q: searchQuery,
-                      paginate: true
+                        partDict: "all", // titles
+                        categories: this.categories, // subcategories
+                        q: searchQuery,
+                        paginate: true,
                     });
 
                     this.supplementalContent = searchResults;
@@ -404,65 +449,79 @@ export default {
                 }
             } else {
                 this.supplementalContent = await getSupplementalContentV3({
-                  partDict: "all", // titles
-                  categories: this.categories,
-                  q: searchQuery,
-                  start: 0, // start
-                  max_results: 100, // max_results
-                  paginate:false,
+                    partDict: "all", // titles
+                    categories: this.categories,
+                    q: searchQuery,
+                    start: 0, // start
+                    max_results: 100, // max_results
+                    paginate: false,
                 });
                 this.isLoading = false;
             }
         },
         async getFormattedPartsList() {
             const TOC = await getTOC();
-            const partsList = TOC[0].children[0].children.map(
-                subChapter => subChapter.children.map(part => (
-                    {label: part.label, name:part.identifier[0]}
-                ))
-            ).flat(1)
+            const partsList = TOC[0].children[0].children
+                .map((subChapter) =>
+                    subChapter.children.map((part) => ({
+                        label: part.label,
+                        name: part.identifier[0],
+                    }))
+                )
+                .flat(1);
 
-            this.filters.part.listItems = await Promise.all(partsList.map(async part =>{
-                const newPart = JSON.parse(JSON.stringify(part))
-                const PartToc = await getPartTOC(42, part.name)
-                const sections = {}
-                PartToc.children.filter(TOCpart => TOCpart.type==="subpart").forEach(subpart => {
-
-                    subpart.children.filter(section =>
-                        section.type==="section").forEach(c=>{
-                          sections[c.identifier[c.identifier.length-1]] = c.parent[0]
-                    })})
-                newPart.sections = sections
-                return newPart
-            }))
-
+            this.filters.part.listItems = await Promise.all(
+                partsList.map(async (part) => {
+                    const newPart = JSON.parse(JSON.stringify(part));
+                    const PartToc = await getPartTOC(42, part.name);
+                    const sections = {};
+                    PartToc.children
+                        .filter((TOCpart) => TOCpart.type === "subpart")
+                        .forEach((subpart) => {
+                            subpart.children
+                                .filter((section) => section.type === "section")
+                                .forEach((c) => {
+                                    sections[
+                                        c.identifier[c.identifier.length - 1]
+                                    ] = c.parent[0];
+                                });
+                        });
+                    newPart.sections = sections;
+                    return newPart;
+                })
+            );
         },
-
 
         async getFormattedSubpartsList(parts) {
             this.filters.subpart.listItems = await getSubPartsForPart(parts);
         },
 
         async getFormattedSectionsList() {
-            const rawSections = await Promise.all(Object.keys(this.partDict).map(async part =>getSectionsForPart("42", part)))
+            const rawSections = await Promise.all(
+                Object.keys(this.partDict).map(async (part) =>
+                    getSectionsForPart("42", part)
+                )
+            );
 
-            const finalSections = rawSections.flat(1).map(section =>({
+            const finalSections = rawSections.flat(1).map((section) => ({
                 label: section.label_level,
                 description: section.label_description,
                 part: section.identifier[0],
                 [section.parent_type]: section.parent[0],
-                identifier: section.identifier[section.identifier.length-1],
-            }))
+                identifier: section.identifier[section.identifier.length - 1],
+            }));
 
-            this.filters.section.listItems = finalSections.flat(1).sort((a, b) =>
-                a.part > b.part
-                    ? 1
-                    : a.part == b.part
-                    ? parseInt(a.identifier) > parseInt(b.identifier)
+            this.filters.section.listItems = finalSections
+                .flat(1)
+                .sort((a, b) =>
+                    a.part > b.part
                         ? 1
+                        : a.part == b.part
+                        ? parseInt(a.identifier) > parseInt(b.identifier)
+                            ? 1
+                            : -1
                         : -1
-                    : -1
-            );
+                );
         },
         async getPartLastUpdatedDates() {
             this.partsLastUpdated = await getLastUpdatedDates(this.apiUrl);
@@ -483,15 +542,13 @@ export default {
                 }
             });
 
-            const categories = Object.values(reducedCats).sort((a, b) =>
-                a.order - b.order
+            const categories = Object.values(reducedCats).sort(
+                (a, b) => a.order - b.order
             );
             categories.forEach((category) => {
-                category.subcategories.sort((a, b) =>
-                    a.order - b.order
-                );
+                category.subcategories.sort((a, b) => a.order - b.order);
             });
-            this.filters.resourceCategory.listItems = categories
+            this.filters.resourceCategory.listItems = categories;
         },
     },
 
@@ -564,7 +621,6 @@ export default {
         }
 
         this.getSupplementalContent(this.queryParams, this.searchQuery);
-
     },
 
     beforeMount() {},

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -138,7 +138,6 @@ export default {
             },
             supplementalContent: [],
             searchInputValue: "",
-            URL: import.meta.env.VITE_API_URL
         };
     },
 

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -11,13 +11,12 @@
                         flat
                         solo
                         clearable
-                        label="Search Resources"
+                        label="Search resources using keywords or citations."
                         type="text"
                         class="search-field"
                         append-icon="mdi-magnify"
+                        hide-details
                         dense
-                        hint="Search resources using keywords or citations."
-                        persistent-hint
                         v-model="searchInputValue"
                         @click:append="executeSearch"
                         @click:clear="clearSearchQuery"

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -138,7 +138,7 @@ export default {
             },
             supplementalContent: [],
             searchInputValue: "",
-            URL: import.meta.env.VITE_API_URL,
+            URL: import.meta.env.VITE_API_URL
         };
     },
 
@@ -311,11 +311,11 @@ export default {
         },
 
         async checkPart(payload, scope) {
-            const partExist = this.filters.part.listItems.filter((part) => part.name == payload[0]).length > 0;
+            const partExist = this.filters.part.listItems.find((part) => part.name == payload[0]);
 
             if (partExist && scope === "section") {
                 const sectionList = await getSectionsForPart(42, payload[0]);
-                return (sectionList.filter((section) => section.identifier[1] == payload[1]).length > 0);
+                return (sectionList.find((section) => section.identifier[1] == payload[1]));
             }
             return partExist;
         },
@@ -379,7 +379,7 @@ export default {
             if (dataQueryParams.section) {
                 const sections = dataQueryParams.section
                     .split(",")
-                    .filter((x) => x.match(/^\d+/) && x.match(/\d+$/))
+                    .filter((section) => section.match(/^\d+/) && section.match(/\d+$/))
                     .map((x) => ({
                         part: x.match(/^\d+/)[0],
                         section: x.match(/\d+$/)[0],
@@ -393,12 +393,12 @@ export default {
             if (dataQueryParams.subpart) {
                 const subparts = dataQueryParams.subpart
                     .split(",")
-                    .filter((x) => x.match(/^\d+/) && x.match(/\w+$/))
+                    .filter((section) => section.match(/^\d+/) && section.match(/\w+$/))
                     .map((x) => ({
                         part: x.match(/^\d+/)[0],
                         subparts: x.match(/\w+$/)[0],
                     }));
-
+                
                 Object.keys(subparts).forEach((subpart) => {
                     this.partDict[subparts[subpart].part].subparts.push(
                         subparts[subpart].subparts

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -279,8 +279,9 @@ export default {
                     newQueryParams.title = "42"; // hard coding for now
                     if (payload.scope === "section") {
                         if (newQueryParams.part) {
-                            newQueryParams.part =
-                                newQueryParams.part + "," + splitSection[0];
+                            if (!newQueryParams.part.includes(splitSection[0])) {
+                                newQueryParams.part = newQueryParams.part + "," + splitSection[0];
+                            }
                         } else {
                             newQueryParams.part = splitSection[0];
                         }
@@ -289,7 +290,7 @@ export default {
                 }
 
                 if (payload.scope === "subpart") {
-                      newQueryParams = await this.combineSections(
+                    newQueryParams = await this.combineSections(
                         payload.selectedIdentifier,
                         newQueryParams
                     );
@@ -300,7 +301,7 @@ export default {
                     this.searchInputValue = "";
                 }
 
-                this.getPartDict(newQueryParams)
+                this.getPartDict(newQueryParams);
 
                 this.$router.push({
                     name: "resources",
@@ -314,7 +315,7 @@ export default {
 
             if (partExist && scope === "section") {
                 const sectionList = await getSectionsForPart(42, payload[0]);
-                return sectionList.filter((section) => section.identifier[1] == payload[1]).length >0;
+                return (sectionList.filter((section) => section.identifier[1] == payload[1]).length > 0);
             }
             return partExist;
         },

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -379,9 +379,9 @@ export default {
                 const sections = dataQueryParams.section
                     .split(",")
                     .filter((section) => section.match(/^\d+/) && section.match(/\d+$/))
-                    .map((x) => ({
-                        part: x.match(/^\d+/)[0],
-                        section: x.match(/\d+$/)[0],
+                    .map((section) => ({
+                        part: section.match(/^\d+/)[0],
+                        section: section.match(/\d+$/)[0],
                     }));
                 Object.keys(sections).forEach((section) => {
                     this.partDict[sections[section].part].sections.push(
@@ -393,9 +393,9 @@ export default {
                 const subparts = dataQueryParams.subpart
                     .split(",")
                     .filter((section) => section.match(/^\d+/) && section.match(/\w+$/))
-                    .map((x) => ({
-                        part: x.match(/^\d+/)[0],
-                        subparts: x.match(/\w+$/)[0],
+                    .map((section) => ({
+                        part: section.match(/^\d+/)[0],
+                        subparts: section.match(/\w+$/)[0],
                     }));
                 
                 Object.keys(subparts).forEach((subpart) => {


### PR DESCRIPTION
Resolves # EREGSCSC-1321

**Description-**

We want to make it so that if you search a location ex. 400.200 you will update the filters with the appropriate chips

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

Type in 400.200 into the search bar.  It should add the chips for part 400 and section 400.200

Clear the results.  Type in 400.200 hello.  No chips should be added but it will search on that as a normal query.

Type in 400.99.  No chips should be added since its an invalid section.  Will just query on 400.99

Type in 500.9.  Same behavior s above

It will work for any valid part/section combination.  It will check the part first to see if the part number is valid, then check the section number to see if it belongs to that part.
