### PR TITLE
EREGCSC-1386 -- Sticky navigation for tab concept

### DIFF
--- a/solution/ui/prototype/src/components/Header.vue
+++ b/solution/ui/prototype/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-    <header id="header" class="sticky">
+    <header id="header" :class="stickyClass">
         <!-- desktop -->
         <div class="flexbox header-large">
             <div class="title-container">
@@ -63,17 +63,63 @@ export default {
         JumpTo,
     },
 
+    mounted() {
+        window.addEventListener("scroll", this.onScroll);
+    },
+
+    beforeDestroy() {
+        window.removeEventListener("scroll", this.onScroll);
+    },
+
+    props: {
+        stickyMode: {
+            validator: function (value) {
+                return ["hideOnScrollDown", "normal", "disabled"].includes(
+                    value
+                );
+            },
+            default: "normal",
+        },
+    },
+
     data() {
         return {
             action: "open",
             state: "expanded",
+            showNavbar: true,
+            lastScrollPosition: 0,
         };
+    },
+
+    computed: {
+        stickyClass() {
+            return this.stickyMode === "hideOnScrollDown" || "normal"
+                ? "sticky"
+                : "";
+        },
     },
 
     methods: {
         toggleState(payload) {
             this.action = payload.action;
             this.state = payload.state;
+        },
+        onScroll() {
+            if (this.stickyMode === "hideOnScrollDown") {
+                const scrollPosition = window.scrollY;
+                const scrollDirection =
+                    scrollPosition > this.lastScrollPosition ? "down" : "up";
+
+                this.lastScrollPosition = scrollPosition;
+
+                if (scrollDirection === "down") {
+                    console.log("hide header!");
+                    this.showNavbar = false;
+                } else {
+                    console.log("show header!");
+                    this.showNavbar = true;
+                }
+            }
         },
     },
 };

--- a/solution/ui/prototype/src/components/Header.vue
+++ b/solution/ui/prototype/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-    <header id="header" :class="stickyClass">
+    <header id="header" :class="headerClasses">
         <!-- desktop -->
         <div class="flexbox header-large">
             <div class="title-container">
