### PR TITLE
EREGCSC-1438 Fixing section index bug when clicking on section first

### DIFF
--- a/solution/ui/prototype/src/views/Part.vue
+++ b/solution/ui/prototype/src/views/Part.vue
@@ -596,8 +596,6 @@ export default {
             let updatedQueryParams = {};
             // get associated subpart for section
             if (payload.scope == "section") {
-                const sections = this.tabsShape.section.listItems.map(sec => sec.identifier)
-                this.secIndex = sections.indexOf(valueToSet)
                 const sectionSubpart = this.tabsShape.section.listItems.find(
                     (item) => {
                         return item.identifier == valueToSet;
@@ -606,6 +604,10 @@ export default {
                 const subpartToSet = /^\d+$/.test(sectionSubpart)
                     ? {}
                     : { subpart: sectionSubpart };
+                    
+                const sections = this.tabsShape.section.listItems.filter(sec => sec.subpart ==sectionSubpart).map(sec => sec.identifier)
+                this.secIndex = sections.indexOf(valueToSet)
+
                 updatedQueryParams = {
                     ...this.queryParams,
                     ...subpartToSet,


### PR DESCRIPTION
Resolves #

**Description-**

Fixes bug when clicking on tab view section without a subpart selected.  Gets the index for the section after the subpart is determined



**Steps to manually verify this change...**

1. steps to view and verify change

Go to the tab view, and click a section.  The floating buttons on the bottom will reflect the appropriate sections before and after the sbupart
