### PR TITLE
EREGCSC-1440 -- Load resources when loading linking to paragraph

### DIFF
--- a/solution/ui/regulations/js/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContent.vue
@@ -166,7 +166,11 @@ export default {
     created() {
         let location = ""
         if (window.location.hash) {
-            const section = window.location.hash.substring(1).replace("-", ".");
+            let section = window.location.hash.substring(1).replace("-", ".");
+            if (section.includes("-")) {
+                // eslint-prefer-destructuring, kinda cool
+                [section] = section.split("-");
+            }
             if (isNaN(section)) {
                 location = `locations=${this.title}.${this.part}.${section}`
             }


### PR DESCRIPTION
Resolves [EREGCSC-1440](https://jiraent.cms.gov/browse/EREGCSC-1440)

**Description**
When loading a link that has Part, Section, AND paragraph information in the location hash (e.g. `42/431/Subpart-A/2020-06-30/#431-12-a`), the resources in the resources sidebar do not load.

The expected behavior would be that the sidebar would load the resources for the containing section (e.g. Part 431 section 12).

**This pull request changes**

- Adds a condition that checks for paragraph information in location hash and strips it out of request for supplemental resources

**Steps to manually verify this change**

1. Load a link that has a hash containing paragraph information (e.g. `42/431/Subpart-A/2020-06-30/#431-12-a`)
2. Make sure the right sidebar loads resources related to the parent section
3. Compare against the same link in the prod site, which should not load the related resources in the right sidebar

