### PR TITLE
Fixing ECFR to use current instead of today's date

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -265,7 +265,6 @@ jobs:
           go-version: '^1.16' # The Go version to download (if necessary) and use.
       # deploy and run eCFR parser
       - name: deploy and run eCFR parser
-        continue-on-error: true
         id: deploy-run-ecfr-parser
         timeout-minutes: 20
         env:
@@ -281,7 +280,6 @@ jobs:
           popd
       # deploy and run Federal Register parser
       - name: deploy and run FR parser
-        continue-on-error: true
         id: deploy-run-fr-parser
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/solution/parser/ecfr-parser/ecfr/ecfr.go
+++ b/solution/parser/ecfr-parser/ecfr/ecfr.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/url"
 	"path"
-	
+
 	"github.com/cmsgov/cmcs-eregulations/ecfr-parser/network"
 )
 
@@ -16,7 +16,7 @@ var EcfrSite = "https://ecfr.gov/api/versioner/v1/"
 var (
 	ecfrFullXML       = "full/%s/title-%d.xml"
 	ecfrVersionsXML   = "versions/title-%d"
-	ecfrStructureJSON = "structure/%s/title-%d.json"
+	ecfrStructureJSON = "structure/current/title-%d.json"
 )
 
 // FetchFull fetches the full regulation from eCFR
@@ -30,12 +30,12 @@ func FetchFull(ctx context.Context, date string, title int, opts ...network.Fetc
 }
 
 // FetchStructure fetches the structure for a given title and options
-func FetchStructure(ctx context.Context, date string, title int, opts ...network.FetchOption) (io.Reader, int, error) {
+func FetchStructure(ctx context.Context, title int, opts ...network.FetchOption) (io.Reader, int, error) {
 	ecfrURL, err := url.Parse(EcfrSite)
 	if err != nil {
 		return nil, -1, err
 	}
-	ecfrURL.Path = path.Join(ecfrURL.Path, fmt.Sprintf(ecfrStructureJSON, date, title))
+	ecfrURL.Path = path.Join(ecfrURL.Path, fmt.Sprintf(ecfrStructureJSON, title))
 	return network.FetchWithOptions(ctx, ecfrURL, false, opts)
 }
 

--- a/solution/parser/ecfr-parser/ecfr/ecfr_test.go
+++ b/solution/parser/ecfr-parser/ecfr/ecfr_test.go
@@ -69,7 +69,7 @@ func TestFetchFunctions(t *testing.T) {
 		},
 		{
 			Name: "test-fetch-structure",
-			Path: "/" + fmt.Sprintf(ecfrStructureJSON, "2022-01-01", 42),
+			Path: "/" + fmt.Sprintf(ecfrStructureJSON, 42),
 			Function: func(ctx context.Context, opts ...network.FetchOption) (int, error) {
 				_, code, err := FetchStructure(ctx, "2022-01-01", 42, opts...)
 				return code, err

--- a/solution/parser/ecfr-parser/ecfr/ecfr_test.go
+++ b/solution/parser/ecfr-parser/ecfr/ecfr_test.go
@@ -71,7 +71,7 @@ func TestFetchFunctions(t *testing.T) {
 			Name: "test-fetch-structure",
 			Path: "/" + fmt.Sprintf(ecfrStructureJSON, 42),
 			Function: func(ctx context.Context, opts ...network.FetchOption) (int, error) {
-				_, code, err := FetchStructure(ctx, "2022-01-01", 42, opts...)
+				_, code, err := FetchStructure(ctx, 42, opts...)
 				return code, err
 			},
 		},

--- a/solution/parser/ecfr-parser/ecfr/structure.go
+++ b/solution/parser/ecfr-parser/ecfr/structure.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"html"
 	"strings"
-	"time"
 )
 
 // Structure is the struct that represents the structure of a regulation part at eCFR
@@ -76,7 +75,7 @@ func (is *IdentifierString) UnmarshalJSON(data []byte) error {
 }
 
 var (
-    // ErrUnexpectedStructure is an error for when the structure does not appear to be formatted correctly
+	// ErrUnexpectedStructure is an error for when the structure does not appear to be formatted correctly
 	ErrUnexpectedStructure = errors.New("the structure had an unexpected number of children")
 )
 
@@ -92,8 +91,8 @@ func SubchapterParts(s *Structure) ([]*Structure, error) {
 }
 
 // ExtractSubchapterParts extracts the subchapter parts from eCFR and returns then as an array of strings
-func ExtractSubchapterParts(ctx context.Context, date time.Time, title int, sub *SubchapterOption) ([]string, error) {
-	sbody, _, err := FetchStructure(ctx, date.Format("2006-01-02"), title, sub)
+func ExtractSubchapterParts(ctx context.Context, title int, sub *SubchapterOption) ([]string, error) {
+	sbody, _, err := FetchStructure(ctx, title, sub)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +120,7 @@ func DeterminePartDepth(s *Structure, part string) int {
 	for _, child := range s.Children {
 		depth := DeterminePartDepth(child, part)
 		if depth != -1 {
-			return depth+1
+			return depth + 1
 		}
 	}
 	return -1

--- a/solution/parser/ecfr-parser/ecfr/structure_test.go
+++ b/solution/parser/ecfr-parser/ecfr/structure_test.go
@@ -338,7 +338,7 @@ func TestExtractSubchapterParts(t *testing.T) {
 				Subchapter: "C",
 			}
 
-			out, err := ExtractSubchapterParts(ctx, time.Now(), 42, &subchapter)
+			out, err := ExtractSubchapterParts(ctx, 42, &subchapter)
 
 			diff := deep.Equal(out, tc.Expected)
 			if err != nil && !tc.Error {

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -92,10 +92,9 @@ func loadConfig() (*ecfrEregs.ParserConfig, error) {
 var extractSubchapterPartsFunc = ecfr.ExtractSubchapterParts
 
 func getPartsList(ctx context.Context, t *ecfrEregs.TitleConfig) []string {
-	today := time.Now()
 	var parts []string
 	for _, subchapter := range t.Subchapters {
-		subchapterParts, err := extractSubchapterPartsFunc(ctx, today, t.Title, &ecfr.SubchapterOption{subchapter[0], subchapter[1]})
+		subchapterParts, err := extractSubchapterPartsFunc(ctx, t.Title, &ecfr.SubchapterOption{subchapter[0], subchapter[1]})
 		if err != nil {
 			log.Error("[main] Failed to retrieve parts for title ", t.Title, " subchapter ", subchapter, ". Skipping.")
 			continue

--- a/solution/parser/fr-parser/main_test.go
+++ b/solution/parser/fr-parser/main_test.go
@@ -142,7 +142,7 @@ func TestGetPartsList(t *testing.T) {
 		Parts: ecfrEregs.PartList{"1", "2", "3"},
 	}
 
-	extractSubchapterPartsFunc = func(ctx context.Context, date time.Time, title int, sub *ecfr.SubchapterOption) ([]string, error) {
+	extractSubchapterPartsFunc = func(ctx context.Context, title int, sub *ecfr.SubchapterOption) ([]string, error) {
 		if sub.Chapter == "IV" && sub.Subchapter == "C" {
 			return []string{"4", "5", "6"}, nil
 		}


### PR DESCRIPTION
Resolves #

**Description-**

The ECFR parser has been failing because requesting today's date is no longer valid.  This will use "current" instead of the actual date.
**This pull request changes...**

- ECFR parser should work as normal

**Steps to manually verify this change...**

1. Github actions should all just work.

