### PR TITLE
EREGCSC-1468 -- Fix last updated timestamp issues

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -80,6 +80,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
     'django.core.context_processors.request',
     'regulations.context_processors.site_config',
+    'regcore.context_processors.regcore_config',
 )
 
 ROOT_URLCONF = 'cmcs_regulations.urls'
@@ -108,6 +109,7 @@ TEMPLATES = [
                 "cmcs_regulations.context_processors.google_analytics",
                 "cmcs_regulations.context_processors.automated_testing",
                 'regulations.context_processors.site_config',
+                'regcore.context_processors.regcore_config',
             ),
         },
         "DIRS": [

--- a/solution/backend/regcore/context_processors.py
+++ b/solution/backend/regcore/context_processors.py
@@ -1,0 +1,9 @@
+from regcore.models import ECFRParserResult
+
+
+def regcore_config(request):
+    parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
+
+    return {
+        "parser_last_success": parserResult.end if parserResult else None,
+    }

--- a/solution/backend/regulations/templates/regulations/partials/footer.html
+++ b/solution/backend/regulations/templates/regulations/partials/footer.html
@@ -6,7 +6,6 @@
 {% load site_statistics %}
 {% load string_formatters %}
 
-{% last_updated as last_updated_var %}
 
 <div class="flexbox site-footer">
     <div class="footer-left match-sides">
@@ -24,12 +23,12 @@
         <p>Unless authorized by law to be binding, the guidance linked on this tool does not have the force and effect of law and is not meant to bind CMS or the public in any way, unless specifically incorporated into a contract. The guidance is intended only to provide clarity to the public regarding existing requirements under the law. This tool does not bind CMS or the public and creates no rights, obligations, or defenses, substantive or procedural, that are enforceable by any party in any manner.</p>
     </div>
     <div class="footer-right match-sides">
-        <h4 class="last-update-footer">Regulations up to date from <a href="https://www.ecfr.gov" target="_blank" class="external">eCFR</a> as of {{ last_updated_var|footer_date_formatter }}.</h4>
+        <h4 class="last-update-footer">Regulations up to date from <a href="https://www.ecfr.gov" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}.</h4>
       <div class="about-footer"><a href="{% url 'about' %}">About Medicaid &amp; CHIP eRegulations</a></div>
         <p>A federal government managed website by the Centers for Medicare &amp; Medicaid Services.</p>
     </div>
 </div>
 
 <div class="print-footer">
-    <em>Regulations up to date from <a href="https://www.ecfr.gov" target="_blank" class="external">eCFR</a> as of {{ last_updated_var|footer_date_formatter }}.</em>
+    <em>Regulations up to date from <a href="https://www.ecfr.gov" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}.</em>
 </div>

--- a/solution/backend/regulations/templates/regulations/partials/landing_default.html
+++ b/solution/backend/regulations/templates/regulations/partials/landing_default.html
@@ -1,6 +1,7 @@
 {% load render_nested %}
 {% load citation %}
 {% load url_formatters %}
+{% load string_formatters %}
 <h1>
     {% if toc.label_level %}
         <span>{{ toc.label_level }} - </span>
@@ -8,7 +9,7 @@
     {{ toc.label_description }}
 </h1>
 {% ecfr_part_url_formatter title reg_part as ecfr_part_url %}
