### PR TITLE
removed auto escaping of URL because it breaks some URLs

### DIFF
--- a/solution/backend/regulations/templates/regulations/supplemental_content.html
+++ b/solution/backend/regulations/templates/regulations/supplemental_content.html
@@ -20,7 +20,7 @@
     </head>
     <body>
         <script type="text/javascript">
-            window.location = '{{ redirect_link }}';
+            window.location = '{% autoescape off %}{{ redirect_link }}{% endautoescape %}';
         </script>
     </body>
 </html>


### PR DESCRIPTION
Resolves #EREGCSC-1445
**Description-**

removes auto escape from redirect URL field

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

links such as http://localhost:8000/supplemental_content/447 should just work.  

I removed escaping which technically makes us less standards compliant (but more things work) so the following links which contain an & might be affected, but have been tested and found working.

http://localhost:8000/supplemental_content/1364
http://localhost:8000/supplemental_content/518
http://localhost:8000/supplemental_content/135
http://localhost:8000/supplemental_content/407
http://localhost:8000/supplemental_content/591
http://localhost:8000/supplemental_content/447
http://localhost:8000/supplemental_content/627
http://localhost:8000/supplemental_content/1296
http://localhost:8000/supplemental_content/272
http://localhost:8000/supplemental_content/777
http://localhost:8000/supplemental_content/1280
http://localhost:8000/supplemental_content/1279
http://localhost:8000/supplemental_content/552
http://localhost:8000/supplemental_content/1073
http://localhost:8000/supplemental_content/1341
http://localhost:8000/supplemental_content/1359
http://localhost:8000/supplemental_content/83
http://localhost:8000/supplemental_content/543

