### PR TITLE
Zoom text clarifcation and fix subgroup hyperlinks

### DIFF
--- a/solution/ui/prototype/src/components/node_types/Section.vue
+++ b/solution/ui/prototype/src/components/node_types/Section.vue
@@ -5,7 +5,7 @@
                 class="supplemental-content-count">
                 {{ numSupplementalContent }}
             </button>
-            <router-link v-if="node.children && headerLinks" :to="{
+            <router-link v-if="node.children && headerLinks && !hideHyperlink" :to="{
                 name: 'PDpart-section',
                 params: { title: '42', part: this.node.label[0], subPart: this.formattedSubpart, section: this.node.label[1] }
             }">
@@ -13,7 +13,7 @@
                     <template v-slot:activator="{ on, attrs }">
                         <span v-bind="attrs" class="header-text" v-on="on">{{ node.title }}</span>
                     </template>
-                    <span class="tooltip-text">Click to zoom into the heading</span>
+                    <span class="tooltip-text">View § {{this.node.label[0]}}.{{this.node.label[1]}}</span>
                 </v-tooltip>
             </router-link>
             <span v-else>{{ node.title }}</span>
@@ -89,6 +89,9 @@ export default {
     computed: {
         kebabTitle() {
             return getKebabTitle(this.node.label);
+        },
+        hideHyperlink(){
+            return this.$route.name === "PDpart-section"
         },
         formattedSubpart() {
             if(this.subpart){

--- a/solution/ui/prototype/src/components/node_types/SubjectGroup.vue
+++ b/solution/ui/prototype/src/components/node_types/SubjectGroup.vue
@@ -12,6 +12,8 @@
                 :resource-params-emitter="resourceParamsEmitter"
                 :showResourceButtons="showResourceButtons"
                 :supplementalContentCount="supplementalContentCount"
+                :subpart="subpart"
+                :headerLinks="headerLinks"
             />
         </template>
     </div>
@@ -47,6 +49,15 @@ export default {
             required: false,
             default: () => {}
         },
+        subpart: {
+            type:String,
+            required: false
+        },
+        headerLinks:{
+            type: Boolean,
+            required: false,
+            default: false
+        }
     },
 
     computed: {

--- a/solution/ui/prototype/src/components/node_types/Subpart.vue
+++ b/solution/ui/prototype/src/components/node_types/Subpart.vue
@@ -5,7 +5,7 @@
                 class="supplemental-content-count">
                 {{ numSupplementalContent }}
             </button>
-            <span v-if="!headerLinks">{{node.title}}</span>
+            <span v-if="!headerLinks || hideHyperlink">{{node.title}}</span>
             <router-link v-else :to="{
                 name: 'PDpart-subPart',
                 params: { title: this.title, part: this.part, subPart: 'Subpart-' + this.node.label[0] }
@@ -14,7 +14,7 @@
                     <template v-slot:activator="{ on, attrs }">
                         <span v-bind="attrs" v-on="on">{{ node.title }}</span>
                     </template>
-                    <span class="tooltip-text">Click to zoom into the heading</span></v-tooltip>
+                    <span class="tooltip-text">View Subpart {{this.node.label[0]}}</span></v-tooltip>
             </router-link>
         </h1>
         <div v-if="showResourceButtons && numDirectContent" class="btn-container">
@@ -79,6 +79,9 @@ export default {
     computed: {
         kebabTitle() {
             return getKebabTitle(this.node.label);
+        },
+        hideHyperlink(){
+            return this.$route.name =='PDpart-subPart'
         },
         numSupplementalContent() {
             let total = 0


### PR DESCRIPTION
Resolves #

EREGCSC-1429
**Description-**

**This pull request changes...**

The tooltips to show what section or subpart is being clicked.

Remove hyperlink for the subpart or section its clicked in

Fix sections clickable under subject groups.

**Steps to manually verify this change...**

1. steps to view and verify change

Go to the zoom view.

Hover over a subpart and/or section.

The tooltip should say what section or subpart you are clicking.

click a subpart.

The subpart should not be clickable in the zoom view. 

Click a section.

The section should not be clickable

Go to a subcategory.  Sections should be clickable.