@@ -92,10 +92,11 @@ export default {
     },
 
     computed: {
-        stickyClass() {
-            return this.stickyMode === "hideOnScrollDown" || "normal"
-                ? "sticky"
-                : "";
+        headerClasses() {
+            return {
+                sticky: this.stickyMode === "hideOnScrollDown" || "normal",
+                "sticky-hide": !this.showNavbar,
+            }
         },
     },
 
@@ -129,6 +130,7 @@ export default {
 header {
     box-sizing: border-box;
     border: 1px solid #d6d7d9;
+    transition: transform 0.3s ease-in-out;
 }
 .links-container {
     padding-right: 10px;
@@ -142,5 +144,10 @@ header {
 .header-link {
     color: #212121;
     padding-right: 20px;
+}
+
+.sticky-hide {
+    box-shadow: none;
+    transform: translate3d(0, -100%, 0);
 }
 </style>

--- a/solution/ui/prototype/src/components/Header.vue
+++ b/solution/ui/prototype/src/components/Header.vue
@@ -63,14 +63,6 @@ export default {
         JumpTo,
     },
 
-    mounted() {
-        window.addEventListener("scroll", this.onScroll);
-    },
-
-    beforeDestroy() {
-        window.removeEventListener("scroll", this.onScroll);
-    },
-
     props: {
         stickyMode: {
             validator: function (value) {
@@ -80,14 +72,16 @@ export default {
             },
             default: "normal",
         },
+        showHeader: {
+            type: Boolean,
+            default: true,
+        }
     },
 
     data() {
         return {
             action: "open",
             state: "expanded",
-            showNavbar: true,
-            lastScrollPosition: 0,
         };
     },
 
@@ -95,7 +89,7 @@ export default {
         headerClasses() {
             return {
                 sticky: this.stickyMode === "hideOnScrollDown" || "normal",
-                "sticky-hide": !this.showNavbar,
+                "sticky-hide": !this.showHeader,
             };
         },
     },
@@ -104,24 +98,6 @@ export default {
         toggleState(payload) {
             this.action = payload.action;
             this.state = payload.state;
-        },
-        onScroll() {
-            if (this.stickyMode === "hideOnScrollDown") {
-                const scrollPosition = window.scrollY;
-                const scrollDirection =
-                    scrollPosition > 0 &&
-                    scrollPosition > this.lastScrollPosition
-                        ? "down"
-                        : "up";
-
-                this.lastScrollPosition = scrollPosition;
-
-                if (scrollDirection === "down") {
-                    this.showNavbar = false;
-                } else {
-                    this.showNavbar = true;
-                }
-            }
         },
     },
 };
@@ -133,6 +109,7 @@ header {
     border: 1px solid #d6d7d9;
     transition: transform 0.3s ease-in-out;
 }
+
 .links-container {
     padding-right: 10px;
 }

--- a/solution/ui/prototype/src/components/Header.vue
+++ b/solution/ui/prototype/src/components/Header.vue
@@ -96,7 +96,7 @@ export default {
             return {
                 sticky: this.stickyMode === "hideOnScrollDown" || "normal",
                 "sticky-hide": !this.showNavbar,
-            }
+            };
         },
     },
 
@@ -109,15 +109,16 @@ export default {
             if (this.stickyMode === "hideOnScrollDown") {
                 const scrollPosition = window.scrollY;
                 const scrollDirection =
-                    scrollPosition > this.lastScrollPosition ? "down" : "up";
+                    scrollPosition > 0 &&
+                    scrollPosition > this.lastScrollPosition
+                        ? "down"
+                        : "up";
 
                 this.lastScrollPosition = scrollPosition;
 
                 if (scrollDirection === "down") {
-                    console.log("hide header!");
                     this.showNavbar = false;
                 } else {
-                    console.log("show header!");
                     this.showNavbar = true;
                 }
             }

--- a/solution/ui/prototype/src/components/part/PartHero.vue
+++ b/solution/ui/prototype/src/components/part/PartHero.vue
@@ -1,0 +1,81 @@
+<template>
+    <div class="nav-container">
+        <div class="content" :class="resourcesClass">
+            <h1>
+                <span> {{ title }} CFR Part {{ part }} - </span>
+                <span v-if="partLabel">{{ partLabel }}</span>
+                <span v-else>
+                    <InlineLoader />
+                </span>
+            </h1>
+        </div>
+    </div>
+</template>
+
+<script>
+import InlineLoader from "@/components/InlineLoader.vue";
+
+export default {
+    components: {
+        InlineLoader,
+    },
+
+    name: "PartHero",
+
+    props: {
+        title: {
+            type: String,
+            required: true,
+        },
+        part: {
+            type: String,
+            required: true,
+        },
+        partLabel: {
+            type: String,
+        },
+        resourcesDisplay: {
+            type: String,
+        },
+    },
+
+    computed: {
+        resourcesClass() {
+            return `content-with-${this.resourcesDisplay}`;
+        },
+    },
+};
+</script>
+
+<style lang="scss">
+$font-path: "~@cmsgov/design-system/dist/fonts/"; // cmsgov font path
+$additional-font-path: "~legacy-static/fonts"; // additional Open Sans fonts
+$image-path: "~@cmsgov/design-system/dist/images/"; // cmsgov image path
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
+$eregs-image-path: "~legacy-static/images";
+
+@import "legacy/css/scss/main.scss";
+
+.nav-container {
+    overflow: auto;
+    width: 100%;
+    background: $lightest_blue;
+
+    .content-with-drawer {
+        margin: 0 auto;
+    }
+
+    .content-with-sidebar {
+        margin-left: 50px;
+    }
+
+    .content {
+        max-width: $text-max-width;
+
+        h1 {
+            margin-top: 55px;
+            margin-bottom: 40px;
+        }
+    }
+}
+</style>

--- a/solution/ui/prototype/src/components/part/PartNav.vue
+++ b/solution/ui/prototype/src/components/part/PartNav.vue
@@ -1,48 +1,37 @@
 <template>
-    <div class="nav-container">
-        <div class="content" :class="resourcesClass">
-            <h1>
-                <span> {{ title }} CFR Part {{ part }} - </span>
-                <span v-if="partLabel">{{ partLabel }}</span>
-                <span v-else>
-                    <InlineLoader />
-                </span>
-            </h1>
+    <div class="part-nav-tabs" :class="partNavTabClasses">
+        <div class="tabs-container">
             <slot></slot>
         </div>
     </div>
 </template>
 
 <script>
-import InlineLoader from "@/components/InlineLoader.vue";
-
 export default {
-    components: {
-        InlineLoader,
-    },
+    components: {},
 
     name: "PartNav",
 
     props: {
-        title: {
-            type: String,
-            required: true,
+        stickyMode: {
+            validator: function (value) {
+                return ["hideOnScrollDown", "normal", "disabled"].includes(
+                    value
+                );
+            },
+            default: "normal",
         },
-        part: {
-            type: String,
-            required: true,
-        },
-        partLabel: {
-            type: String,
-        },
-        resourcesDisplay: {
-            type: String,
-        },
+        showHeader: {
+            type: Boolean,
+            default: true,
+        }
     },
 
     computed: {
-        resourcesClass() {
-            return `content-with-${this.resourcesDisplay}`;
+        partNavTabClasses() {
+            return {
+                "top-header-hidden": !this.showHeader,
+            };
         },
     },
 };
@@ -57,26 +46,31 @@ $eregs-image-path: "~legacy-static/images";
 
 @import "legacy/css/scss/main.scss";
 
-.nav-container {
-    overflow: auto;
-    width: 100%;
+$sidebar-top-margin: 40px;
+
+.part-nav-tabs {
+    position: sticky;
+    z-index: 1;
     background: $lightest_blue;
+    transition: top 0.3s ease-in-out;
 
-    .content-with-drawer {
-        margin: 0 auto;
+    top: $header_height_mobile;
+
+    @include screen-md {
+        top: $header_height_tablet;
     }
 
-    .content-with-sidebar {
+    @include screen-lg {
+        top: $header_height;
+    }
+
+    &.top-header-hidden {
+        top: 0;
+    }
+
+    .tabs-container {
         margin-left: 50px;
-    }
-
-    .content {
         max-width: $text-max-width;
-
-        h1 {
-            margin-top: 55px;
-            margin-bottom: 40px;
-        }
 
         .nav-tabs.v-tabs .v-tabs-bar {
             background-color: transparent;

--- a/solution/ui/prototype/src/components/part/PartNav.vue
+++ b/solution/ui/prototype/src/components/part/PartNav.vue
@@ -1,7 +1,10 @@
 <template>
     <div class="part-nav-tabs" :class="partNavTabClasses">
         <div class="tabs-container">
-            <slot></slot>
+            <div class="scroll-info" :class="scrollInfoClasses">
+                <slot name="titlePart"></slot>
+            </div>
+            <slot name="tabs"></slot>
         </div>
     </div>
 </template>
@@ -24,13 +27,22 @@ export default {
         showHeader: {
             type: Boolean,
             default: true,
-        }
+        },
+        lastScrollPosition: {
+            type: Number,
+            default: 0,
+        },
     },
 
     computed: {
         partNavTabClasses() {
             return {
                 "top-header-hidden": !this.showHeader,
+            };
+        },
+        scrollInfoClasses() {
+            return {
+                "is-pinned": this.lastScrollPosition >= 280, // magic number for now
             };
         },
     },
@@ -69,8 +81,29 @@ $sidebar-top-margin: 40px;
     }
 
     .tabs-container {
+        display: flex;
         margin-left: 50px;
         max-width: $text-max-width;
+
+        .scroll-info {
+            display: none;
+            overflow: hidden;
+
+            &.is-pinned {
+                display: flex;
+                align-items: center;
+                width: fit-content;
+                padding-right: 20px;
+                margin-right: 20px;
+                border-right: 1px solid $light_gray;
+                font-size: 18px;
+                font-weight: 700;
+            }
+        }
+
+        .nav-tabs.v-tabs {
+            width: unset;
+        }
 
         .nav-tabs.v-tabs .v-tabs-bar {
             background-color: transparent;

--- a/solution/ui/prototype/src/router/index.js
+++ b/solution/ui/prototype/src/router/index.js
@@ -77,6 +77,7 @@ const router = new VueRouter({
                 offset: { x: 0, y: 80 },
             };
         }
+        return { x: 0, y: 0 };
     },
 });
 

--- a/solution/ui/prototype/src/router/index.js
+++ b/solution/ui/prototype/src/router/index.js
@@ -77,7 +77,6 @@ const router = new VueRouter({
                 offset: { x: 0, y: 80 },
             };
         }
-        return { x: 0, y: 0 };
     },
 });
 

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -109,6 +109,7 @@ import {
 } from "@/utilities/api";
 
 import _isEmpty from "lodash/isEmpty";
+import _throttle from "lodash/throttle";
 import _isUndefined from "lodash/isUndefined";
 
 export default {
@@ -552,7 +553,7 @@ export default {
 
             this.tabsShape.section.listItems = filteredSections;
         },
-        onScroll() {
+        onScroll: _throttle(function() {
             if (this.stickyMode === "hideOnScrollDown") {
                 const scrollPosition = window.scrollY;
                 const scrollDirection =
@@ -569,7 +570,7 @@ export default {
                     this.showHeader = true;
                 }
             }
-        },
+        }, 100),
     },
 
     watch: {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -8,39 +8,50 @@
                 :partLabel="partLabel"
                 resourcesDisplay="sidebar"
             />
-            <PartNav :stickyMode="stickyMode" :showHeader="showHeader">
-                <v-tabs
-                    slider-size="5"
-                    class="nav-tabs"
-                    v-model="tab"
-                    ref="tabs"
-                >
-                    <v-tab
-                        v-for="(item, key) in tabsShape"
-                        :key="item.label"
-                        :disabled="item.disabled"
+            <PartNav
+                :stickyMode="stickyMode"
+                :showHeader="showHeader"
+                :lastScrollPosition="lastScrollPosition"
+             >
+                <template v-slot:titlePart>
+                    <div>
+                        {{ title }} CFR Part {{ part }}
+                    </div>
+                </template>
+                <template v-slot:tabs>
+                    <v-tabs
+                        slider-size="5"
+                        class="nav-tabs"
+                        v-model="tab"
+                        ref="tabs"
                     >
-                        {{ tabLabels[key] }}
-                        <template
-                            v-if="
-                                item.value === 'subpart' ||
-                                item.value === 'section'
-                            "
+                        <v-tab
+                            v-for="(item, key) in tabsShape"
+                            :key="item.label"
+                            :disabled="item.disabled"
                         >
-                            <FancyDropdown
-                                label=""
-                                buttonTitle=""
-                                type="splitTab"
+                            {{ tabLabels[key] }}
+                            <template
+                                v-if="
+                                    item.value === 'subpart' ||
+                                    item.value === 'section'
+                                "
                             >
-                                <component
-                                    :is="item.listType"
-                                    :listItems="item.listItems"
-                                    :filterEmitter="setQueryParam"
-                                ></component>
-                            </FancyDropdown>
-                        </template>
-                    </v-tab>
-                </v-tabs>
+                                <FancyDropdown
+                                    label=""
+                                    buttonTitle=""
+                                    type="splitTab"
+                                >
+                                    <component
+                                        :is="item.listType"
+                                        :listItems="item.listItems"
+                                        :filterEmitter="setQueryParam"
+                                    ></component>
+                                </FancyDropdown>
+                            </template>
+                        </v-tab>
+                    </v-tabs>
+                </template>
             </PartNav>
             <div class="content-container content-container-sidebar">
                 <v-tabs-items v-model="tab" class="tab-content">

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -1,7 +1,7 @@
 <template>
     <body class="ds-base">
         <div id="app">
-            <Header />
+            <Header stickyMode="hideOnScrollDown" />
             <PartNav
                 :title="title"
                 :part="part"

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -8,6 +8,8 @@
                 :partLabel="partLabel"
                 resourcesDisplay="sidebar"
             >
+            </PartNav>
+            <div class="part-nav-tabs">
                 <v-tabs
                     slider-size="5"
                     class="nav-tabs"
@@ -40,7 +42,7 @@
                         </template>
                     </v-tab>
                 </v-tabs>
-            </PartNav>
+            </div>
             <div class="content-container content-container-sidebar">
                 <v-tabs-items v-model="tab" class="tab-content">
                     <v-tab-item


### PR DESCRIPTION
Resolves [EREGCSC-1386](https://jiraent.cms.gov/browse/EREGCSC-1386)

**Description:**
This work affects the TABS VIEW-SWITCHING concept.

If user is in Part view and scrolls down, the Global Header disappears.
If user scrolls back up, the Global Header appears.
If user scrolls below the light blue hero/nav stripe with the navigation tabs, the navigation tabs will stick to the top of the screen.  
If user scrolls up a bit, the navigation tabs will stick to the underside of the global header, which reappears on scroll up.

**This pull request changes:**

- Updates header component with stick modes to hide/unhide it when scrolling.
- Re-organizes PartNav component into two components:
   - PartHero that contains Part Number and Description
   - PartNav that contains the navigation tabs
- Makes PartNav sticky to top of page when scrolling down
- adds onScroll event listeners to Part view to determine scrollPosition and scrollDirection to inform when to show/hide global header and when to update sticky nav tabs.

**Steps to manually verify this change.*

1. Go to any part in the Prototype
2. Scroll up and down and notice the global header disappearing on scroll down and re-appearing on scroll up
3. Scroll up and down and notice the navigation tabs stick to top of screen when scrolling down deep into a part
4. Use navigation tabs to navigation to subparts and sections within the part, as well as the ToC
5. Compare styling and behavior to what is described in [Figma entry here](https://www.figma.com/file/OI3yDAbymYvHU3L7gTkhxR/eRegs-Multi-View-Nav-%26-View-Switching?node-id=2808%3A5290) (find View Switching Tabs > Interaction Details > Sticky Header)

