### PR TITLE
EREGCSC-1479 Improve anti-indexing methods

### DIFF
--- a/solution/backend/regcore/templates/add_synonym.html
+++ b/solution/backend/regcore/templates/add_synonym.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Bulk Synonym Import</title>
+    <meta name="robots" content="noindex" />
 </head>
 <body>
 <form action="{% url 'bulk_synonyms' %}" method="post">

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -1,5 +1,9 @@
-{% extends "regulations/base.html" %} {% load static %} {% block title %}About
-This Tool | Medicaid & CHIP eRegulations{% endblock %} {% block body %}
+{% extends "regulations/base.html" %}
+{% load static %}
+
+{% block title %}About This Tool | Medicaid & CHIP eRegulations{% endblock %}
+
+{% block body %}
 <div class="site-container">
     <main class="about">
         <h1>About This Tool</h1>
@@ -249,6 +253,8 @@ This Tool | Medicaid & CHIP eRegulations{% endblock %} {% block body %}
         </section>
     </main>
 </div>
-{% endblock %} {% block post_footer %}
+{% endblock %}
+
+{% block post_footer %}
 <script src="{% static '/js/main.build.js' %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -23,9 +23,7 @@ CSS/Javascript etc., should inherit from this template.
         <meta name="msvalidate.01" content="2564ADEFA9801CDF3DD1287C2109D2A9" />
         <meta name="google-site-verification" content="iNAu2rAPdykHG6aKtClENiu_fRheE-TBM4drtyCVlWk" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        {% if not allow_indexing %}
-            <meta name="robots" content="noindex" />
-        {% endif %}
+        {% if not allow_indexing %}<meta name="robots" content="noindex" />{% endif %}
         <title>
             {% block title %}
                 {{title}} CFR {{reg_part}} {% if subpart %} Subpart {{subpart}} {% endif %} | Medicaid &amp; CHIP eRegulations

--- a/solution/backend/regulations/templates/regulations/supplemental_content.html
+++ b/solution/backend/regulations/templates/regulations/supplemental_content.html
@@ -17,6 +17,7 @@
         <meta property="og:description" content="{{ description }}" />
         <meta property="article:published_time" content="{{ pub_time }}" />
         <meta property="article:modified_time" content="{{ mod_time }}" />
+        {% if not allow_indexing %}<meta name="robots" content="noindex" />{% endif %}
     </head>
     <body>
         <script type="text/javascript">

--- a/solution/backend/regulations/templates/robots.txt
+++ b/solution/backend/regulations/templates/robots.txt
@@ -1,4 +1,10 @@
 User-agent: *
 {% if allow_indexing %}Allow{% else %}Disallow{% endif %}: /
+{% if not allow_indexing %}
+User-agent: Googlebot
+Allow: /
 
+User-agent: bingbot
+Allow: /
+{% endif %}
 Sitemap: https://{{request.META.HTTP_HOST}}/sitemap.xml


### PR DESCRIPTION
Resolves #1479

**Description-**

Further helps to prevent eRegs from showing up in search engine results.

**This pull request changes...**

- When search indexing is disabled via the admin panel:
    - Google & Bing are allowed to crawl the site, but all pages contain "noindex" tags so any existing data will be dropped.
    - All other robots are disallowed from crawling.
- Verified all pages are correctly serving noindex tags.

**Steps to manually verify this change...**

1. With indexing disabled via the admin panel, visit /robots.txt and note that Google and Bing are allowed to crawl, but other robots are not.
2. View the source of pages on the site and note the `<meta name="robots" content="noindex" />` tag within the `<head>` of the page.

