### PR TITLE
Disable resources test suite

### DIFF
--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -1,4 +1,4 @@
-describe("Resources page", () => {
+describe.skip("Resources page", () => {
     beforeEach(() => {
         cy.clearLocalStorage()
         cy.intercept("/**", (req) => {


### PR DESCRIPTION
**Description**

Resources test suite is temperamental and does not pass reliably.

This PR skips resources test suite until it can be looked at closer and debugged.

**This pull request changes**

- adds `skip` keyword to resources test suite so the test runner skips it.

**Steps to manually verify this change**

1. Look in deploy action for this PR and see if the resources tests were skipped
2. Pull down branch locally and run `make test` and see if resources tests were skipped

