### PR TITLE
Prototype v3 sections

### DIFF
--- a/solution/ui/prototype/src/utilities/api.js
+++ b/solution/ui/prototype/src/utilities/api.js
@@ -422,7 +422,7 @@ const getHomepageStructure = async () => {
  */
 
 const getAllParts = async () => {
-    return await httpApiGet("all_parts");
+    return undefined;
 };
 
 /**
@@ -817,6 +817,15 @@ const getSupplementalContentSearchResults = async (query) => {
     return result;
 };
 
+const getTOC = async (title) =>  httpApiGetV3(title? `title/${title}/toc`:`toc`);
+
+const getPartTOC = async (title, part) =>  httpApiGetV3(`title/${title}/part/${part}/version/latest/toc`);
+
+const getSectionsForPart = async (title, part) => httpApiGetV3(`title/${title}/part/${part}/version/latest/sections`)
+
+const getSubpartTOC = async (title, part, subPart) => httpApiGetV3(`title/${title}/part/${part}/version/latest/subpart/${subPart}/toc`)
+
+
 // API Functions Insertion Point (do not change this text, it is being used by hygen cli)
 
 export {
@@ -849,6 +858,10 @@ export {
     getSupByPart,
     getAllSections,
     getSupplementalContentV3,
-    getSupplementalContentSearchResults
+    getSupplementalContentSearchResults,
+    getTOC,
+    getPartTOC,
+    getSectionsForPart,
+    getSubpartTOC
     // API Export Insertion Point (do not change this text, it is being used by hygen cli)
 };

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -91,7 +91,6 @@ import SubpartList from "@/components/custom_elements/SubpartList.vue";
 import SectionList from "@/components/custom_elements/SectionList.vue";
 
 import {
-    getAllSections,
     getPart,
     getSupplementalContentCountForPart,
     getPartTOC,
@@ -100,7 +99,6 @@ import {
 
 import _isEmpty from "lodash/isEmpty";
 import _isUndefined from "lodash/isUndefined";
-import {getSubpartTOC} from "../utilities/api";
 
 export default {
     components: {


### PR DESCRIPTION
Resolves #

**Description-**

updates Part.vue in prototype site to use the V3 api

**This pull request changes...**

- removes calls that use old getAllParts endpoint because it is inconsistent.

**Steps to manually verify this change...**

Part page should still have subparts and sections populated as expected.

