### PR TITLE
EREGCSC-1447 -- Enable "sort by oldest" for resources search page

### DIFF
--- a/solution/backend/resources/v3views.py
+++ b/solution/backend/resources/v3views.py
@@ -231,7 +231,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
                               "search with quotes.", str, False),
         OpenApiQueryParameter("categories", "Limit results to only resources found within these categories. Use "
                               "\"&categories=X&categories=Y\" for multiple.", int, False),
-        OpenApiQueryParameter("sort", "Sort results by this field. Valid values are \"newest\" and \"relevance\". "
+        OpenApiQueryParameter("sort", "Sort results by this field. Valid values are \"newest\", \"oldest\", and \"relevance\". "
                               "Newest is the default, and relevance requires a search query.", str, False),
     ] + OptionalPaginationMixin.PARAMETERS + LocationFiltererMixin.PARAMETERS
 
@@ -322,6 +322,8 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         query = query.filter(rank__gte=0.2) if search_query else query
         if search_query and sort_method == "relevance":
             return query.distinct().order_by("-rank")
+        elif sort_method == "oldest":
+            return query.distinct().order_by(F("date_annotated").asc(nulls_last=True))
         else:
             return query.distinct().order_by(F("date_annotated").desc(nulls_last=True))
 

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -158,7 +158,9 @@ export default {
                 return `${base}/${title}/${part}/Subpart-${subpart_id}/${partDate}`;
             }
             const partObj = partsList.find((parts) => parts.name == part);
