### PR TITLE
EREGCSC-1335 Added quotes around synonym search, adjusted size

### DIFF
--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -119,7 +119,7 @@ class AbstractResourcePolymorphicSerializer(PolymorphicSerializer):
     def get_serializer_map(self):
         return {
             SupplementalContent: ("supplemental_content", SupplementalContentSerializer),
-            FederalRegisterDocument: ("federal_register_doc", FederalRegisterDocumentSerializer),
+            FederalRegisterDocument: ("federal_register_doc", FederalRegisterDocumentSerializer),  
         }
 
 

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -241,7 +241,7 @@ export default {
             });
         },
         async synonymLinks(synonym){
-            this.searchInputValue = synonym
+            this.searchInputValue = `"${synonym}"`
             await this.executeSearch()
         },
         clearSearchQuery() {
@@ -250,16 +250,6 @@ export default {
                 name: "resources",
                 query: {
                     ...this.filterParams,
-                },
-            });
-        },
-        doQuoteSearch(){
-            this.searchInputValue = `"${this.searchInputValue}"`
-            this.$router.push({
-                name: "resources",
-                query: {
-                    ...this.filterParams,
-                    q: `"${this.searchQuery}"`,
                 },
             });
         },
@@ -318,8 +308,11 @@ export default {
             });
         },
         async retrieveSynonyms(query){
+            if(query.charAt(0) == '"' && query.charAt(query.length-1) == '"'){
+                query = query.slice(1,-1)
+            }
             let synonyms = await getSynonyms(query)
-            synonyms = synonyms.map(word => word.synonyms.map(word => word.baseWord))[0]
+            synonyms = synonyms.map(word => word.synonyms.filter(word=>word.isActive==true).map(word => word.baseWord))[0]
             return synonyms ? synonyms : []
         },
         async updateFilters(payload) {
@@ -493,7 +486,6 @@ export default {
 
         async getSupplementalContent(dataQueryParams, searchQuery, sortMethod) {
             this.isLoading = true;
-
             if (dataQueryParams.resourceCategory) {
                 this.categories = dataQueryParams.resourceCategory.split(",");
             } else {
@@ -736,6 +728,8 @@ export default {
 
         if (this.queryParams.q) {
             this.searchQuery = this.queryParams.q;
+            this.synonyms = await this.retrieveSynonyms(this.queryParams.q)
+            this.multiWordQuery()
         }
 
         if (this.queryParams.part) {
@@ -798,6 +792,7 @@ export default {
         .search-suggestion{
             margin-top: -50px;
             margin-bottom: 50px;
+            font-size: 14px;
         }
     }
 

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -29,7 +29,7 @@
                             <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
                         </div>
                         <div class="synonyms" v-if="synonyms.length > 0"> 
-                            <span v-if="multiWordQuery">Or </span>Search for similar terms:
+                            <span v-if="multiWordQuery">Or </span>search for similar terms:
                             <span v-bind:key=a v-for="a in synonyms">
                                 <a @click="synonymLinks(a)">{{a}}</a>
                                 <span v-if="synonyms[synonyms.length-1] != a">, </span>


### PR DESCRIPTION
Resolves #


**This pull request changes...**

Adds quotes on suggested synonyms when searching by them.    Adjust the font size for the synonym text as search.  Removes unactive synonyms

**Steps to manually verify this change...**

1. steps to view and verify change

Go to the resources page.

search for ele.

The synonym text should be font size 14.

Click one of the synonyms.  The search should update and be in quotations.

Go to the admin.  

Disable one of the synonyms for ele's active status.

Clear cache an redo the search.  

The one updated to not active should no longer dispaly.