### PR TITLE
EREGCSC-1457 Update representation of locations from 42 1.123 to 42 CFR 1.123

### DIFF
--- a/solution/backend/resources/models.py
+++ b/solution/backend/resources/models.py
@@ -138,7 +138,7 @@ class Subpart(AbstractLocation):
     subpart_id = models.CharField(max_length=12)
 
     def __str__(self):
-        return f'{self.title} {self.part} Subpart {self.subpart_id}'
+        return f'{self.title} CFR {self.part} Subpart {self.subpart_id}'
 
     class Meta:
         verbose_name = "Subpart"
@@ -151,7 +151,7 @@ class Section(AbstractLocation):
     parent = models.ForeignKey(AbstractLocation, null=True, blank=True, on_delete=models.SET_NULL, related_name="children")
 
     def __str__(self):
-        return f'{self.title} {self.part}.{self.section_id}'
+        return f'{self.title} CFR {self.part}.{self.section_id}'
 
     class Meta:
         verbose_name = "Section"


### PR DESCRIPTION
Resolves #1457

**Description-**

Needed for more accurately reflecting how our users conceptualize regulations.

**This pull request changes...**

- Calling `str()` on a Section model shows `<title> CFR <part>.<section`.
- Calling `str()` on a Subpart model shows `<title> CFR <part> Subpart <subpart>`.
- These changes are reflected in the admin panel and anywhere else that utilizes `str()`.

**Steps to manually verify this change...**

1. Visit the admin panel and click on add new Supplemental Content
2. Look at string representations of locations in the "Locations" widget, make sure they match the above format

