### PR TITLE
EREGCSC-1470 -- Only show last updated dates when that date has meaning

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/landing_default.html
+++ b/solution/backend/regulations/templates/regulations/partials/landing_default.html
@@ -9,7 +9,7 @@
     {{ toc.label_description }}
 </h1>
 {% ecfr_part_url_formatter title reg_part as ecfr_part_url %}
-<p class="last-updated">{{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" class="external" target="_blank" rel="noopener noreferrer">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}; last amended {{ version_string }}.</p>
+<p class="last-updated">{{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" class="external" target="_blank" rel="noopener noreferrer">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}{% if has_meaningful_latest_version_date %}<span class="latest-version">; last amended </span>{{ version_string }}{% endif %}.</p>
 
 <section class="part-meta"><b>{{ authority.header }}</b> {{ authority.content }}</section>
 <section class="part-meta"><b>{{ source.header }}</b> {{ source.content | citation }}</section>

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -19,7 +19,7 @@
             <main class="reg-text match-middle" id="main-content">
                 {% ecfr_part_url_formatter title reg_part as ecfr_part_url %}
                 <p class="up-to-date{{ subpart|yesno:" subpart," }}">
-                {{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}{% if isLatestVersion %}<span class="latest-version">; last amended </span>{{ formattedLatestVersion }}{% endif %}.
+                {{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}{% if isLatestVersion and has_meaningful_latest_version_date %}<span class="latest-version">; last amended </span>{{ formattedLatestVersion }}{% endif %}.
                 </p>
                 {% include "regulations/partials/node_types/node.html" with resource_count=resource_count node=tree cfr_title=title citation=citation version=version %}
                 {% include "regulations/partials/navigation.html" %}

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -19,7 +19,7 @@
             <main class="reg-text match-middle" id="main-content">
                 {% ecfr_part_url_formatter title reg_part as ecfr_part_url %}
                 <p class="up-to-date{{ subpart|yesno:" subpart," }}">
-                {{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}{% if isLatestVersion and has_meaningful_latest_version_date %}<span class="latest-version">; last amended </span>{{ formattedLatestVersion }}{% endif %}.
+                {{ toc.label_level }} up to date from <a href="{{ecfr_part_url}}" target="_blank" class="external">eCFR</a> as of {{ parser_last_success|parser_success_date_formatter }}{% if is_latest_version and has_meaningful_latest_version_date %}<span class="latest-version">; last amended </span>{{ formatted_latest_version }}{% endif %}.
                 </p>
                 {% include "regulations/partials/node_types/node.html" with resource_count=resource_count node=tree cfr_title=title citation=citation version=version %}
                 {% include "regulations/partials/navigation.html" %}

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -14,7 +14,7 @@ from regulations.views.mixins import CitationContextMixin
 from regulations.views.utils import find_subpart
 from regulations.views.errors import NotInSubpart
 
-from datetime import datetime
+from datetime import date, datetime
 
 
 class ReaderView(CitationContextMixin, TemplateView):
@@ -118,7 +118,9 @@ class ReaderView(CitationContextMixin, TemplateView):
         return {
             'version': version,
             'formattedLatestVersion': datetime.strftime(latestVersion, "%b %-d, %Y"),
-            'isLatestVersion': version == latestVersionString
+            'isLatestVersion': version == latestVersionString,
+            # last updated dates of Jan 1, 2017 are not meaningful
+            'has_meaningful_latest_version_date': latestVersion > date(2017, 1, 1)
         }
 
 

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -112,15 +112,15 @@ class ReaderView(CitationContextMixin, TemplateView):
     def get_version_info(self, version, title, part):
         versions = self.get_versions(title, part)
 
-        latestVersion = versions[0]['date']
-        latestVersionString = datetime.strftime(latestVersion, "%Y-%m-%d")
+        latest_version = versions[0]['date']
+        latest_version_string = datetime.strftime(latest_version, "%Y-%m-%d")
 
         return {
             'version': version,
-            'formattedLatestVersion': datetime.strftime(latestVersion, "%b %-d, %Y"),
-            'isLatestVersion': version == latestVersionString,
+            'formatted_latest_version': datetime.strftime(latest_version, "%b %-d, %Y"),
+            'is_latest_version': version == latest_version_string,
             # last updated dates of Jan 1, 2017 are not meaningful
-            'has_meaningful_latest_version_date': latestVersion > date(2017, 1, 1)
+            'has_meaningful_latest_version_date': latest_version > date(2017, 1, 1)
         }
 
 

--- a/solution/backend/regulations/views/regulation_landing.py
+++ b/solution/backend/regulations/views/regulation_landing.py
@@ -36,6 +36,8 @@ class RegulationLandingView(TemplateView):
             'title': title,
             'version': reg_version,
             'version_string': reg_version_string,
+            # last updated dates of Jan 1, 2017 are not meaningful
+            'has_meaningful_latest_version_date': current.date > date(2017, 1, 1),
             'part': reg_part,
             'part_label': part_label,
             'reg_part': reg_part, 'parts': parts,


### PR DESCRIPTION
Resolves [EREGCSC-1470](https://jiraent.cms.gov/browse/EREGCSC-1470)

**Description**

eCFR did not track individual changes to parts prior to January 1st, 2017.  

If a part has not been updated since eCFR began tracking individual changes, it shows a last amended date of January 1st, 2017, even though it was not amended on that date.  The actual last amended date is unknown.

Therefore, if a part has a last updated date of January 1st, 2017, it is not a meaningful date and that date should not be shown on the landing or reader view pages.

**This pull request changes**

- adds `has_meaningful_latest_version_date` field to context for `reader` templates and `regulation_landing` template
- Only shows `latest-version` span in those templates if `has_meaningful_latest_version_date` is true

**Steps to manually verify this change**

1. Visit Parts 434 and 436 in two places:
   - [the "landing" view](https://syiazh8oec.execute-api.us-east-1.amazonaws.com/dev525/42/434/#434): the subpart table of context, which is where you are sent when you use the "Jump To" functionality
   - [the "reader" view](https://syiazh8oec.execute-api.us-east-1.amazonaws.com/dev525/42/434/Subpart-A/2017-01-01/), which is the actual regulations at the supart level
2. Ensure that these part pages do not have a "last amended date" at the top of the page.  You should only see "Part 436 up to date from eCFR as of Aug 31, 2022."
3. Visit any other part ([Part 435](https://syiazh8oec.execute-api.us-east-1.amazonaws.com/dev525/42/435/#435), for example) in both landing and reader view
4. Ensure that it has an "up to date" date and a "last amended" date, since it has been amended since January 1st, 2017
