### PR TITLE
Only seed experimental deploy databases once

### DIFF
--- a/solution/backend/populate_content.py
+++ b/solution/backend/populate_content.py
@@ -3,20 +3,6 @@ import os
 from django.core.management import call_command
 
 
-from resources.models import (
-    Category,
-    SubCategory,
-    Subpart,
-    Section,
-    SupplementalContent,
-    FederalRegisterDocumentGroup,
-    FederalRegisterDocument,
-    ResourcesConfiguration,
-)
-
-from regcore.search.models import Synonym
-
-
 def load_data(fixture, model):
     if not model.objects.count():
         call_command("loaddata", fixture)
@@ -26,6 +12,19 @@ def handler(event, context):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cmcs_regulations.settings")
     import django
     django.setup()
+
+    from resources.models import (
+        Category,
+        SubCategory,
+        Subpart,
+        Section,
+        SupplementalContent,
+        FederalRegisterDocumentGroup,
+        FederalRegisterDocument,
+        ResourcesConfiguration,
+    )
+
+    from regcore.search.models import Synonym
 
     load_data("resources.category.json", Category)
     load_data("resources.subcategory.json", SubCategory)

--- a/solution/backend/populate_content.py
+++ b/solution/backend/populate_content.py
@@ -3,17 +3,36 @@ import os
 from django.core.management import call_command
 
 
+from resources.models import (
+    Category,
+    SubCategory,
+    Subpart,
+    Section,
+    SupplementalContent,
+    FederalRegisterDocumentGroup,
+    FederalRegisterDocument,
+    ResourcesConfiguration,
+)
+
+from regcore.search.models import Synonym
+
+
+def load_data(fixture, model):
+    if not model.objects.count():
+        call_command("loaddata", fixture)
+
+
 def handler(event, context):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cmcs_regulations.settings")
     import django
     django.setup()
 
-    call_command('loaddata', 'resources.category.json')
-    call_command('loaddata', 'resources.subcategory.json')
-    call_command('loaddata', 'resources.subpart.json')
-    call_command('loaddata', 'resources.section.json')
-    call_command('loaddata', 'resources.supplementalcontent.json')
-    call_command('loaddata', 'resources.federalregisterdocumentgroup.json')
-    call_command('loaddata', 'resources.federalregisterdocument.json')
-    call_command('loaddata', 'resources.resourcesconfiguration.json')
-    call_command('loaddata', 'search.synonym.json')
+    load_data("resources.category.json", Category)
+    load_data("resources.subcategory.json", SubCategory)
+    load_data("resources.subpart.json", Subpart)
+    load_data("resources.section.json", Section)
+    load_data("resources.supplementalcontent.json", SupplementalContent)
+    load_data("resources.federalregisterdocumentgroup.json", FederalRegisterDocumentGroup)
+    load_data("resources.federalregisterdocument.json", FederalRegisterDocument)
+    load_data("resources.resourcesconfiguration.json", ResourcesConfiguration)
+    load_data("search.synonym.json", Synonym)

--- a/solution/test.txt
+++ b/solution/test.txt
@@ -1,0 +1,1 @@
+This is a temporary test file


### PR DESCRIPTION
Resolves #n/a

**Description-**

Currently every time you commit and push to an open PR, the experimental deploy attempts to reload the fixtures.

To more closely match the behavior of local environments and production, and fix fixture import bugs (when IDs differ causing unique constraints to be violated), we should only load fixtures automatically once per deploy, on first creation.

**This pull request changes...**

The `populate_content` function checks the count of each model with a fixture. If the count is 0, we can safely load the fixture. Otherwise it is skipped.

**Steps to manually verify this change...**

1. Check that this PR deploys correctly after the first and second push.

