### PR TITLE
EREGCSC-1295 -- Cypress API testing

### DIFF
--- a/solution/ui/e2e/cypress/integration/api.spec.js
+++ b/solution/ui/e2e/cypress/integration/api.spec.js
@@ -33,8 +33,8 @@ const API_ENDPOINTS_V3 = [
 ];
 
 describe("API testing", () => {
-    it("sends GET request and checks for a 200 response", () => {
-        cy.wrap(API_ENDPOINTS_V3).each((endpoint, i, array) => {
+    API_ENDPOINTS_V3.forEach(endpoint => {
+        it(`sends GET request to ${endpoint} and checks for a 200 response`, () => {
             cy.request(endpoint).as("request");
             cy.get("@request").then((response) => {
                 cy.log(`${endpoint} - ${response.status}`);

--- a/solution/ui/e2e/cypress/integration/api.spec.js
+++ b/solution/ui/e2e/cypress/integration/api.spec.js
@@ -1,0 +1,45 @@
+const TITLE = 42;
+const SUBPART = "A";
+const PART = 430;
+const SECTION = 10;
+const VERSION = "latest";
+const SYNONYM = "synonym";
+
+const API_ENDPOINTS_V3 = [
+    `/v3/ecfr_parser_result/${TITLE}`,
+    `/v3/resources/`,
+    `/v3/resources/categories`,
+    `/v3/resources/categories/tree`,
+    `/v3/resources/federal_register_docs`,
+    `/v3/resources/federal_register_docs/doc_numbers`,
+    `/v3/resources/locations`,
+    `/v3/resources/locations/sections`,
+    `/v3/resources/locations/subparts`,
+    `/v3/resources/supplemental_content`,
+    `/v3/synonym/${SYNONYM}`,
+    `/v3/title/${TITLE}`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/section/${SECTION}`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/sections`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/subpart/${SUBPART}`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/subpart/${SUBPART}/toc`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/subparts`,
+    `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/toc`,
+    `/v3/title/${TITLE}/part/${PART}/versions`,
+    `/v3/title/${TITLE}/parts`,
+    `/v3/title/${TITLE}/toc`,
+    `/v3/titles`,
+    `/v3/toc`,
+];
+
+describe("API testing", () => {
+    it("sends GET request and checks for a 200 response", () => {
+        cy.wrap(API_ENDPOINTS_V3).each((endpoint, i, array) => {
+            cy.request(endpoint).as("request");
+            cy.get("@request").then((response) => {
+                cy.log(`${endpoint} - ${response.status}`);
+                expect(response.status).to.eq(200);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Resolves [EREGCSC-1295](https://jiraent.cms.gov/browse/EREGCSC-1295)

**Description:**

First step towards adding automated API test suite to the project.

**This pull request changes:**

- Adds `api.spec.js` test suite to existing integration test folder
- hard-codes array of existing `v3` endpoints with some constant values (ex: `latest` for version date, part `430`, section `10`, etc) and iterates over them, making a request to each and expecting a `200` response
- number of tests equals number of API endpoints being tested
- `api.spec.js` runs as part of our existing integration test process -- i.e. it will run with existing integration tests during the testing step of the existing CI/CD pipeline.
- Can also be run locally by using existing test commands
   - `make test` in `solution` folder to run all integration tests locally
   - `npm run cypress:open` in `solution/ui/e2e` to open Cypress desktop and run tests interactively on demand
   - Note: the local instance of the app must be running for these tests to succeeed

**Steps to manually verify this change**

1. run `make test` or `npm run cypress:open` with app running locally to verify that all endpoints return `200`

