### PR TITLE
EREGCSC-1359 Correct FR parser handling of non-Title-42 SECTNOs

### DIFF
--- a/solution/parser/ecfr-parser/main.go
+++ b/solution/parser/ecfr-parser/main.go
@@ -60,7 +60,7 @@ func getLogLevel(l string) log.Level {
 	case "trace":
 		return log.TraceLevel
 	default:
-		log.Warn("[main] \"", config.LogLevel, "\" is an invalid log level, defaulting to \"warn\".")
+		log.Warn("[main] '", config.LogLevel, "' is an invalid log level, defaulting to 'warn'.")
 		return log.WarnLevel
 	}
 }

--- a/solution/parser/ecfr-parser/network/network_test.go
+++ b/solution/parser/ecfr-parser/network/network_test.go
@@ -80,7 +80,7 @@ func TestFetch(t *testing.T) {
 			defer tc.Server.Close()
 			testURL, err := url.Parse(tc.Server.URL)
 			if err != nil {
-				t.Errorf("error parsing url \"%s\": %+v", tc.Server.URL, err)
+				t.Errorf("error parsing url '%s': %+v", tc.Server.URL, err)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
@@ -271,7 +271,7 @@ func TestSendJSON(t *testing.T) {
 			defer tc.Server.Close()
 			testURL, err := url.Parse(tc.Server.URL)
 			if err != nil {
-				t.Errorf("error parsing url \"%s\": %+v", tc.Server.URL, err)
+				t.Errorf("error parsing url '%s': %+v", tc.Server.URL, err)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
@@ -394,7 +394,7 @@ func TestFetchWithOptions(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			testURL, err := url.Parse(server.URL)
 			if err != nil {
-				t.Errorf("error parsing url \"%s\": %+v", server.URL, err)
+				t.Errorf("error parsing url '%s': %+v", server.URL, err)
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()

--- a/solution/parser/fr-parser/eregs/eregs.go
+++ b/solution/parser/fr-parser/eregs/eregs.go
@@ -65,13 +65,19 @@ func SendDocument(ctx context.Context, doc *FRDoc) error {
 }
 
 // CreateSections takes a list of strings and converts it to proper section identifiers
-func CreateSections(title string, s []string) []*Section {
+func CreateSections(s []string, pm map[string]string) []*Section {
 	var sections []*Section
 
 	for _, section := range s {
 		sp := strings.Split(section, ".")
 		if len(sp) != 2 || sp[0] == "" || sp[1] == "" {
 			log.Warn("[eregs] Section identifier ", section, " is invalid.")
+			continue
+		}
+
+		title, exists := pm[sp[0]]
+		if !exists {
+			log.Warn("[eregs] Section identifier ", section, " has no matching title.")
 			continue
 		}
 

--- a/solution/parser/fr-parser/eregs/eregs.go
+++ b/solution/parser/fr-parser/eregs/eregs.go
@@ -51,7 +51,7 @@ type FRDoc struct {
 func SendDocument(ctx context.Context, doc *FRDoc) error {
 	eregsURL, err := url.Parse(BaseURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse eRegs URL \"%s\": %+v", BaseURL, err)
+		return fmt.Errorf("failed to parse eRegs URL '%s': %+v", BaseURL, err)
 	}
 	eregsURL.Path = path.Join(eregsURL.Path, DocumentURL)
 	code, err := network.SendJSON(ctx, eregsURL, doc, true, postAuth, network.HTTPPut)
@@ -97,7 +97,7 @@ func CreateSections(s []string, pm map[string]string) []*Section {
 func FetchDocumentList(ctx context.Context) ([]string, error) {
 	eregsURL, err := url.Parse(BaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse eRegs URL \"%s\": %+v", BaseURL, err)
+		return nil, fmt.Errorf("failed to parse eRegs URL '%s': %+v", BaseURL, err)
 	}
 	eregsURL.Path = path.Join(eregsURL.Path, DocListURL)
 

--- a/solution/parser/fr-parser/eregs/eregs_test.go
+++ b/solution/parser/fr-parser/eregs/eregs_test.go
@@ -104,7 +104,7 @@ func TestSendDocument(t *testing.T) {
 }
 
 func TestCreateSections(t *testing.T) {
-	input := []string{
+	sections := []string{
 		"443.42",
 		"1.1",
 		"443.",
@@ -114,6 +114,11 @@ func TestCreateSections(t *testing.T) {
 		"123.45",
 	}
 
+	partMap := map[string]string{
+		"443": "42",
+		"123": "45",
+	}
+
 	expected := []*Section{
 		&Section{
 			Title:   "42",
@@ -121,18 +126,13 @@ func TestCreateSections(t *testing.T) {
 			Section: "42",
 		},
 		&Section{
-			Title:   "42",
-			Part:    "1",
-			Section: "1",
-		},
-		&Section{
-			Title:   "42",
+			Title:   "45",
 			Part:    "123",
 			Section: "45",
 		},
 	}
 
-	output := CreateSections("42", input)
+	output := CreateSections(sections, partMap)
 	if diff := deep.Equal(expected, output); diff != nil {
 		t.Errorf("output not as expected: %+v", diff)
 	}

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -90,7 +90,7 @@ type XMLQuery struct {
 
 // FetchSections pulls the full document from the Federal Register and extracts all SECTNO tags
 // Returns a list of sections and a map of parts => titles
-func FetchSections(ctx context.Context, path string) ([]string, map[string]string, error) {
+func FetchSections(ctx context.Context, path string, titles map[string]struct{}) ([]string, map[string]string, error) {
 	reader, err := fetch(ctx, path)
 	if err != nil {
 		return nil, nil, err
@@ -120,7 +120,7 @@ func FetchSections(ctx context.Context, path string) ([]string, map[string]strin
 					title, parts, err := extractCFR(l.Loc)
 					if err != nil {
 						log.Warn("[fedreg] failed to extract CFR information from '", l.Loc, "': ", err)
-					} else {
+					} else if _, exists := titles[title]; exists {
 						for _, part := range parts {
 							if _, exists := cfrs[part]; !exists {
 								cfrs[part] = title

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -96,7 +96,7 @@ func FetchSections(ctx context.Context, path string) ([]string, map[string]strin
 		return nil, nil, err
 	}
 
-	var cfrs map[string]string
+	cfrs := make(map[string]string)
 	var sections []string
 
 	d := xml.NewDecoder(reader)
@@ -162,11 +162,6 @@ func extractCFR(input string) (string, []string, error) {
 	title := split[0]
 	if !regexp.MustCompile(`\d+`).MatchString(title) {
 		return "", nil, fmt.Errorf("title \"%s\" is not a valid title", title)
-	}
-
-	// extract parts
-	if len(split) < 2 {
-		return "", nil, fmt.Errorf("the CFR string contains a title but no parts")
 	}
 	
 	for _, p := range split[1:] {

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -163,7 +163,7 @@ func extractCFR(input string) (string, []string, error) {
 	if !regexp.MustCompile(`\d+`).MatchString(title) {
 		return "", nil, fmt.Errorf("title '%s' is not a valid title", title)
 	}
-	
+
 	for _, p := range split[1:] {
 		part := strings.Trim(strings.TrimSpace(p), ".,;:")
 		if regexp.MustCompile(`\d+`).MatchString(part) {

--- a/solution/parser/fr-parser/fedreg/fedreg.go
+++ b/solution/parser/fr-parser/fedreg/fedreg.go
@@ -119,7 +119,7 @@ func FetchSections(ctx context.Context, path string) ([]string, map[string]strin
 					// extract CFR information and put it in the CFR table
 					title, parts, err := extractCFR(l.Loc)
 					if err != nil {
-						log.Warn("[fedreg] failed to extract CFR information from \"", l.Loc, "\": ", err)
+						log.Warn("[fedreg] failed to extract CFR information from '", l.Loc, "': ", err)
 					} else {
 						for _, part := range parts {
 							if _, exists := cfrs[part]; !exists {
@@ -161,7 +161,7 @@ func extractCFR(input string) (string, []string, error) {
 	//extract title
 	title := split[0]
 	if !regexp.MustCompile(`\d+`).MatchString(title) {
-		return "", nil, fmt.Errorf("title \"%s\" is not a valid title", title)
+		return "", nil, fmt.Errorf("title '%s' is not a valid title", title)
 	}
 	
 	for _, p := range split[1:] {

--- a/solution/parser/fr-parser/fedreg/fedreg_test.go
+++ b/solution/parser/fr-parser/fedreg/fedreg_test.go
@@ -285,8 +285,8 @@ func TestFetchSections(t *testing.T) {
 	testTable := []struct {
 		Name     string
 		InputXML []byte
-		Sections   []string
-		PartMap map[string]string
+		Sections []string
+		PartMap  map[string]string
 		Error    bool
 	}{
 		{
@@ -325,9 +325,9 @@ func TestFetchSections(t *testing.T) {
 				"440": "42",
 				"457": "42",
 				"460": "42",
-				"41": "45",
+				"41":  "45",
 			},
-			Error:  false,
+			Error: false,
 		},
 		{
 			Name: "test-bad-xml",
@@ -349,8 +349,8 @@ func TestFetchSections(t *testing.T) {
 				</PRORULE>
 			`),
 			Sections: nil,
-			PartMap: nil,
-			Error:  true,
+			PartMap:  nil,
+			Error:    true,
 		},
 		{
 			Name: "test-bad-sectno",
@@ -372,8 +372,8 @@ func TestFetchSections(t *testing.T) {
 				</PRORULE>
 			`),
 			Sections: nil,
-			PartMap: nil,
-			Error:  true,
+			PartMap:  nil,
+			Error:    true,
 		},
 	}
 
@@ -459,53 +459,53 @@ func TestExtractSection(t *testing.T) {
 
 func TestExtractCFR(t *testing.T) {
 	testTable := []struct {
-		Name   string
-		Input  string
+		Name  string
+		Input string
 		Title string
 		Parts []string
-		Error  bool
+		Error bool
 	}{
 		{
-			Name:   "test-multi-part",
-			Input:  "45 CFR Parts 80, 84, 86, 91, 92, 147, 155, and 156",
+			Name:  "test-multi-part",
+			Input: "45 CFR Parts 80, 84, 86, 91, 92, 147, 155, and 156",
 			Title: "45",
 			Parts: []string{"80", "84", "86", "91", "92", "147", "155", "156"},
-			Error:  false,
+			Error: false,
 		},
 		{
-			Name:   "test-single-part",
-			Input:  "42 CFR Part 438.",
+			Name:  "test-single-part",
+			Input: "42 CFR Part 438.",
 			Title: "42",
 			Parts: []string{"438"},
-			Error:  false,
+			Error: false,
 		},
 		{
-			Name:   "test-no-parts",
-			Input:  "42 CFR Part",
+			Name:  "test-no-parts",
+			Input: "42 CFR Part",
 			Title: "",
 			Parts: nil,
-			Error:  true,
+			Error: true,
 		},
 		{
-			Name:   "test-empty-string",
-			Input:  "   ",
+			Name:  "test-empty-string",
+			Input: "   ",
 			Title: "",
 			Parts: nil,
-			Error:  true,
+			Error: true,
 		},
 		{
-			Name:   "test-invalid-title",
-			Input:  "blah CFR Part 438.",
+			Name:  "test-invalid-title",
+			Input: "blah CFR Part 438.",
 			Title: "",
 			Parts: nil,
-			Error:  true,
+			Error: true,
 		},
 		{
-			Name:   "test-title-only",
-			Input:  "42",
+			Name:  "test-title-only",
+			Input: "42",
 			Title: "",
 			Parts: nil,
-			Error:  true,
+			Error: true,
 		},
 	}
 

--- a/solution/parser/fr-parser/fedreg/fedreg_test.go
+++ b/solution/parser/fr-parser/fedreg/fedreg_test.go
@@ -296,28 +296,36 @@ func TestFetchSections(t *testing.T) {
 					<PREAMB>
 						<SUBAGY>Centers for Medicare &amp; Medicaid Services</SUBAGY>
 						<CFR>42 CFR Parts 438, 440, 457, and 460</CFR>
+						<CFR>45 CFR Parts 41.</CFR>
+						<CFR>47 CFR Parts 123</CFR>
 					</PREAMB>
 					<TEST>Some data</TEST>
 					<SUPLINF>
 						<SECTION>
-							<SECTNO>§ 447.502 </SECTNO>
+							<SECTNO>§ 438.502 </SECTNO>
 							<SUBJECT>Definitions.</SUBJECT>
 							<STARS/>
 						</SECTION>
 						<SECTION>
-							<SECTNO>§ 33.118 </SECTNO>
+							<SECTNO>§ 41.118 </SECTNO>
 							<SUBJECT>abc xyz...</SUBJECT>
+							<STARS/>
+						</SECTION>
+						<SECTION>
+							<SECTNO>§ 123.1418 </SECTNO>
+							<SUBJECT>abc xyz asdfasdf...</SUBJECT>
 							<STARS/>
 						</SECTION>
 					</SUPLINF>
 				</PRORULE>
 			`),
-			Sections: []string{"447.502", "33.118"},
+			Sections: []string{"438.502", "41.118", "123.1418"},
 			PartMap: map[string]string{
 				"438": "42",
 				"440": "42",
 				"457": "42",
 				"460": "42",
+				"41": "45",
 			},
 			Error:  false,
 		},
@@ -369,6 +377,11 @@ func TestFetchSections(t *testing.T) {
 		},
 	}
 
+	titleMap := map[string]struct{}{
+		"42": struct{}{},
+		"45": struct{}{},
+	}
+
 	for _, tc := range testTable {
 		t.Run(tc.Name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -380,7 +393,7 @@ func TestFetchSections(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
-			sections, partMap, err := FetchSections(ctx, server.URL)
+			sections, partMap, err := FetchSections(ctx, server.URL, titleMap)
 			if err != nil && !tc.Error {
 				t.Errorf("expected no error, received (%+v)", err)
 			} else if err == nil && tc.Error {

--- a/solution/parser/fr-parser/fedreg/fedreg_test.go
+++ b/solution/parser/fr-parser/fedreg/fedreg_test.go
@@ -425,3 +425,64 @@ func TestExtractSection(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractCFR(t *testing.T) {
+	testTable := []struct {
+		Name   string
+		Input  string
+		Title string
+		Parts []string
+		Error  bool
+	}{
+		{
+			Name:   "test-multi-part",
+			Input:  "45 CFR Parts 80, 84, 86, 91, 92, 147, 155, and 156",
+			Title: "45",
+			Parts: []string{"80", "84", "86", "91", "92", "147", "155", "156"},
+			Error:  false,
+		},
+		{
+			Name:   "test-single-part",
+			Input:  "42 CFR Part 438.",
+			Title: "42",
+			Parts: []string{"438"},
+			Error:  false,
+		},
+		{
+			Name:   "test-no-parts",
+			Input:  "42 CFR Part",
+			Title: "",
+			Parts: nil,
+			Error:  true,
+		},
+		{
+			Name:   "test-empty-string",
+			Input:  "   ",
+			Title: "",
+			Parts: nil,
+			Error:  true,
+		},
+		{
+			Name:   "test-invalid-title",
+			Input:  "blah CFR Part 438.",
+			Title: "",
+			Parts: nil,
+			Error:  true,
+		},
+	}
+
+	for _, tc := range testTable {
+		t.Run(tc.Name, func(t *testing.T) {
+			title, parts, err := extractCFR(tc.Input)
+			if err != nil && !tc.Error {
+				t.Errorf("expected no error, received (%+v)", err)
+			} else if err == nil && tc.Error {
+				t.Errorf("expected error, received title (%s) parts (%+v)", title, parts)
+			} else if title != tc.Title {
+				t.Errorf("expected title (%s), received title (%s)", tc.Title, title)
+			} else if diff := deep.Equal(parts, tc.Parts); diff != nil {
+				t.Errorf("output not as expected: (%+v)", diff)
+			}
+		})
+	}
+}

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -68,7 +68,7 @@ func getLogLevel(l string) log.Level {
 	case "trace":
 		return log.TraceLevel
 	default:
-		log.Warn("[main] \"", l, "\" is an invalid log level, defaulting to \"warn\".")
+		log.Warn("[main] '", l, "' is an invalid log level, defaulting to 'warn'.")
 		return log.WarnLevel
 	}
 }

--- a/solution/parser/fr-parser/main.go
+++ b/solution/parser/fr-parser/main.go
@@ -195,11 +195,11 @@ func processDocument(ctx context.Context, title int, part string, content *fedre
 
 	if content.FullTextURL != "" {
 		log.Trace("[main] retrieving list of associated sections for title ", title, " part ", part, " doc ID ", content.DocumentNumber)
-		sections, err := fetchSectionsFunc(ctx, content.FullTextURL)
+		sections, partMap, err := fetchSectionsFunc(ctx, content.FullTextURL)
 		if err != nil {
 			log.Error("[main] failed to fetch list of sections for FR doc ", content.DocumentNumber, ": ", err)
 		} else {
-			doc.Locations = eregs.CreateSections(fmt.Sprintf("%d", title), sections)
+			doc.Locations = eregs.CreateSections(sections, partMap)
 		}
 	} else {
 		log.Warn("[main] no list of sections available for FR doc ", content.DocumentNumber)

--- a/solution/parser/fr-parser/main_test.go
+++ b/solution/parser/fr-parser/main_test.go
@@ -467,14 +467,14 @@ func TestProcessPart(t *testing.T) {
 func TestProcessDocument(t *testing.T) {
 	testTable := []struct {
 		Name              string
-		FetchSectionsFunc func(context.Context, string) ([]string, error)
+		FetchSectionsFunc func(context.Context, string) ([]string, map[string]string, error)
 		SendDocumentFunc  func(context.Context, *eregs.FRDoc) error
 		Error             bool
 	}{
 		{
 			Name: "test-send",
-			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, error) {
-				return []string{"433.12", "12.1", "1.1"}, nil
+			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, map[string]string, error) {
+				return []string{"433.12", "12.1", "1.1"}, map[string]string{"433": "42", "12": "42", "1": "45"}, nil
 			},
 			SendDocumentFunc: func(ctx context.Context, doc *eregs.FRDoc) error {
 				return nil
@@ -483,8 +483,8 @@ func TestProcessDocument(t *testing.T) {
 		},
 		{
 			Name: "test-fetch-sections-failure",
-			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, error) {
-				return nil, fmt.Errorf("this is expected")
+			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, map[string]string, error) {
+				return nil, nil, fmt.Errorf("this is expected")
 			},
 			SendDocumentFunc: func(ctx context.Context, doc *eregs.FRDoc) error {
 				if len(doc.Locations) != 0 {
@@ -496,8 +496,8 @@ func TestProcessDocument(t *testing.T) {
 		},
 		{
 			Name: "test-send-document-failure",
-			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, error) {
-				return []string{"433.12", "12.1", "1.1"}, nil
+			FetchSectionsFunc: func(ctx context.Context, path string) ([]string, map[string]string, error) {
+				return []string{"433.12", "12.1", "1.1"}, map[string]string{"433": "42", "12": "42", "1": "45"}, nil
 			},
 			SendDocumentFunc: func(ctx context.Context, doc *eregs.FRDoc) error {
 				return fmt.Errorf("this is expected")


### PR DESCRIPTION
Resolves #1359

**Description-**

When the FR parser encounters a doc that exists for more than one title, it marks all extracted sections (from SECTNO tags in the XML) as belonging to the first title it processes that contains that doc. Thus the sections once uploaded to eRegs are invalid, e.g. 42 CFR 123.45 actually belongs to title 45.

**This pull request changes...**

- The FR parser processes `<CFR>` tags in the XML to map sections listed in `<SECTNO>` tags to the proper title.
- Sections that belong to titles outside the scope of our parsing are ignored.
- Unit tests are updated accordingly.

**Steps to manually verify this change...**

1. From a clean database, run the FR parser with the default title options.
2. In the Django Admin panel, go to "Federal Register Documents" and search for "84 FR 7610".
3. Navigate to the Locations field for that doc, and verify that there is exactly one section that is marked as belonging to title 45, and the rest are title 42. (Before this fix, all locations would belong to title 42.)
4. Optional: check other FR docs to make sure their locations are correct.

