### PR TITLE
Filling out TOC accordion on PDPart views.

### DIFF
--- a/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
+++ b/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
@@ -35,10 +35,15 @@
         <v-expansion-panels>
             <v-expansion-panel>
                 <v-expansion-panel-header>
-                    Table of Contents
+                    <span class="v-expansion-panel-header-text">Table of Contents</span>
+                    <template v-slot:actions>
+                        <v-icon color="black">
+                            mdi-plus
+                        </v-icon>
+                    </template>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
-                    TABLE OF CONTENTS HERE
+                    <PartToc :structure="tocContent" navName="PDpart" />
                 </v-expansion-panel-content>
             </v-expansion-panel>
         </v-expansion-panels>
@@ -60,10 +65,12 @@
 <script>
 import PartContent from "@/components/part/PartContent.vue";
 import Breadcrumbs from "@/components/PDPart/Breadcrumbs.vue";
+import PartToc from "@/components/part/PartToc";
 
 export default {
     name: "LeftColumn",
     components: {
+      PartToc,
         PartContent,
         Breadcrumbs,
     },
@@ -73,6 +80,7 @@ export default {
         subPart: { type: String },
         section: { type: String },
         structure: { type: Array },
+        tocContent: {type: Object},
         navigation: { type: Object },
         supplementalContentCount: { type: Object },
         partLabel: {type: String},
@@ -100,5 +108,25 @@ export default {
       line-height: 30px;
       letter-spacing: 0em;
       text-align: left;
+  }
+  .toc-group{
+    margin-top: 5px;
+  }
+  .toc{
+    margin-left:0;
+  }
+  .v-expansion-panel{
+    border: 3px solid #f3f3f3;
+  }
+
+  .v-expansion-panel-header{
+    background-color: #f3f3f3;
+    color: black;
+    font-weight: bold;
+    font-size: 16px;
+    line-height: 20px
+  }
+  .v-expansion-panel-header-text{
+    padding:18px;
   }
 </style>

--- a/solution/ui/prototype/src/components/part/PartToc.vue
+++ b/solution/ui/prototype/src/components/part/PartToc.vue
@@ -40,6 +40,11 @@ export default {
         structure: {
             type: Object,
             required: false
+        },
+        navName : {
+          type: String,
+          required: false,
+          default: 'part'
         }
     },
     data() {
@@ -67,7 +72,7 @@ export default {
             query.subpart = item.parent[item.parent.length-1]
           }
           this.$router.push({
-              name: "part",
+              name: this.navName,
               params: {
                   ...urlParams,
                   tab: item.type,

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -12,6 +12,7 @@
                         :section="section"
                         :partLabel="partLabel"
                         :structure="partContent"
+                        :tocContent="tocContent"
                         :navigation="navigation"
                         :supplementalContentCount="supplementalContentCount"
                         @view-resources="setResourcesParams"


### PR DESCRIPTION
Resolves #EREGCSC-1401

**Description-**

Fills in Table of Contents on the PD Part views

**This pull request changes...**

Styles up the expander for TOC
adds the partTOC element to the expansion panel
Passes a navName to the part TOC so it can do slightly different nav for each implementation

**Steps to manually verify this change...**

1. Go to PD/42/433 (or any option) and look at the Tabel of contents.  clicking links should update the URL, but that will have no effect on the content.
