### PR TITLE
Category only Filtering bug

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           STATIC_URL: http://localhost:8888/
           STATIC_ROOT: ../static-assets/regulations
-          VITE_ENV: dev-${{ steps.findPr.outputs.pr }}
+          VITE_ENV: dev${{ steps.findPr.outputs.pr }}
         run: |
           pushd solution/backend
           python manage.py collectstatic --noinput
@@ -220,7 +220,7 @@ jobs:
         env:
           STATIC_URL: http://localhost:8888/
           STATIC_ROOT: ../static-assets/regulations
-          VITE_ENV: dev-${{ steps.findPr.outputs.pr }}
+          VITE_ENV: dev${{ steps.findPr.outputs.pr }}
         run: |
           pushd solution
           make regulations

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -299,9 +299,9 @@ export default {
                     newQueryParams.q = "";
                     this.searchInputValue = "";
                 }
-
-                this.getPartDict(newQueryParams);
-
+                if (newQueryParams.part) {
+                  this.getPartDict(newQueryParams);
+                }
                 this.$router.push({
                     name: "resources",
                     query: newQueryParams,


### PR DESCRIPTION

Resolves #

**Description-**
On the resources page if you select only a category the filtering does not happen.  A part is currently required to make category filtering work, which isn't right.  Someone should be able to filter for a category without choosing a part first.

**This pull request changes...**

- a small check for part Dict is skipped if not parts are selected.

**Steps to manually verify this change...**

1. Go to resources page, change the category.  On Prod nothing will happen, on this branch it should search for all resources that have that category.
