### PR TITLE
remove opacity from tooltip and add arrow

### DIFF
--- a/solution/ui/prototype/src/components/node_types/Section.vue
+++ b/solution/ui/prototype/src/components/node_types/Section.vue
@@ -143,6 +143,7 @@ export default {
 
 .v-tooltip__content {
     box-shadow: rgba(0, 0, 0, 0.3) 0 2px 10px;
+    opacity: 1!important;
 }
 
 .tooltip-text {
@@ -151,5 +152,18 @@ export default {
 
     display: block !important;
     color: #212121;
+}
+.tooltip-text::after {
+    border-right: solid 5px transparent;
+    border-left: solid 5px transparent;
+    border-top: solid 5px #EEFAFE;
+    transform: translateX(-50%);
+    position: absolute;
+    z-index: -1;
+    content: "";
+    top: 100%;
+    left: 50%;
+    height: 0;
+    width: 0;
 }
 </style>


### PR DESCRIPTION
Resolves # 1399

**Description-**

Turn off opacity on the tool tip and add an arrow
**This pull request changes...**

- expected change 1

The tooltip on the zoom pages will have no opacity and will have an arrow on it.
**Steps to manually verify this change...**

1. steps to view and verify change

Go to any zoom view
hover over a link.
 A tooltip with an arrow will be on the tool tip