### PR TITLE
Eregcsc 1415 section navigation

### DIFF
--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -25,12 +25,15 @@ class HomepageView(TemplateView):
             return context
 
         full_structure = get_structure(parts)
+        # find the identifier for each part in the structure
+        titles = [part.structure['identifier'] for part in parts]
 
         c = {
             'structure': full_structure,
             'regulations': parts,
             'cfr_title_text': parts[0].structure['label_description'],
-            'cfr_title_number': parts[0].structure['identifier'],
+            # for now, the lowest numerical value for title is correct
+            'cfr_title_number': min(titles),
         }
 
         return {**context, **c}

--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -25,15 +25,12 @@ class HomepageView(TemplateView):
             return context
 
         full_structure = get_structure(parts)
-        # find the identifier for each part in the structure
-        titles = [part.structure['identifier'] for part in parts]
 
         c = {
             'structure': full_structure,
             'regulations': parts,
             'cfr_title_text': parts[0].structure['label_description'],
-            # for now, the lowest numerical value for title is correct
-            'cfr_title_number': min(titles),
+            'cfr_title_number': parts[0].structure['identifier'],
         }
 
         return {**context, **c}

--- a/solution/ui/prototype/src/components/JumpTo.vue
+++ b/solution/ui/prototype/src/components/JumpTo.vue
@@ -119,7 +119,8 @@ export default {
             )
             if (!orphans.length){
               // keep looking
-              subpart =  partToc.children.filter( child => child.type === "subpart")
+              // also, reserved subparts have no children or descendant range.
+              subpart =  partToc.children.filter( child => child.type === "subpart" && child.reserved === false)
               .find( sp =>
                   Number(sp.descendant_range[0].split(".")[1]) <= this.selectedSection
                   && Number(sp.descendant_range[1].split(".")[1]) >= this.selectedSection

--- a/solution/ui/prototype/src/components/JumpTo.vue
+++ b/solution/ui/prototype/src/components/JumpTo.vue
@@ -118,22 +118,24 @@ export default {
                   && child.identifier[1] === this.selectedSection
             )
             if (!orphans.length){
-              // keep looking
-              // also, reserved subparts have no children or descendant range.
-              subpart =  partToc.children.filter( child => child.type === "subpart" && child.reserved === false)
-              .find( sp =>
-                  Number(sp.descendant_range[0].split(".")[1]) <= this.selectedSection
-                  && Number(sp.descendant_range[1].split(".")[1]) >= this.selectedSection
-              )
+                // keep looking
+                // also, reserved subparts have no children or descendant range.
+                subpart =  partToc.children.filter( child => child.type === "subpart" && child.reserved === false)
+                .find( sp =>
+                    Number(sp.descendant_range[0].split(".")[1]) <= this.selectedSection
+                    && Number(sp.descendant_range[1].split(".")[1]) >= this.selectedSection
+                )
 
-              if (subpart){
-                  const flatSubpart = flattenSubpart(subpart)
-                  const section = flatSubpart.children.find(section => section.identifier[1] === this.selectedSection)
-                  subpart = flatSubpart.identifier[0]
-                  if (!section){
-                      this.selectedSection = undefined
-                  }
-              }
+                if (subpart){
+                    const flatSubpart = flattenSubpart(subpart)
+                    const section = flatSubpart.children.find(section => section.identifier[1] === this.selectedSection)
+                    subpart = flatSubpart.identifier[0]
+                    if (!section){
+                        this.selectedSection = undefined
+                    }
+                } else {
+                    this.selectedSection = undefined
+                }
 
             }
 

--- a/solution/ui/prototype/src/components/JumpTo.vue
+++ b/solution/ui/prototype/src/components/JumpTo.vue
@@ -123,7 +123,11 @@ export default {
                 subpart =  partToc.children.filter( child => child.type === "subpart" && child.reserved === false)
                 .find( sp =>
                     Number(sp.descendant_range[0].split(".")[1]) <= this.selectedSection
-                    && Number(sp.descendant_range[1].split(".")[1]) >= this.selectedSection
+                    && (sp.descendant_range.length > 1 ?
+                            Number(sp.descendant_range[1].split(".")[1]) >= this.selectedSection
+                        :
+                            true
+                        )
                 )
 
                 if (subpart){

--- a/solution/ui/prototype/src/utilities/api.js
+++ b/solution/ui/prototype/src/utilities/api.js
@@ -535,8 +535,6 @@ const getSubPartsForPart = async (partParam) => {
             range: s.descendant_range,
         };
     });
-    console.log('************************************************')
-    console.log(toReturn)
     return toReturn
 };
 

--- a/solution/ui/prototype/src/utilities/utils.js
+++ b/solution/ui/prototype/src/utilities/utils.js
@@ -456,6 +456,27 @@ function capitalizeFirstLetter(string) {
     return string[0].toUpperCase() + string.slice(1);
 }
 
+/**
+ *
+ * @param subpart {Object} - the TOC for a subpart
+ * @returns {Object} - The subpart, but with  sections in subject groups in children and not children of subject groups
+ *
+ */
+function flattenSubpart(subpart){
+    const result = JSON.parse(JSON.stringify(subpart))
+    const subjectGroupSections = subpart.children
+        .filter(child => child.type=== 'subject_group')
+        .map(subjgrp => subjgrp.children)
+        .flat(1)
+        .filter(child => child.type ==="section")
+
+
+    result.children = result.children
+        .concat(subjectGroupSections)
+        .filter(child => child.type ==="section")
+
+    return result
+}
 
 export {
     mapToArray,
@@ -487,5 +508,6 @@ export {
     getParagraphDepth,
     getDisplayName,
     getCategoryTree,
-    capitalizeFirstLetter
+    capitalizeFirstLetter,
+    flattenSubpart
 };

--- a/solution/ui/prototype/src/utilities/utils.js
+++ b/solution/ui/prototype/src/utilities/utils.js
@@ -466,8 +466,7 @@ function flattenSubpart(subpart){
     const result = JSON.parse(JSON.stringify(subpart))
     const subjectGroupSections = subpart.children
         .filter(child => child.type=== 'subject_group')
-        .map(subjgrp => subjgrp.children)
-        .flat(1)
+        .flatMap(subjgrp => subjgrp.children)
         .filter(child => child.type ==="section")
 
 

--- a/solution/ui/prototype/src/views/PDPart.vue
+++ b/solution/ui/prototype/src/views/PDPart.vue
@@ -167,8 +167,7 @@ export default {
                 return [
                     this.subpartContent[0].children
                         .filter((child) => child.node_type === "SUBJGRP")
-                        .map((sg) => sg.children)
-                        .flat(1)
+                        .flatMap((sg) => sg.children)
                         .find(
                             (child) =>
                                 child.node_type === "SECTION" &&
@@ -305,10 +304,9 @@ export default {
                 );
 
             let filteredSections = subParts
-                .map((sp) =>
+                .flatMap((sp) =>
                     sp.children.filter((child) => child.type === "section")
                 )
-                .flat(1)
                 .map((section) => section.identifier[1]);
             if (subpart === "Subpart-undefined") {
                 const orphanSections = toc.children
@@ -317,12 +315,11 @@ export default {
                 filteredSections = filteredSections.concat(orphanSections);
             }
             const subjectGroups = subParts
-                .map((sp) =>
+                .flatMap((sp) =>
                     sp.children.filter(
                         (child) => child.type === "subject_group"
                     )
                 )
-                .flat(1);
             subjectGroups.forEach((subject_group) => {
                 const subPart = subject_group.parent[0];
                 subject_group.children.forEach((section) => {

--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -356,8 +356,7 @@ export default {
                 return [
                     this.subpartContent[0].children
                         .filter((child) => child.node_type === "SUBJGRP")
-                        .map((sg) => sg.children)
-                        .flat(1)
+                        .flatMap((sg) => sg.children)
                         .find(
                             (child) =>
                                 child.node_type === "SECTION" &&
@@ -691,10 +690,9 @@ export default {
                 );
 
             let filteredSections = subParts
-                .map((sp) =>
+                .flatMap((sp) =>
                     sp.children.filter((child) => child.type === "section")
                 )
-                .flat(1)
                 .map((section) => ({
                     subpart: section.parent[0],
                     identifier: section.identifier[1],
@@ -715,12 +713,11 @@ export default {
                 filteredSections = filteredSections.concat(orphanSections);
             }
             const subjectGroups = subParts
-                .map((sp) =>
+                .flatMap((sp) =>
                     sp.children.filter(
                         (child) => child.type === "subject_group"
                     )
                 )
-                .flat(1);
             subjectGroups.forEach((subject_group) => {
                 const subPart = subject_group.parent[0];
                 subject_group.children.forEach((section) => {


### PR DESCRIPTION
Resolves #EREGCSC-1415

**Description-**

Allows for navigation to a specific section of a specific part in either title 42 or 45.  

**This pull request changes...**

- configures navigation from the jump to widget for either the zoom or tabbed regulation page

**Steps to manually verify this change...**
In both the zoom and tabbed view:
1. Navigate to:
    2. an orphan section (433.1)
    3. a "regular section"
    4. a section in a subgroup (433.152)
    5. a section AFTER a reserved subpart (438.600)
    6. an invalid section (Should show part view)
    7. a section that is too high (438.999)
    8. a section in a subpart without a descendant range (433.400)
NOTE: You should remain in your current view.  Using zoom should not take you to the tabbed version and vice versa.