-            const subpart = partObj.sections[section_id];
+            const subpart = partObj?.sections?.[section_id];
+
+            console.log("subpart", subpart);
 
             // todo: Figure out which no subpart sections are invalid and which are orphans
             return subpart

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -160,8 +160,6 @@ export default {
             const partObj = partsList.find((parts) => parts.name == part);
             const subpart = partObj?.sections?.[section_id];
 
-            console.log("subpart", subpart);
-
             // todo: Figure out which no subpart sections are invalid and which are orphans
             return subpart
                 ? `${base}/${title}/${part}/Subpart-${subpart}/${partDate}#${part}-${section_id}`

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -19,22 +19,22 @@
                     >
                         <v-list class="sort-options-list">
                             <v-list-item-group
+                                v-model="sortOptions"
                                 class="sort-options-list-item-group"
                             >
-                                <v-list-item
-                                    data-value="newest"
-                                    class="sort-options-list-item"
-                                    @click="clickMethod"
+                                <template
+                                    v-for="(sortOption, index) in sortOptions"
                                 >
-                                    <span>Date (Newest)</span>
-                                </v-list-item>
-                                <v-list-item
-                                    data-value="relevance"
-                                    class="sort-options-list-item"
-                                    @click="clickMethod"
-                                >
-                                    <span>Relevance</span>
-                                </v-list-item>
+                                    <v-list-item
+                                        :key="sortOption.value + index"
+                                        :data-value="sortOption.value"
+                                        :disabled="sortOption.disabled"
+                                        :inactive="sortOption.disabled"
+                                        @click="clickMethod"
+                                    >
+                                        <span>{{ sortOption.label }}</span>
+                                    </v-list-item>
+                                </template>
                             </v-list-item-group>
                         </v-list>
                     </FancyDropdown>
@@ -126,7 +126,7 @@ import SearchEmptyState from "@/components/SearchEmptyState.vue";
 const SORT_METHODS = {
     newest: "Date (Newest)",
     oldest: "Date (Oldest)",
-    relevance: "relevance",
+    relevance: "Relevance",
 };
 
 export default {
@@ -203,12 +203,20 @@ export default {
         sortDisabled: {
             type: Boolean,
             required: false,
-            default: true,
+            default: false,
+        },
+        disabledSortOptions: {
+            type: Array,
+            required: false,
+            default() {
+                return [];
+            },
         },
     },
 
     data() {
         return {
+            activeSortMethod: this.sortMethod,
             base:
                 import.meta.env.VITE_ENV && import.meta.env.VITE_ENV !== "prod"
                     ? `/${import.meta.env.VITE_ENV}`
@@ -232,6 +240,13 @@ export default {
         sortMethodTitle() {
             return SORT_METHODS[this.sortMethod];
         },
+        sortOptions() {
+            return Object.keys(SORT_METHODS).map((key) => ({
+                label: SORT_METHODS[key],
+                value: key,
+                disabled: this.disabledSortOptions.includes(key),
+            }));
+        },
     },
 
     methods: {
@@ -247,13 +262,16 @@ export default {
     overflow: auto;
     width: 100%;
     margin-bottom: 30px;
+
     .results-content {
         max-width: $text-max-width;
         margin: 0 auto;
+
         .top-rule {
             border-top: 1px solid #dddddd;
             margin-bottom: 30px;
         }
+
         .results-count {
             font-size: 15px;
             font-weight: bold;
@@ -262,6 +280,7 @@ export default {
             justify-content: space-between;
             align-items: center;
         }
+
         .sort-control {
             display: flex;
             align-items: center;
@@ -277,8 +296,10 @@ export default {
                 }
             }
         }
+
         .category-labels {
             margin-bottom: 5px;
+
             .result-label {
                 font-size: 11px;
                 display: inline;
@@ -291,8 +312,10 @@ export default {
                 }
             }
         }
+
         .result-content-wrapper {
             margin-bottom: 20px;
+
             .supplemental-content a.supplemental-content-link {
                 .supplemental-content-date,
                 .supplemental-content-title,
@@ -301,14 +324,17 @@ export default {
                 }
             }
         }
+
         .related-sections {
             margin-bottom: 40px;
             font-size: 12px;
             color: $mid_gray;
+
             .related-sections-title {
                 font-weight: 600;
                 color: $dark_gray;
             }
+
             a {
                 text-decoration: none;
             }

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -71,6 +71,7 @@
                         :query="searchQuery"
                         :sortMethod="sortMethod"
                         :disabledSortOptions="disabledSortOptions"
+                        :sortDisabled="sortDisabled"
                         @sort="setSortMethod"
                     />
                 </div>
@@ -159,6 +160,7 @@ export default {
             },
             supplementalContent: [],
             searchInputValue: undefined,
+            sortDisabled: true,
         };
     },
 
@@ -686,6 +688,10 @@ export default {
         queryParams: {
             // beware, some yucky code ahead...
             async handler(newParams, oldParams) {
+                if (this.sortDisabled) {
+                    this.sortDisabled = false;
+                }
+
                 if (
                     _isEmpty(newParams.part) &&
                     _isEmpty(newParams.q) &&
@@ -738,6 +744,10 @@ export default {
                 this.queryParams.part,
                 this.queryParams.subpart
             );
+        }
+
+        if (!_isEmpty(this.queryParams)) {
+            this.sortDisabled = false;
         }
 
         this.getSupplementalContent(this.queryParams, this.searchQuery, this.sortMethod);

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -70,7 +70,7 @@
                         :partsLastUpdated="partsLastUpdated"
                         :query="searchQuery"
                         :sortMethod="sortMethod"
-                        :sortDisabled="sortDisabled"
+                        :disabledSortOptions="disabledSortOptions"
                         @sort="setSortMethod"
                     />
                 </div>
@@ -201,8 +201,8 @@ export default {
         sortMethod() {
             return this.queryParams.sort || "newest";
         },
-        sortDisabled() {
-            return _isEmpty(this.searchQuery);
+        disabledSortOptions() {
+            return _isEmpty(this.searchQuery) ? ["relevance"] : [];
         },
     },
 


### PR DESCRIPTION
Resolves [EREGCSC-1447](https://jiraent.cms.gov/browse/EREGCSC-1447)

**Description**
- null dates go to the end of the list
- newest first is the default when sorting by date, can choose oldest
- copy would be "Date (newest)" vs "Date (oldest)"

**This pull request changes**
- Updates `resources/v3views` to accept new `oldest` sort method
- Sort select on Resources page is always active now, as any results can be sorted by newest/oldest
- If there is no text `searchQuery`, the "Relevance" search option is disabled.  It becomes enabled when a search query is also used as a search paramter.

**Steps to manually verify this change**

1. On the resources page, I can search for a term like COVID and sort by oldest, and I see documents from 2020 at the top
