### PR TITLE
EREGCSC-1410 Selecting Subpart doesn't show all chips

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -340,7 +340,13 @@ export default {
             const sectionList = allSections
                 .filter((sec) => sec.type === "section")
                 .map((sec) => `${sec.identifier[0]}-${sec.identifier[1]}`);
-            return sectionList;
+            // subject groups are a bit lower down the tree, need to look there too.
+            const subjectGroupSections = allSections
+                .filter((sec) => sec.type === "subject_group")
+                .map(subjgrp => subjgrp.children
+                .map( sec => `${sec.identifier[0]}-${sec.identifier[1]}`))
+                .flat(1);
+            return sectionList.concat(subjectGroupSections).sort();
         },
         filterCategories(resultArray) {
             return resultArray.filter((item) =>


### PR DESCRIPTION
Resolves #EREGCSC-1410

**Description-**

**This pull request changes...**
Fixes search for sections within a subpart that has subject groups

**Steps to manually verify this change...**

go to the resources page
Choose Part 433
Select Subpart D
There should be 8 more chips than on production

