### PR TITLE
Fixing search message

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -29,7 +29,7 @@
                             <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
                         </div>
                         <div class="synonyms" v-if="synonyms.length > 0"> 
-                            <span v-if="multiWordQuery">Or </span>search for similar terms:
+                            <span v-if="multiWordQuery">Or s</span><span v-else>S</span>earch for similar terms:
                             <span v-bind:key=a v-for="a in synonyms">
                                 <a @click="synonymLinks(a)">{{a}}</a>
                                 <span v-if="synonyms[synonyms.length-1] != a">, </span>


### PR DESCRIPTION
Resolves #

**Description-**

**This pull request changes...**
Makes the "S" in search capitalize if there is multiword, otherwise its lower case
- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

Search for something like "Express Lane Eligibility".  The S in "Or search" should be lower case.  

Next search for ELE.  There should be no "Or" and the "S" should be lowercase.