### PR TITLE
Eregcsc 1507

### DIFF
--- a/solution/ui/regulations/js/src/components/RelatedRuleList.vue
+++ b/solution/ui/regulations/js/src/components/RelatedRuleList.vue
@@ -27,7 +27,7 @@
             </template>
         </template>
         <collapse-button
-            v-if="showMoreNeeded && rulesCount > limit"
+            v-if="showMoreNeeded"
             :name="innerName"
             state="collapsed"
             class="category-title"
@@ -81,7 +81,7 @@
                 </template>
             </template>
             <collapse-button
-                v-if="showMoreNeeded && rulesCount > 0"
+                v-if="showMoreNeeded && rulesCount > 10"
                 :name="innerName"
                 state="collapsed"
                 class="category-title"

--- a/solution/ui/regulations/js/src/components/RelatedRuleList.vue
+++ b/solution/ui/regulations/js/src/components/RelatedRuleList.vue
@@ -27,7 +27,7 @@
             </template>
         </template>
         <collapse-button
-            v-if="showMoreNeeded && rulesCount > 10"
+            v-if="showMoreNeeded && rulesCount > limit"
             :name="innerName"
             state="collapsed"
             class="category-title"

--- a/solution/ui/regulations/js/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContentList.vue
@@ -47,7 +47,7 @@
             >
             </supplemental-content-object>
             <collapse-button
-                v-if="showMoreNeeded && contentCount > 10"
+                v-if="showMoreNeeded && contentCount > limit"
                 v-bind:class="{ subcategory: subcategory }"
                 :name="innerName"
                 state="collapsed"

--- a/solution/ui/regulations/js/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContentList.vue
@@ -47,7 +47,7 @@
             >
             </supplemental-content-object>
             <collapse-button
-                v-if="showMoreNeeded && contentCount > limit"
+                v-if="showMoreNeeded && contentCount > 10"
                 v-bind:class="{ subcategory: subcategory }"
                 :name="innerName"
                 state="collapsed"


### PR DESCRIPTION
Resolves #

EREGCSC-1507  Missing FR Docs in sidebar

**Description-**

Some FR-DOCS are missing on the sidebar.  This will allow them to appear if not there.

**This pull request changes...**

If there are more FRDOCS than the limit it will show a show more button allowing more federal documetns to appear.  Before there was a hardcoded 10 in there with a limit of 5.  So if it was less than 10 FR docs but more than5 you had no way of showing them.  Threw in the bonus of it not working in supplemental content as well :D.

**Steps to manually verify this change...**

1. steps to view and verify change

Go to title 42 part 400 section 200.  Before you were missing a bunch of them such as Medicare Program; Hospital Insurance Entitlement and Benefits.  you should see a show more button now with the display and find the fr group in there.
