### PR TITLE
Message suggesting using quoted search for resource searching.

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -21,6 +21,10 @@
                         @click:append="executeSearch"
                         @click:clear="clearSearchQuery"
                     />
+                    <div class="search-suggestion" v-if="multiWordQuery">
+                        Didn't find what you were looking for? Try searching for
+                      <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
+                    </div>
                 </form>
             </ResourcesNav>
             <div
@@ -159,6 +163,9 @@ export default {
                 this.searchInputValue = value;
             },
         },
+        multiWordQuery() {
+          return this.searchQuery.split(" ").length > 1 && (this.searchQuery[0] !== '"' && this.searchQuery[this.searchQuery.length-1] !== '"' )
+        },
         filterParams() {
             return {
                 title: this.queryParams.title,
@@ -208,6 +215,16 @@ export default {
             this.$router.push({
                 name: "resources",
                 query: { ...this.filterParams },
+            });
+        },
+        doQuoteSearch(){
+            this.searchInputValue = `"${this.searchInputValue}"`
+            this.$router.push({
+                name: "resources",
+                query: {
+                    ...this.filterParams,
+                    q: `"${this.searchQuery}"`,
+                },
             });
         },
 
@@ -705,7 +722,12 @@ export default {
                 color: $mid_blue;
             }
         }
+        .search-suggestion{
+            margin-top: -50px;
+            margin-bottom: 50px;
+        }
     }
+
 }
 </style>
 


### PR DESCRIPTION
Resolves #EREGCSC1437

**Description-**
Adds some words to the resources page if the search term is more than one word (a space exists) and search is not quoted
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

Search for a single word - no message
Search for multiple words - see message
search for multiple words, but in quotes - no message
click on link in message, see search has quotes (results will probably change, but maybe not)

