### PR TITLE
EREGCSC-1501 Fix issue with resource page

### DIFF
--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -178,7 +178,7 @@ class FederalRegisterDocumentSerializer(SimpleFederalRegisterDocumentSerializer)
 
     def to_representation(self, instance):
         obj = super().to_representation(instance)
-        if(self.context['fr_grouping'] == 'false'):
+        if self.context['fr_grouping'] == 'false':
             return obj
         docs = [obj] + obj["related_docs"]
         del obj["related_docs"]

--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -140,7 +140,6 @@ class AbstractResourceSerializer(OptionalFieldDetailsMixin, serializers.Serializ
     optional_details = {
         "category": ("category_details", "true", AbstractCategoryPolymorphicSerializer, False),
         "locations": ("location_details", "true", AbstractLocationPolymorphicSerializer, True),
-        "fr_grouping": ("fr_grouping", "true", AbstractLocationPolymorphicSerializer, True),
     }
 
 

--- a/solution/backend/resources/v3serializers.py
+++ b/solution/backend/resources/v3serializers.py
@@ -140,6 +140,7 @@ class AbstractResourceSerializer(OptionalFieldDetailsMixin, serializers.Serializ
     optional_details = {
         "category": ("category_details", "true", AbstractCategoryPolymorphicSerializer, False),
         "locations": ("location_details", "true", AbstractLocationPolymorphicSerializer, True),
+        "fr_grouping": ("fr_grouping", "true", AbstractLocationPolymorphicSerializer, True),
     }
 
 
@@ -178,6 +179,8 @@ class FederalRegisterDocumentSerializer(SimpleFederalRegisterDocumentSerializer)
 
     def to_representation(self, instance):
         obj = super().to_representation(instance)
+        if(self.context['fr_grouping'] == 'false'):
+            return obj
         docs = [obj] + obj["related_docs"]
         del obj["related_docs"]
         docs = sorted(docs, key=lambda i: i["date"] or "", reverse=True)

--- a/solution/backend/resources/v3views.py
+++ b/solution/backend/resources/v3views.py
@@ -241,6 +241,8 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
                               "\"&categories=X&categories=Y\" for multiple.", int, False),
         OpenApiQueryParameter("sort", "Sort results by this field. Valid values are \"newest\", \"oldest\", and \"relevance\". "
                               "Newest is the default, and relevance requires a search query.", str, False),
+        OpenApiQueryParameter("fr_grouping", "Determines if FR Documents should be grouped or not"
+                              "Default is true", bool, False),
     ] + OptionalPaginationMixin.PARAMETERS + LocationFiltererMixin.PARAMETERS
 
     location_filter_prefix = "locations__"
@@ -258,6 +260,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         context = super().get_serializer_context()
         context["category_details"] = self.request.GET.get("category_details", "true")
         context["location_details"] = self.request.GET.get("location_details", "true")
+        context["fr_grouping"] = self.request.GET.get("fr_grouping", "true")
         return context
 
     def get_search_vectors(self):

--- a/solution/ui/regulations/eregs-vite/src/utilities/api.js
+++ b/solution/ui/regulations/eregs-vite/src/utilities/api.js
@@ -717,7 +717,8 @@ const getSupplementalContentV3 = async (
         cat_details = true,
         page_size = 100,
         location_details = true,
-        sortMethod = "newest"
+        sortMethod = "newest",
+        fr_grouping = true,
     }
 ) => {
     const queryString = q ? `&q=${q}` : "";
@@ -755,6 +756,7 @@ const getSupplementalContentV3 = async (
     sString = `${sString}&sort=${sortMethod}`;
 
     sString = `${sString}&paginate=true&page_size=${page_size}&page=${page}`
+    sString = `${sString}&fr_grouping=${fr_grouping}`
     const response = await httpApiGetV3(`resources/?${sString}`)
     return response;
 

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -513,6 +513,7 @@ export default {
                     partDict: this.partDict,
                     categories: this.categories,
                     q: searchQuery,
+                    fr_grouping:false,
                     sortMethod,
                 });
 
@@ -534,6 +535,7 @@ export default {
                         partDict: "all", // titles
                         categories: this.categories, // subcategories
                         q: searchQuery,
+                        fr_grouping:false,
                         sortMethod,
                     });
 
@@ -554,6 +556,7 @@ export default {
                     categories: this.categories,
                     q: searchQuery,
                     start: 0, // start
+                    fr_grouping:false,
                     max_results: 100, // max_results
                     sortMethod,
                 });


### PR DESCRIPTION
Resolves #
EREGCSC-101
**Description-**

Fixes issue where FRDOCS got grouped together and would replace the linked documents with the most recent one.

**This pull request changes...**

- expected change 1

When you sort supplemental content by oldest it should all be in order again
**Steps to manually verify this change...**

1. steps to view and verify change

Go to the resources page.  Sort by oldest.  Within the first 20 they should all be in order.

Search for "36443".  This should pull up the FR doc realated to 36443.  Before it would pull up 33209

