### PR TITLE
Fix reader view FR Doc grouping

### DIFF
--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -43,8 +43,8 @@ class ReaderView(CitationContextMixin, TemplateView):
         part_label = toc['label_description']
         tree = self.get_content(context, document, toc)
         node_list = self.get_supp_content_params(context, [tree])
-        categories = list(Category.objects.filter(show_if_empty=True).order_by('order').values())
-        sub_categories = list(SubCategory.objects.filter(show_if_empty=True).order_by('order').values())
+        categories = list(Category.objects.filter(show_if_empty=True).contains_fr_docs().order_by('order').values())
+        sub_categories = list(SubCategory.objects.filter(show_if_empty=True).contains_fr_docs().order_by('order').values())
 
         locations = AbstractLocation.objects.filter(part=reg_part).select_subclasses().annotate(
             num_locations=Count(

--- a/solution/backend/resources/models.py
+++ b/solution/backend/resources/models.py
@@ -1,5 +1,5 @@
 import datetime
-from model_utils.managers import InheritanceManager
+from model_utils.managers import InheritanceManager, InheritanceQuerySet
 from django.core.validators import RegexValidator
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -64,6 +64,15 @@ class DisplayNameFieldMixin:
 # Category types
 # Current choice is one model per level due to constraint of exactly 2 levels.
 
+class AbstractCategoryQuerySet(InheritanceQuerySet):
+    def contains_fr_docs(self):
+        return self.annotate(
+            is_fr_doc_category=models.ExpressionWrapper(
+                ~models.Q(fr_doc_category_config=None),
+                output_field=models.BooleanField()
+            )
+        )
+
 
 class AbstractCategory(models.Model, DisplayNameFieldMixin):
     name = models.CharField(max_length=512, unique=True)
@@ -71,7 +80,7 @@ class AbstractCategory(models.Model, DisplayNameFieldMixin):
     order = models.IntegerField(default=0, blank=True)
     show_if_empty = models.BooleanField(default=False)
 
-    objects = InheritanceManager()
+    objects = AbstractCategoryQuerySet.as_manager()
 
     def __str__(self):
         return f"{self.name} ({self._meta.verbose_name})"

--- a/solution/backend/resources/v3views.py
+++ b/solution/backend/resources/v3views.py
@@ -41,11 +41,6 @@ from .v3serializers import (
 from regcore.serializers import StringListSerializer
 
 
-CATEGORY_ANNOTATIONS = {
-    "is_fr_doc_category": ExpressionWrapper(~Q(fr_doc_category_config=None), output_field=BooleanField()),
-}
-
-
 def OpenApiQueryParameter(name, description, type, required):
     return OpenApiParameter(name=name, description=description, required=required, type=type, location=OpenApiParameter.QUERY)
 
@@ -94,7 +89,7 @@ class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
     paginate_by_default = False
     serializer_class = AbstractCategoryPolymorphicSerializer
     queryset = AbstractCategory.objects.all().select_subclasses().select_related("subcategory__parent")\
-                               .order_by("order").annotate(**CATEGORY_ANNOTATIONS)
+                               .order_by("order").contains_fr_docs()
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -110,8 +105,8 @@ class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
 class CategoryTreeViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
     paginate_by_default = False
     queryset = Category.objects.all().select_subclasses().prefetch_related(
-        Prefetch("sub_categories", SubCategory.objects.all().order_by("order").annotate(**CATEGORY_ANNOTATIONS)),
-    ).order_by("order").annotate(**CATEGORY_ANNOTATIONS)
+        Prefetch("sub_categories", SubCategory.objects.all().order_by("order").contains_fr_docs()),
+    ).order_by("order").contains_fr_docs()
     serializer_class = CategoryTreeSerializer
 
 
@@ -323,7 +318,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         ids = [i[0] for i in id_query.values_list("id", "group_annotated")]
         locations_prefetch = AbstractLocation.objects.all().select_subclasses()
         category_prefetch = AbstractCategory.objects.all().select_subclasses().select_related("subcategory__parent")\
-                                            .annotate(**CATEGORY_ANNOTATIONS)
+                                            .contains_fr_docs()
         query = self.model.objects.filter(id__in=ids).select_subclasses().prefetch_related(
             Prefetch("locations", queryset=locations_prefetch),
             Prefetch("category", queryset=category_prefetch),

--- a/solution/backend/resources/v3views.py
+++ b/solution/backend/resources/v3views.py
@@ -2,7 +2,7 @@ from django.http import JsonResponse
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from django.core.exceptions import BadRequest
-from django.db.models import Prefetch, Q, Case, When, F, BooleanField, ExpressionWrapper
+from django.db.models import Prefetch, Q, Case, When, F
 from rest_framework.pagination import PageNumberPagination
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 


### PR DESCRIPTION
Resolves #n/a

**Description-**

Reader view is not showing grouped FR docs because reader.py isn't annotating `is_fr_doc_category` on the Category queryset.

**This pull request changes...**

- Uses an `InheritanceQuerySet` to add method `contains_fr_docs()` method to the queryset
- `contains_fr_docs()` added to querysets in reader.py and also in resources/v3views.py

**Steps to manually verify this change...**

1. Clear your cache and visit a reader view page known to have grouped FR docs (e.g. 42 CFR 433 Subpart A)
2. Verify docs are grouped in the sidebar