-<p class="last-updated">{{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" class="external" target="_blank" rel="noopener noreferrer">eCFR</a> as of {{ last_updated|date:"M j, Y" }}; last amended {{ version_string }}.</p>
+<p class="last-updated">{{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" class="external" target="_blank" rel="noopener noreferrer">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}; last amended {{ version_string }}.</p>
 
 <section class="part-meta"><b>{{ authority.header }}</b> {{ authority.content }}</section>
 <section class="part-meta"><b>{{ source.header }}</b> {{ source.content | citation }}</section>

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load render_nested %}
 {% load url_formatters %}
+{% load string_formatters %}
 
 {% block pre_header %}
     <a class="ds-c-skip-nav" href="#main-content">Skip to main content</a>
@@ -18,7 +19,7 @@
             <main class="reg-text match-middle" id="main-content">
                 {% ecfr_part_url_formatter title reg_part as ecfr_part_url %}
                 <p class="up-to-date{{ subpart|yesno:" subpart," }}">
-                {{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" target="_blank" class="external">eCFR</a> as of {{last_updated|date:"M j, Y"}}{% if isLatestVersion %}<span class="latest-version">; last amended </span>{{ formattedLatestVersion }}{% endif %}.
+                {{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}{% if isLatestVersion %}<span class="latest-version">; last amended </span>{{ formattedLatestVersion }}{% endif %}.
                 </p>
                 {% include "regulations/partials/node_types/node.html" with resource_count=resource_count node=tree cfr_title=title citation=citation version=version %}
                 {% include "regulations/partials/navigation.html" %}

--- a/solution/backend/regulations/templatetags/string_formatters.py
+++ b/solution/backend/regulations/templatetags/string_formatters.py
@@ -67,9 +67,12 @@ def appendix_formatter(title, node_label):
 
 @register.filter
 @stringfilter
-def footer_date_formatter(footer_date):
-    new_date = datetime.strptime(footer_date, '%b %d, %Y')
-    return new_date.strftime('%b %-d, %Y')
+def parser_success_date_formatter(success_date):
+    if success_date == "None":
+        return "unknown date. Parser has not yet run"
+    else:
+        new_date = datetime.strptime(success_date, "%Y-%m-%d %H:%M:%S")
+        return new_date.strftime('%b %-d, %Y')
 
 
 @register.filter

--- a/solution/backend/regulations/templatetags/string_formatters.py
+++ b/solution/backend/regulations/templatetags/string_formatters.py
@@ -68,8 +68,8 @@ def appendix_formatter(title, node_label):
 @register.filter
 @stringfilter
 def parser_success_date_formatter(success_date):
-    if success_date == "None":
-        return "unknown date. Parser has not yet run"
+    if success_date == "None" or success_date == "":
+        return "an unknown date"
     else:
         new_date = datetime.strptime(success_date, "%Y-%m-%d %H:%M:%S")
         return new_date.strftime('%b %-d, %Y')

--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -3,7 +3,7 @@ import logging
 
 from django.views.generic.base import TemplateView
 
-from regcore.models import Part
+from regcore.models import Part, ECFRParserResult
 from .utils import get_structure
 
 
@@ -21,6 +21,7 @@ class HomepageView(TemplateView):
 
         today = date.today()
         parts = Part.objects.effective(today)
+        parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
         if not parts:
             return context
 
@@ -29,6 +30,7 @@ class HomepageView(TemplateView):
         c = {
             'structure': full_structure,
             'regulations': parts,
+            'parser_last_success': parserResult.end if parserResult else None,
             'cfr_title_text': parts[0].structure['label_description'],
             'cfr_title_number': parts[0].structure['identifier'],
         }

--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -3,7 +3,7 @@ import logging
 
 from django.views.generic.base import TemplateView
 
-from regcore.models import Part, ECFRParserResult
+from regcore.models import Part
 from .utils import get_structure
 
 
@@ -21,7 +21,6 @@ class HomepageView(TemplateView):
 
         today = date.today()
         parts = Part.objects.effective(today)
-        parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
         if not parts:
             return context
 
@@ -30,7 +29,6 @@ class HomepageView(TemplateView):
         c = {
             'structure': full_structure,
             'regulations': parts,
-            'parser_last_success': parserResult.end if parserResult else None,
             'cfr_title_text': parts[0].structure['label_description'],
             'cfr_title_number': parts[0].structure['identifier'],
         }

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -8,7 +8,7 @@ from django.http import Http404
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 
-from regcore.models import Part
+from regcore.models import Part, ECFRParserResult
 from resources.models import Category, SubCategory, AbstractLocation
 from regulations.views.mixins import CitationContextMixin
 from regulations.views.utils import find_subpart
@@ -38,6 +38,7 @@ class ReaderView(CitationContextMixin, TemplateView):
         version_info = self.get_version_info(reg_version, reg_title, reg_part)
 
         parts = Part.objects.filter(title=reg_title).effective(reg_version)
+        parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
         document = query.document
         toc = query.toc
         part_label = toc['label_description']
@@ -68,7 +69,8 @@ class ReaderView(CitationContextMixin, TemplateView):
             'categories':   categories,
             'sub_categories': sub_categories,
             'resource_count': resource_count,
-            'last_updated':   query.last_updated
+            'last_updated':   query.last_updated,
+            'parser_last_success': parserResult.end if parserResult else None,
         }
 
         end = datetime.now().timestamp()

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -8,7 +8,7 @@ from django.http import Http404
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 
-from regcore.models import Part, ECFRParserResult
+from regcore.models import Part
 from resources.models import Category, SubCategory, AbstractLocation
 from regulations.views.mixins import CitationContextMixin
 from regulations.views.utils import find_subpart
@@ -38,7 +38,6 @@ class ReaderView(CitationContextMixin, TemplateView):
         version_info = self.get_version_info(reg_version, reg_title, reg_part)
 
         parts = Part.objects.filter(title=reg_title).effective(reg_version)
-        parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
         document = query.document
         toc = query.toc
         part_label = toc['label_description']
@@ -69,8 +68,6 @@ class ReaderView(CitationContextMixin, TemplateView):
             'categories':   categories,
             'sub_categories': sub_categories,
             'resource_count': resource_count,
-            'last_updated':   query.last_updated,
-            'parser_last_success': parserResult.end if parserResult else None,
         }
 
         end = datetime.now().timestamp()

--- a/solution/backend/regulations/views/regulation_landing.py
+++ b/solution/backend/regulations/views/regulation_landing.py
@@ -3,7 +3,7 @@ from django.views.generic.base import TemplateView
 from django.http import Http404
 from datetime import date, datetime
 
-from regcore.models import Part
+from regcore.models import Part, ECFRParserResult
 
 
 class RegulationLandingView(TemplateView):
@@ -23,6 +23,7 @@ class RegulationLandingView(TemplateView):
             raise Http404
 
         parts = Part.objects.effective(date.today()).filter(title=title)
+        parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
         reg_version = current.date.isoformat()
         reg_version_string = datetime.strftime(current.date, "%b %-d, %Y")
         toc = current.toc
@@ -40,6 +41,7 @@ class RegulationLandingView(TemplateView):
             'part_label': part_label,
             'reg_part': reg_part, 'parts': parts,
             'last_updated': current.last_updated,
+            'parser_last_success': parserResult.end if parserResult else None,
             'authority': authority,
             'source': source,
             'editorial_note': editorial_note,

--- a/solution/backend/regulations/views/regulation_landing.py
+++ b/solution/backend/regulations/views/regulation_landing.py
@@ -3,7 +3,7 @@ from django.views.generic.base import TemplateView
 from django.http import Http404
 from datetime import date, datetime
 
-from regcore.models import Part, ECFRParserResult
+from regcore.models import Part
 
 
 class RegulationLandingView(TemplateView):
@@ -23,7 +23,6 @@ class RegulationLandingView(TemplateView):
             raise Http404
 
         parts = Part.objects.effective(date.today()).filter(title=title)
-        parserResult = ECFRParserResult.objects.filter(errors=0).order_by("-end").first()
         reg_version = current.date.isoformat()
         reg_version_string = datetime.strftime(current.date, "%b %-d, %Y")
         toc = current.toc
@@ -40,8 +39,6 @@ class RegulationLandingView(TemplateView):
             'part': reg_part,
             'part_label': part_label,
             'reg_part': reg_part, 'parts': parts,
-            'last_updated': current.last_updated,
-            'parser_last_success': parserResult.end if parserResult else None,
             'authority': authority,
             'source': source,
             'editorial_note': editorial_note,

--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -119,7 +119,7 @@ class AbstractResourcePolymorphicSerializer(PolymorphicSerializer):
     def get_serializer_map(self):
         return {
             SupplementalContent: ("supplemental_content", SupplementalContentSerializer),
-            FederalRegisterDocument: ("federal_register_doc", FederalRegisterDocumentSerializer),  
+            FederalRegisterDocument: ("federal_register_doc", FederalRegisterDocumentSerializer),
         }
 
 


### PR DESCRIPTION
Resolves [EREGCSC-1468](https://jiraent.cms.gov/browse/EREGCSC-1468)

**Description**
Fixes bug introduced in [EREGCSC-1176](https://jiraent.cms.gov/browse/EREGCSC-1176) where the "last updated from eCFR" date was not correct.

**This pull request changes:**
- removes `last_updated` variable from reader and regulation_landing views and their associated templates, since that is no longer trusted to be the date that the parser last ran
- adds a regcore context processor to query ECFRParserResult object, get date of most recent parser run that ended without an error, and inject that date as `parser_last_success` into the context of all templates
- updates templates to use `parser_last_success` date where needed to communicate the most recent error-free parser run
- refactors `footer_date_formatter` templatetag filter into `parser_success_date_formatter` with condition to handle `NoneType` and empty strings

**Steps to manually verify this change**

1. Visit [ecfr_parser_result](https://regulations-pilot.cms.gov/v3/ecfr_parser_result/42) API endpoint to see `end` date for most recent successful parser run
2. Visit any page in the [experimental deployment for this PR](https://jcyxph5gw5.execute-api.us-east-1.amazonaws.com/dev506) and make sure the date in the footer matches the `end` date above
3. Visit ToC view and Reader view for any Part and Subpart to make sure the "up to date from eCFR as of" date matches the `end` date from item 1 above