### PR TITLE
EREGCSC-1426 Include sections in subject groups in resources sidebar

### DIFF
--- a/solution/ui/regulations/js/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContent.vue
@@ -37,10 +37,9 @@ import SupplementalContentCategory from "./SupplementalContentCategory.vue";
 import {
     getSupplementalContentByCategory,
     v3GetSupplementalContent,
-    getSubPartsForPart,
     getSubpartTOC
 } from "../../api";
-import { EventCodes, formatResourceCategories } from "../../utils";
+import {EventCodes, flattenSubpart, formatResourceCategories} from "../../utils";
 
 function getDefaultCategories() {
     if (!document.getElementById("categories")) return [];
@@ -222,7 +221,8 @@ export default {
         },
         async get_location_string(){
             const sections = await getSubpartTOC(this.api_url, this.title, this.part, this.subparts[0])
-            this.joined_locations= sections.reduce((previousValue, section) =>  `${previousValue}locations=${this.title}.${this.part}.${section.identifier[1]}&`, "")+ `locations=${this.title}.${this.part}.${this.subparts[0]}`;
+            const flatSections = flattenSubpart({children: sections})
+            this.joined_locations = `${flatSections.children.reduce((previousValue, section) =>  `${previousValue}locations=${this.title}.${this.part}.${section.identifier[1]}&`, "") }locations=${this.title}.${this.part}.${this.subparts[0]}`;
         },
         clearSection() {
             console.log("Clearing Section");

--- a/solution/ui/regulations/js/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContentList.vue
@@ -6,7 +6,7 @@
             :name="content.name"
             :description="content.description"
             :date="content.date"
-            :url="content.internalURL"
+            :url="content.internalURL || content.url"
         >
         </supplemental-content-object>
         <collapse-button
@@ -40,7 +40,7 @@
                 :name="content.name"
                 :description="content.description"
                 :date="content.date"
-                :url="content.internalURL"
+                :url="content.internalURL || content.url"
             >
             </supplemental-content-object>
             <collapse-button

--- a/solution/ui/regulations/js/utils.js
+++ b/solution/ui/regulations/js/utils.js
@@ -97,9 +97,25 @@ const formatResourceCategories = (resources) => {
     return categories
 }
 
+function flattenSubpart(subpart){
+    const result = JSON.parse(JSON.stringify(subpart))
+    const subjectGroupSections = subpart.children
+        .filter(child => child.type=== 'subject_group')
+        .flatMap(subjgrp => subjgrp.children)
+        .filter(child => child.type ==="section")
+
+
+    result.children = result.children
+        .concat(subjectGroupSections)
+        .filter(child => child.type ==="section")
+
+    return result
+}
+
 export {
     delay,
     parseError,
     formatResourceCategories,
-    EventCodes
+    EventCodes,
+    flattenSubpart
 };


### PR DESCRIPTION
Resolves #EREGCSC-1426

**Description-**
Fixes a bug in the subpart resources section.  When subparts have sections in them that are in subject groups, the sections are not requested from the API
**This pull request changes...**

FIxes how the list of locations is determined when populating the resources sidebar

**Steps to manually verify this change...**

Go to 42.435 subpart J.  In the resources sidebar there should be over 100 resources.  Production has appx 5 currently.

