### PR TITLE
EREGCSC-1421 -- Reduce potential confusion of zoom view sidebar

### DIFF
--- a/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
+++ b/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
@@ -19,7 +19,7 @@
 
         <v-expansion-panels>
             <v-expansion-panel>
-                <v-expansion-panel-header>
+                <v-expansion-panel-header disable-icon-rotate>
                     <span class="v-expansion-panel-header-text">Table of Contents</span>
                     <template v-slot:actions>
                         <v-icon color="black">
@@ -55,7 +55,7 @@ export default {
     props: {
         title: { type: String },
         part: { type: String },
-        subPart: { type: String },
+        subPart: { type: String, required: false, default: "" },
         section: { type: String },
         structure: { type: Array },
         tocContent: {type: Object},
@@ -96,6 +96,9 @@ export default {
   .v-expansion-panel{
     border: 3px solid #f3f3f3;
   }
+  .v-expansion-panel button {
+    padding: 0;
+  }
 
   .v-expansion-panel-header{
     background-color: #f3f3f3;
@@ -104,6 +107,11 @@ export default {
     font-size: 16px;
     line-height: 20px
   }
+
+  .v-expansion-panel-header__icon.v-expansion-panel-header__icon--disable-rotate i {
+    width: 40px;
+  }
+
   .v-expansion-panel-header-text{
     padding:18px;
   }

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -336,5 +336,3 @@ export default {
     },
 };
 </script>
-
-<style></style>

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -3,33 +3,23 @@
         <div id="app">
             <FlashBanner />
             <Header />
-            <splitpanes v-on:changeSection="updateSection($event)">
-                <pane min-size="30">
-                    <left-column
-                        :title="title"
-                        :part="part"
-                        :subPart="subPart"
-                        :section="section"
-                        :partLabel="partLabel"
-                        :structure="partContent"
-                        :tocContent="tocContent"
-                        :navigation="navigation"
-                        :supplementalContentCount="supplementalContentCount"
-                        @view-resources="setResourcesParams"
-                    />
-                </pane>
-                <pane min-size="30">
-                    <right-column
-                        :title="title"
-                        :part="part"
-                        :subPart="subPart"
-                        :section="section"
-                        :supList="supList"
-                        :suggestedTab="suggestedTab"
-                        :suggestedSubPart="suggestedSubPart"
-                    />
-                </pane>
-            </splitpanes>
+            <div class="content-container content-container-sidebar">
+                <LeftColumn
+                    :title="title"
+                    :part="part"
+                    :subPart="subPart"
+                    :section="section"
+                    :partLabel="partLabel"
+                    :structure="partContent"
+                    :tocContent="tocContent"
+                    :navigation="navigation"
+                    :supplementalContentCount="supplementalContentCount"
+                    @view-resources="setResourcesParams"
+                />
+                <div class="sidebar">
+                    <SectionResourcesSidebar :title="title" :part="part" />
+                </div>
+            </div>
             <Footer />
         </div>
     </body>
@@ -39,29 +29,24 @@
 import FlashBanner from "@/components/FlashBanner.vue";
 import Footer from "@/components/Footer.vue";
 import Header from "@/components/Header.vue";
-import { Splitpanes, Pane } from "splitpanes";
-import "splitpanes/dist/splitpanes.css";
 import LeftColumn from "@/components/PDPart/LeftColumn";
-import RightColumn from "@/components/PDPart/RightColumn";
+import SectionResourcesSidebar from "@/components/SectionResourcesSidebar.vue";
 import {
     getPart,
     getSubPartsForPart,
     getPartsList,
     getPartTOC,
-    getSectionsForSubPart,
     getSupplementalContentCountForPart,
-    getSupplementalContentNew
+    getSupplementalContentNew,
 } from "@/utilities/api";
 export default {
     name: "Part",
     components: {
-        RightColumn,
         LeftColumn,
         FlashBanner,
         Footer,
         Header,
-        Splitpanes,
-        Pane,
+        SectionResourcesSidebar,
     },
     watch: {
         "$route.params": {
@@ -89,7 +74,11 @@ export default {
                     this.subPartList = await getSubPartsForPart(this.part);
                     this.partsList = await getPartsList();
                     if (this.subPart) {
-                        this.sections = await this.getFormattedSectionsList({title: this.title, part: this.part, subpart: this.subPart.split('-')[1]});
+                        this.sections = await this.getFormattedSectionsList({
+                            title: this.title,
+                            part: this.part,
+                            subpart: this.subPart.split("-")[1],
+                        });
                     }
                     this.supplementalContentCount =
                         await getSupplementalContentCountForPart(this.part);
@@ -98,32 +87,41 @@ export default {
                         this.title,
                         this.part,
                         this.section ? [this.section] : this.renderedSections,
-                        this.subPart ? [this.subPart] : this.subPartList.map(sp => sp.identifier),
-                    )
-
+                        this.subPart
+                            ? [this.subPart]
+                            : this.subPartList.map((sp) => sp.identifier)
+                    );
                 } catch (error) {
                     console.error(error);
                 }
             },
             immediate: true,
         },
-        subPart:{
-            async handler(){
-                this.sections = await this.getFormattedSectionsList({title: this.title, part: this.part, subpart: this.subpart ? this.subPart.split('-')[1]: this.subpart});
-            }
-        }
+        subPart: {
+            async handler() {
+                this.sections = await this.getFormattedSectionsList({
+                    title: this.title,
+                    part: this.part,
+                    subpart: this.subpart
+                        ? this.subPart.split("-")[1]
+                        : this.subpart,
+                });
+            },
+        },
     },
-    async mounted(){
-      try {
-        this.supList = await getSupplementalContentNew(
-            this.title,
-            this.part,
-            this.section ? [this.section] : this.renderedSections,
-            this.subPart ? [this.subPart] : this.subPartList.map(sp => sp.identifier),
-        )
-      } catch (error) {
-          console.error(error);
-      }
+    async mounted() {
+        try {
+            this.supList = await getSupplementalContentNew(
+                this.title,
+                this.part,
+                this.section ? [this.section] : this.renderedSections,
+                this.subPart
+                    ? [this.subPart]
+                    : this.subPartList.map((sp) => sp.identifier)
+            );
+        } catch (error) {
+            console.error(error);
+        }
     },
     data() {
         return {
@@ -137,56 +135,68 @@ export default {
             partsList: [],
             sections: [],
             supplementalContentCount: {},
-            suggestedTab:"",
-            suggestedSubPart:"",
-            renderedSections: []
+            renderedSections: [],
         };
     },
-    async created(){
+    async created() {
         this.structure = await getPart(this.title, this.part);
     },
     computed: {
-        subpartContent(){
-            let subpart = this.subPart.split("-")[1]
-            return this.structure?.[1].filter(child =>
-                child.node_type === "SUBPART" && child.label[0] ===subpart
-          )
+        subpartContent() {
+            let subpart = this.subPart.split("-")[1];
+            return this.structure[1]
+                ? this.structure[1].filter(
+                      (child) =>
+                          child.node_type === "SUBPART" &&
+                          child.label[0] === subpart
+                  )
+                : [];
         },
-        sectionContent(){
-          if (this.subpartContent && this.subpartContent.length > 0){
-            const section = this.subpartContent[0].children.find(child =>
-                child.node_type === "SECTION" && child.label[1] === this.section
-            )
+        sectionContent() {
+            if (this.subpartContent && this.subpartContent.length > 0) {
+                const section = this.subpartContent[0].children.find(
+                    (child) =>
+                        child.node_type === "SECTION" &&
+                        child.label[1] === this.section
+                );
 
-            if (section){
-              return [section]
+                if (section) {
+                    return [section];
+                }
+
+                return [
+                    this.subpartContent[0].children
+                        .filter((child) => child.node_type === "SUBJGRP")
+                        .map((sg) => sg.children)
+                        .flat(1)
+                        .find(
+                            (child) =>
+                                child.node_type === "SECTION" &&
+                                child.label[1] === this.section
+                        ),
+                ];
             }
-
-            return [this.subpartContent[0].children.filter(child =>
-                child.node_type === "SUBJGRP"
-            ).map(sg => sg.children).flat(1)
-            .find(child =>
-                child.node_type === "SECTION" && child.label[1] === this.section
-            )]
-
-          }
-          return this.structure?.[1].filter(child =>
-              child.node_type === "SECTION" && child.label[1] === this.section
-          )
+            return this.structure?.[1].filter(
+                (child) =>
+                    child.node_type === "SECTION" &&
+                    child.label[1] === this.section
+            );
         },
         tocContent() {
             return this.structure?.[0];
         },
         partLabel() {
-            return this.structure?.[0] ? this.structure?.[0].label_description ?? "N/A" : null;
+            return this.structure?.[0]
+                ? this.structure?.[0].label_description ?? "N/A"
+                : null;
         },
-        
+
         partContent() {
-            if(this.subPart && !this.section){
-                return this.subpartContent
+            if (this.subPart && !this.section) {
+                return this.subpartContent;
             }
-            if(this.section){
-                return this.sectionContent
+            if (this.section) {
+                return this.sectionContent;
             }
 
             return this.structure?.[1] || [];
@@ -216,9 +226,9 @@ export default {
                         : null;
             } else if (this.subPart) {
                 results.name = "PDpart-subPart";
-                const currentIndex = this.subPartList.findIndex(
-                    sub => { return sub.identifier === this.subPart.split("-")[1]}
-                );
+                const currentIndex = this.subPartList.findIndex((sub) => {
+                    return sub.identifier === this.subPart.split("-")[1];
+                });
                 results.previous =
                     currentIndex > 0
                         ? {
@@ -262,15 +272,15 @@ export default {
     },
     methods: {
         async setResourcesParams(payload) {
-            if (payload["scope"] === "rendered"){
-              this.renderedSections.push(payload["identifier"])
-              return
+            if (payload["scope"] === "rendered") {
+                this.renderedSections.push(payload["identifier"]);
+                return;
             }
-            this.suggestedTab = payload["scope"]
+            this.suggestedTab = payload["scope"];
             // skip this for subparts
-            if (payload["scope"] === "subpart"){
-              this.suggestedSubPart = payload["identifier"]["subPart"]
-              return
+            if (payload["scope"] === "subpart") {
+                this.suggestedSubPart = payload["identifier"]["subPart"];
+                return;
             }
             try {
                 this.supList = await getSupplementalContentNew(
@@ -282,62 +292,49 @@ export default {
                 console.error(error);
             } finally {
                 console.log(this.supList);
-                this.suggestedTab = payload["scope"]
+                this.suggestedTab = payload["scope"];
             }
             // Implement response to user choosing a section or subpart here
         },
-        changeSection: function (updatedSection) {
-            this.sec = updatedSection;
-        },
-        async getFormattedSectionsList({title, part, subpart}) {
-
-            const toc = await getPartTOC(title, part)
+        async getFormattedSectionsList({ title, part, subpart }) {
+            const toc = await getPartTOC(title, part);
             const subParts = toc.children
-                .filter(child => child.type==="subpart")
-                .filter(subPart => subpart ? subPart.identifier[0] === subpart: true)
+                .filter((child) => child.type === "subpart")
+                .filter((subPart) =>
+                    subpart ? subPart.identifier[0] === subpart : true
+                );
 
-            let filteredSections = subParts.map( sp => sp.children.filter(child => child.type=== 'section'))
+            let filteredSections = subParts
+                .map((sp) =>
+                    sp.children.filter((child) => child.type === "section")
+                )
                 .flat(1)
-                .map(section =>(
-                     section.identifier[1]
-                ))
-            if (subpart === "Subpart-undefined"){
+                .map((section) => section.identifier[1]);
+            if (subpart === "Subpart-undefined") {
                 const orphanSections = toc.children
-                    .filter(child => child.type === "section")
-                    .map(section =>(section.identifier[1]
-                    ))
-                filteredSections = filteredSections.concat(orphanSections)
+                    .filter((child) => child.type === "section")
+                    .map((section) => section.identifier[1]);
+                filteredSections = filteredSections.concat(orphanSections);
             }
-            const subjectGroups = subParts.map( sp => sp.children.filter(child => child.type=== 'subject_group')).flat(1)
-            subjectGroups.forEach(subject_group => {
-                const subPart = subject_group.parent[0]
-                subject_group.children.forEach( section => {
-                    filteredSections.push( section.identifier[1])
-                })
-            })
-            filteredSections.sort((a,b) => Number(a) - Number(b))
+            const subjectGroups = subParts
+                .map((sp) =>
+                    sp.children.filter(
+                        (child) => child.type === "subject_group"
+                    )
+                )
+                .flat(1);
+            subjectGroups.forEach((subject_group) => {
+                const subPart = subject_group.parent[0];
+                subject_group.children.forEach((section) => {
+                    filteredSections.push(section.identifier[1]);
+                });
+            });
+            filteredSections.sort((a, b) => Number(a) - Number(b));
 
             return filteredSections;
         },
     },
-    
 };
 </script>
 
-<style>
-.splitpanes__pane {
-    justify-content: left;
-    align-items: flex-start;
-    display: flex;
-    position: -webkit-sticky;
-    position: sticky;
-    overflow: scroll;
-    height: calc(100vh - 124px);
-}
-
-.splitpanes--vertical > .splitpanes__splitter {
-    min-width: 6px;
-    background: #a3e8ff;
-}
-</style>
-
+<style></style>


### PR DESCRIPTION
Resolves [EREGCSC-1421](https://jiraent.cms.gov/browse/EREGCSC-1421)

**Description**
Makes Zoom concept right sidebar (the resources sidebar) match the Tab view concept.

> **Note**
> the right sidebar should NOT populate with any related resources at this time.  It should only display "Resources" as a title, and then a short paragraph blurb explaining resource links.

**This pull request changes**
- Removes moveable Panes from Zoom concept
- Adds right sidebar component from Tab view and matches its width
- Minor cleanup

**Steps to manually verify this change**

1. Visit prototype
2. Go to Tab part view in one tab and Zoom part view in other tab
3. Right sidebar should width and content should match in both concepts

