### PR TITLE
EREGCSC-1290 Track Supplemental Content Links

### DIFF
--- a/solution/backend/regulations/templates/regulations/supplemental_content.html
+++ b/solution/backend/regulations/templates/regulations/supplemental_content.html
@@ -2,6 +2,15 @@
 
 <html>
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ID }}"></script>
+        <script>
+            window["ga-disable-{{ GA_ID }}"] = {{ AUTOMATED_TEST | yesno:"true,false" }};
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag("js", new Date());
+            gtag("config", "{{ GA_ID }}");
+        </script>
         <title>{{ title }}</title>
         <meta name="description" content="{{ description }}" />
         <meta property="og:title" content="{{ title }}" />

--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -149,7 +149,6 @@ class TypicalResourceFieldsSerializer(DateFieldSerializer):
         return reverse('supplemental_content', kwargs={'id': obj.pk})
 
 
-
 class SupplementalContentSerializer(AbstractResourceSerializer, TypicalResourceFieldsSerializer):
     name_headline = HeadlineField("supplementalcontent")
     description_headline = HeadlineField("supplementalcontent")

--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -1,3 +1,5 @@
+from django.urls import reverse
+
 from rest_framework import serializers
 
 from .models import (
@@ -141,6 +143,11 @@ class TypicalResourceFieldsSerializer(DateFieldSerializer):
     name = serializers.CharField()
     description = serializers.CharField()
     url = serializers.CharField()
+    internalURL = serializers.SerializerMethodField()
+
+    def get_internalURL(self, obj):
+        return reverse('supplemental_content', kwargs={'id': obj.pk})
+
 
 
 class SupplementalContentSerializer(AbstractResourceSerializer, TypicalResourceFieldsSerializer):

--- a/solution/ui/regulations/js/api.js
+++ b/solution/ui/regulations/js/api.js
@@ -390,7 +390,7 @@ const v3GetSupplementalContent = async (apiURL, {locations, locationDetails=fals
     const url = apiURL.replace('/v2/', '/v3/')
 
     return httpApiGetWithPagination(
-        `${url}resources?${locations}&paginate=true&location_details=${locationDetails}`,
+        `${url}resources/?${locations}&paginate=true&location_details=${locationDetails}`,
         {}, // params, default
         apiURL
     );

--- a/solution/ui/regulations/js/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContentList.vue
@@ -6,7 +6,7 @@
             :name="content.name"
             :description="content.description"
             :date="content.date"
-            :url="content.url"
+            :url="content.internalURL"
         >
         </supplemental-content-object>
         <collapse-button
@@ -40,7 +40,7 @@
                 :name="content.name"
                 :description="content.description"
                 :date="content.date"
-                :url="content.url"
+                :url="content.internalURL"
             >
             </supplemental-content-object>
             <collapse-button


### PR DESCRIPTION


Resolves #EREGCSC-1290

**Description-**

Points supplemental content links to an internal link so that we can notify google analytics of the click.

**This pull request changes...**

Adds internal URL to resource serializer
uses internal URL on the sidebar to track when a user clicks
Added google analytics to interstitial page for supplemental content links

**Steps to manually verify this change...**

Go to any subpart, click on any link in the sidebar.  It should be ".../supplemental_content/ID". 
Go the link above in view-source and confirm GA tag is shown.

