### PR TITLE
EREGCSC-1431 changing DB create process to make a clean DB without any data in it.

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -110,6 +110,7 @@ jobs:
           npm install
           serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
+          serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function populate_content --stage dev${PR}
           echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -110,8 +110,8 @@ jobs:
           npm install
           serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
-          serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
+          serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function populate_content --stage dev${PR}
           echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"
           popd

--- a/solution/backend/createdb.py
+++ b/solution/backend/createdb.py
@@ -18,7 +18,7 @@ def handler(event, context):
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'main'"
             )
             cursor.execute(
-                f"CREATE DATABASE {os.environ.get('STAGE')} WITH TEMPLATE main OWNER {os.environ.get('DB_USER')}"
+                f"CREATE DATABASE {os.environ.get('STAGE')} OWNER {os.environ.get('DB_USER')}"
             )
     except ProgrammingError:
         # The next step will tell us if this is a problem.

--- a/solution/backend/regcore/migrations/0002_parserconfiguration_titleconfiguration.py
+++ b/solution/backend/regcore/migrations/0002_parserconfiguration_titleconfiguration.py
@@ -17,6 +17,11 @@ def create_default_parser_config(apps, schema_editor):
             parts="400, 457, 460",
             parser_config=parser_config,
         )
+        TitleConfiguration.objects.create(
+            title=45,
+            parts="75, 95, 155",
+            parser_config=parser_config,
+        )
 
 
 class Migration(migrations.Migration):

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -93,6 +93,11 @@ functions:
     timeout: 300
     layers:
       - ${cf:cmcs-eregs-static-assets-${self:custom.stage}.PythonRequirementsLambdaLayerQualifiedArn}
+  create_su:
+    handler: createsu.handler
+    layers:
+      - ${cf:cmcs-eregs-static-assets-${self:custom.stage}.PythonRequirementsLambdaLayerQualifiedArn}
+    timeout: 300
 
 resources:
 


### PR DESCRIPTION
Resolves #EREGCSC-1431

**Description-**

A small refactor of our initial deployment process.  Instead of copying a reference DB, we simply create a new blank db and run migrations, create an admin, load fixtures, and then run the parser against.  This takes a bit more time than copying a premade database, but it allows us to change the fixtures easily and without breaking anything.

**This pull request changes...**

- Build process should create a new DB
- Parser should automatically pull in title 45 (75, 95, 155)

**Steps to manually verify this change...**
Check the build pipeline times
make sure admin login still works
agree that the time it all takes is not too egregious
