### PR TITLE
Fix for TOC.  Close when selected

### DIFF
--- a/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
+++ b/solution/ui/prototype/src/components/PDPart/LeftColumn.vue
@@ -17,7 +17,7 @@
             </span>
         </div>
 
-        <v-expansion-panels>
+        <v-expansion-panels v-model="panel">
             <v-expansion-panel>
                 <v-expansion-panel-header disable-icon-rotate>
                     <span class="v-expansion-panel-header-text">Table of Contents</span>
@@ -28,7 +28,7 @@
                     </template>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
-                    <PartToc :structure="tocContent" navName="PDpart" />
+                    <PartToc :structure="tocContent" navName="PDpart" @exitTOC="closeTOC" />
                 </v-expansion-panel-content>
             </v-expansion-panel>
         </v-expansion-panels>
@@ -63,6 +63,11 @@ export default {
         supplementalContentCount: { type: Object },
         partLabel: { type: String },
     },
+    data(){
+        return{
+            panel:[]
+        }
+    },
     methods: {
         setResourcesParams(payload) {
             let scope = payload["scope"];
@@ -73,6 +78,9 @@ export default {
                 identifier,
             });
         },
+        closeTOC(){
+            this.panel=[]
+        }
     },
 };
 </script>

--- a/solution/ui/prototype/src/components/part/PartToc.vue
+++ b/solution/ui/prototype/src/components/part/PartToc.vue
@@ -106,6 +106,7 @@ export default {
                 query,
             });
           }
+          this.$emit("exitTOC");
       }
     },
 }


### PR DESCRIPTION
Resolves # 1425

**Description-**

**This pull request changes...**

When a subpart or section is selected it will close the TOC

**Steps to manually verify this change...**

Go to  Part in the zoom view {host}/zoom/title/part

Expand TOC.  Click a subpart or section.
