### PR TITLE
EREGCSC-1427 Fix Cypress tests for Title 45

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/jump_to.html
+++ b/solution/backend/regulations/templates/regulations/partials/jump_to.html
@@ -3,7 +3,7 @@
 
     <form method="GET" action="{% url 'goto' %}">
         <input name="{{ reg_part }}-version" type="hidden" required value="{{ version }}">
-        <input name="title" type="hidden" required value="{{ title }}">
+        <input name="title" type="hidden" required value="42">
 
         <div class="jump-to-input">
             § <select name="part" class="ds-c-field" aria-label="Regulation part number">


### PR DESCRIPTION
Resolves #1427

**Description-**

**This pull request changes...**

- on thehomepage, if you choose a section it currently assumes you want that section in title 45 if title 45 has been loaded.  This hard codes title 42 as a stop gap until we have a design that accomodates 45.

**Steps to manually verify this change...**

Us the navigation on the home page, it should still work as expected.  It should also work if Title 45 has been pulled from ECFR.

