### PR TITLE
EREGCSC-1335 Synonym message for search

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/utilities/api.js
+++ b/solution/ui/regulations/eregs-vite/src/utilities/api.js
@@ -832,7 +832,7 @@ const getSectionsForPart = async (title, part) => httpApiGetV3(`title/${title}/p
 
 const getSubpartTOC = async (title, part, subPart) => httpApiGetV3(`title/${title}/part/${part}/version/latest/subpart/${subPart}/toc`)
 
-
+const getSynonyms = async(query) => httpApiGetV3(`synonym/${query}`);
 /**
  *
  * @param part {string} - a regulation part
@@ -895,6 +895,7 @@ export {
     getTOC,
     getPartTOC,
     getSectionsForPart,
-    getSubpartTOC
+    getSubpartTOC,
+    getSynonyms
     // API Export Insertion Point (do not change this text, it is being used by hygen cli)
 };

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -21,11 +21,21 @@
                         @click:append="executeSearch"
                         @click:clear="clearSearchQuery"
                     />
-                    <div class="search-suggestion" v-if="multiWordQuery">
-                        Didn't find what you were looking for? Try searching for
-                      <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
+                    <div class="search-suggestion">
+                        <div v-if="multiWordQuery">
+                            Didn't find what you were looking for? Try searching for
+                            <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
+                        </div>
+                        <div class="synonyms" v-if="synonyms.length > 0"> 
+                            <span v-if="multiWordQuery">Or </span>Search for similar terms:
+                            <span v-bind:key=a v-for="a in synonyms">
+                                "<a @click="synonymLinks(a)">{{a}}</a>"
+                                <span v-if="synonyms[synonyms.length-1] != a">, </span>
+                            </span>
+                        </div>
                     </div>
                 </form>
+
             </ResourcesNav>
             <div
                 class="resources-content-container"
@@ -82,6 +92,7 @@ import {
     getPartTOC,
     getSectionsForPart,
     getSubpartTOC,
+    getSynonyms
 } from "../utilities/api";
 
 export default {
@@ -108,6 +119,7 @@ export default {
             partsLastUpdated: {},
             partDict: {},
             categories: [],
+            synonyms:[],
             resourcesDisplay:
                 this.$route.name === "resources-sidebar" ? "sidebar" : "column",
             filters: {
@@ -178,7 +190,7 @@ export default {
     },
 
     methods: {
-        executeSearch() {
+        async executeSearch() {
             const sectionRegex = /^\d{2,3}\.(\d{1,4})$/;
 
             if (sectionRegex.test(this.searchInputValue)) {
@@ -189,6 +201,7 @@ export default {
                 };
                 return this.updateFilters(payload);
             }
+            this.synonyms = await this.retrieveSynonyms(this.searchInputValue)
             this.$router.push({
                 name: "resources",
                 query: {
@@ -196,6 +209,17 @@ export default {
                     q: this.searchInputValue,
                 },
             });
+        },
+        async synonymLinks(synonym){
+            this.searchInputValue = synonym
+            this.synonyms  = await this.retrieveSynonyms(synonym)
+            this.$router.push({
+                name: "resources",
+                query: {
+                    ...this.filterParams,
+                    q: synonym
+                }
+            })
         },
         clearSelections() {
             this.partDict = {};
@@ -271,7 +295,11 @@ export default {
                 query: newQueryParams,
             });
         },
-
+        async retrieveSynonyms(query){
+            let synonyms = await getSynonyms(query)
+            synonyms = synonyms.map(word => word.synonyms.map(word => word.baseWord))[0]
+            return synonyms ? synonyms : []
+        },
         async updateFilters(payload) {
             let newQueryParams = { ...this.queryParams };
             const splitSection = payload.selectedIdentifier.split("-");

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -23,7 +23,7 @@
                         @click:append="executeSearch"
                         @click:clear="clearSearchQuery"
                     />
-                    <div class="search-suggestion">
+                    <div v-if="synonyms.length > 0 || multiWordQuery" class="search-suggestion">
                         <div v-if="multiWordQuery">
                             Didn't find what you were looking for? Try searching for
                             <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
@@ -209,7 +209,6 @@ export default {
     methods: {
         async executeSearch() {
             const sectionRegex = /^\d{2,3}\.(\d{1,4})$/;
-
             if (sectionRegex.test(this.searchInputValue)) {
                 const payload = {
                     scope: "section",
@@ -244,6 +243,7 @@ export default {
             await this.executeSearch()
         },
         clearSearchQuery() {
+            this.synonyms = []
             this.$router.push({
                 name: "resources",
                 query: {

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -29,7 +29,7 @@
                         <div class="synonyms" v-if="synonyms.length > 0"> 
                             <span v-if="multiWordQuery">Or </span>Search for similar terms:
                             <span v-bind:key=a v-for="a in synonyms">
-                                "<a @click="synonymLinks(a)">{{a}}</a>"
+                                <a @click="synonymLinks(a)">{{a}}</a>
                                 <span v-if="synonyms[synonyms.length-1] != a">, </span>
                             </span>
                         </div>
@@ -212,14 +212,7 @@ export default {
         },
         async synonymLinks(synonym){
             this.searchInputValue = synonym
-            this.synonyms  = await this.retrieveSynonyms(synonym)
-            this.$router.push({
-                name: "resources",
-                query: {
-                    ...this.filterParams,
-                    q: synonym
-                }
-            })
+            await this.executeSearch()
         },
         clearSelections() {
             this.partDict = {};


### PR DESCRIPTION
Resolves # 1335

Adds the search for synonym message for the resources page

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

Search for a word with a synonym.  example ELE

A message should appear  with "Search for similar terms: {{then the list of synonyms}} seperated by commas

Click on one of them.  It will update the search box and the list of synonyms.  If it is multiple words Didn't find what you were looking for? Try searching for will appear as well as "Or" befoe "Search for similar term:"
