### PR TITLE
update prototype dockerfile to install latest python

### DIFF
--- a/solution/ui/prototype/Dockerfile
+++ b/solution/ui/prototype/Dockerfile
@@ -1,6 +1,9 @@
 # base image
 FROM node:16-alpine
 
+# install python
+RUN apk add --no-cache python3 make g++
+
 # set working directory
 WORKDIR /app/solution/ui/prototype
 


### PR DESCRIPTION
Resolves #

**Description-**
For new users, make prototype would fail due to python not being installed inside the docker container. To resolve this we added a line to install python in the dockerfile to fix this problem. 

**This pull request changes...**
add python installation in the Dockerfile
- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change
run `make prototype` 
expected results: no errors. 

