### PR TITLE
EREGCSC-1262 Implement endpoints for managing FR data

### DIFF
--- a/solution/backend/resources/utils.py
+++ b/solution/backend/resources/utils.py
@@ -1,11 +1,3 @@
-def is_int(x):
-    try:
-        _ = int(x)
-        return True
-    except ValueError:
-        return False
-
-
 # TODO: remove this after v3 move
 class reverse_sort:
     def __init__(self, obj):

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -1,0 +1,37 @@
+from rest_framework import serializers
+
+from resources.models import Category, SubCategory
+from .mixins import PolymorphicSerializer, OptionalFieldDetailsMixin
+
+
+class AbstractCategoryPolymorphicSerializer(PolymorphicSerializer):
+    def get_serializer_map(self):
+        return {
+            Category: ("category", CategorySerializer),
+            SubCategory: ("subcategory", SubCategorySerializer),
+        }
+
+
+class CategorySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    description = serializers.CharField()
+    order = serializers.IntegerField()
+    show_if_empty = serializers.BooleanField()
+    is_fr_doc_category = serializers.SerializerMethodField()
+
+    def get_is_fr_doc_category(self, obj):
+        try:
+            return obj.is_fr_doc_category
+        except Exception:
+            return False
+
+
+class SubCategorySerializer(OptionalFieldDetailsMixin, CategorySerializer):
+    optional_details = {
+        "parent": ("parent_details", "true", CategorySerializer, False),
+    }
+
+
+class CategoryTreeSerializer(CategorySerializer):
+    sub_categories = CategorySerializer(many=True)

--- a/solution/backend/resources/v3serializers/locations.py
+++ b/solution/backend/resources/v3serializers/locations.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+
+from resources.models import Section, Subpart
+from .mixins import PolymorphicSerializer
+
+
+class AbstractLocationPolymorphicSerializer(PolymorphicSerializer):
+    def get_serializer_map(self):
+        return {
+            Section: ("section", SectionSerializer),
+            Subpart: ("subpart", SubpartSerializer),
+        }
+
+
+class AbstractLocationSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    title = serializers.IntegerField()
+    part = serializers.IntegerField()
+
+
+class SubpartSerializer(AbstractLocationSerializer):
+    subpart_id = serializers.CharField()
+
+
+class SectionSerializer(AbstractLocationSerializer):
+    section_id = serializers.IntegerField()
+    parent = serializers.PrimaryKeyRelatedField(read_only=True)
+
+
+class FullSectionSerializer(SectionSerializer):
+    parent = AbstractLocationPolymorphicSerializer()
+
+
+class FullSubpartSerializer(SubpartSerializer):
+    children = AbstractLocationPolymorphicSerializer(many=True)
+
+
+class SectionCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Section
+        fields = "__all__"
+
+
+class SectionRangeCreateSerializer(serializers.Serializer):
+    title = serializers.CharField()
+    part = serializers.CharField()
+    first_sec = serializers.IntegerField()
+    last_sec = serializers.IntegerField()

--- a/solution/backend/resources/v3serializers/mixins.py
+++ b/solution/backend/resources/v3serializers/mixins.py
@@ -1,0 +1,44 @@
+from rest_framework import serializers
+
+
+# Allows details of specified fields to be shown or hidden
+# Must specify "optional_details" as map of strings to 4-tuples:
+#    { "field_name": ("query_param", "default, true or false as a string", serializer class, many=True or False) }
+class OptionalFieldDetailsMixin:
+    def get_fields(self):
+        fields = super().get_fields()
+        for i in self.optional_details.items():
+            fields[i[0]] = (
+                i[1][2](many=i[1][3])
+                if self.context.get(i[1][0], i[1][1]).lower() == "true"
+                else serializers.PrimaryKeyRelatedField(many=i[1][3], read_only=True)
+            )
+        return fields
+
+
+# Retrieves automatically generated search headlines
+class HeadlineField(serializers.Field):
+    def __init__(self, model_name, **kwargs):
+        self.model_name = model_name
+        kwargs["source"] = '*'
+        kwargs["read_only"] = True
+        super().__init__(**kwargs)
+
+    def to_representation(self, obj):
+        return getattr(obj, f"{self.model_name}_{self.field_name}", getattr(obj, self.field_name, None))
+
+
+# Allows subclasses to be serialized independently
+# Must implement get_serializer_map as map of classes to 2-tuples:
+#    { model_class: ("model_name", serializer_class) }
+class PolymorphicSerializer(serializers.Serializer):
+    def get_serializer_map(self):
+        raise NotImplementedError
+
+    def to_representation(self, instance):
+        instance_type = type(instance)
+        if instance_type in self.get_serializer_map():
+            data = self.get_serializer_map()[instance_type][1](instance=instance, context=self.context).data
+            data["type"] = self.get_serializer_map()[instance_type][0]
+            return data
+        return "Serializer not available"

--- a/solution/backend/resources/v3urls.py
+++ b/solution/backend/resources/v3urls.py
@@ -1,46 +1,40 @@
 from django.urls import path
 
-from .v3views import (
-    AbstractResourceViewSet,
-    SupplementalContentViewSet,
-    FederalRegisterDocsViewSet,
-    FederalRegisterDocsNumberViewSet,
-    CategoryViewSet,
-    CategoryTreeViewSet,
-    LocationViewSet,
-    SectionViewSet,
-    SubpartViewSet,
+from resources.v3views import (
+    categories,
+    locations,
+    resources,
 )
 
 
 urlpatterns = [
-    path("", AbstractResourceViewSet.as_view({
+    path("", resources.AbstractResourceViewSet.as_view({
         "get": "list",
     })),
-    path("supplemental_content", SupplementalContentViewSet.as_view({
+    path("supplemental_content", resources.SupplementalContentViewSet.as_view({
         "get": "list",
     })),
-    path("federal_register_docs", FederalRegisterDocsViewSet.as_view({
+    path("federal_register_docs", resources.FederalRegisterDocsViewSet.as_view({
         "get": "list",
         "put": "update",
     })),
-    path("federal_register_docs/doc_numbers", FederalRegisterDocsNumberViewSet.as_view({
+    path("federal_register_docs/doc_numbers", resources.FederalRegisterDocsNumberViewSet.as_view({
         "get": "list",
     })),
-    path("categories", CategoryViewSet.as_view({
+    path("categories", categories.CategoryViewSet.as_view({
         "get": "list",
     })),
-    path("categories/tree", CategoryTreeViewSet.as_view({
+    path("categories/tree", categories.CategoryTreeViewSet.as_view({
         "get": "list",
     })),
-    path("locations", LocationViewSet.as_view({
+    path("locations", locations.LocationViewSet.as_view({
         "get": "list",
         # "post": "create", # TODO: add in another v3 ticket
     })),
-    path("locations/sections", SectionViewSet.as_view({
+    path("locations/sections", locations.SectionViewSet.as_view({
         "get": "list",
     })),
-    path("locations/subparts", SubpartViewSet.as_view({
+    path("locations/subparts", locations.SubpartViewSet.as_view({
         "get": "list",
     })),
 ]

--- a/solution/backend/resources/v3urls.py
+++ b/solution/backend/resources/v3urls.py
@@ -29,7 +29,6 @@ urlpatterns = [
     })),
     path("locations", locations.LocationViewSet.as_view({
         "get": "list",
-        # "post": "create", # TODO: add in another v3 ticket
     })),
     path("locations/sections", locations.SectionViewSet.as_view({
         "get": "list",

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -1,0 +1,50 @@
+from rest_framework import viewsets
+from drf_spectacular.utils import extend_schema
+from django.db.models import Prefetch
+
+from .mixins import OptionalPaginationMixin, OpenApiQueryParameter, PAGINATION_PARAMS
+
+from resources.models import (
+    AbstractCategory,
+    Category,
+    SubCategory,
+)
+
+from resources.v3serializers.categories import (
+    SubCategorySerializer,
+    AbstractCategoryPolymorphicSerializer,
+    CategoryTreeSerializer,
+)
+
+
+@extend_schema(
+    description="Retrieve a flat list of all categories. Pagination is disabled by default.",
+    parameters=OptionalPaginationMixin.PARAMETERS + PAGINATION_PARAMS + [
+        OpenApiQueryParameter("parent_details", "Show details about each sub-category's parent, rather "
+                              "than just the ID.", bool, False),
+    ],
+    responses=SubCategorySerializer,
+)
+class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
+    paginate_by_default = False
+    serializer_class = AbstractCategoryPolymorphicSerializer
+    queryset = AbstractCategory.objects.all().select_subclasses().select_related("subcategory__parent")\
+                               .order_by("order").contains_fr_docs()
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["parent_details"] = self.request.GET.get("parent_details", "true")
+        return context
+
+
+@extend_schema(
+    description="Retrieve a top-down representation of categories, with each category containing zero or more sub-categories. "
+                "Pagination is disabled by default.",
+    parameters=OptionalPaginationMixin.PARAMETERS + PAGINATION_PARAMS,
+)
+class CategoryTreeViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
+    paginate_by_default = False
+    queryset = Category.objects.all().select_subclasses().prefetch_related(
+        Prefetch("sub_categories", SubCategory.objects.all().order_by("order").contains_fr_docs()),
+    ).order_by("order").contains_fr_docs()
+    serializer_class = CategoryTreeSerializer

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -23,6 +23,7 @@ from regcore.views import SettingsAuthentication
 
 class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):
     queryset = AbstractLocation.objects.all().select_subclasses()
+    serializer_class = AbstractLocationPolymorphicSerializer
 
     authentication_classes = [SettingsAuthentication]
     permission_classes = [IsAuthenticatedOrReadOnly]
@@ -34,15 +35,6 @@ class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):
     )
     def list(self, request, **kwargs):
         return super(LocationViewSet, self).list(request, **kwargs)
-
-    # TODO: extend_schema for this method
-    def update(self, request, **kwargs):
-        return super(LocationViewSet, self).update(request, **kwargs)  # TODO: implement this!
-
-    def get_serializer_class(self):
-        # if self.request.method == "POST":  # TODO: implement AbstractLocationCreateSerializer
-        #     return AbstractLocationCreateSerializer
-        return AbstractLocationPolymorphicSerializer
 
 
 @extend_schema(

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -1,0 +1,67 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from drf_spectacular.utils import extend_schema
+from django.db.models import Prefetch
+
+from .mixins import LocationExplorerViewSetMixin
+
+from resources.models import (
+    AbstractLocation,
+    Section,
+    Subpart,
+)
+
+from resources.v3serializers.locations import (
+    AbstractLocationSerializer,
+    AbstractLocationPolymorphicSerializer,
+    FullSectionSerializer,
+    FullSubpartSerializer,
+)
+
+from regcore.views import SettingsAuthentication
+
+
+class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):
+    queryset = AbstractLocation.objects.all().select_subclasses()
+
+    authentication_classes = [SettingsAuthentication]
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    @extend_schema(
+        description="Retrieve a list of all resource locations, filterable by title and part. Results are paginated by default.",
+        parameters=LocationExplorerViewSetMixin.PARAMETERS,
+        responses=AbstractLocationSerializer,
+    )
+    def list(self, request, **kwargs):
+        return super(LocationViewSet, self).list(request, **kwargs)
+
+    # TODO: extend_schema for this method
+    def update(self, request, **kwargs):
+        return super(LocationViewSet, self).update(request, **kwargs)  # TODO: implement this!
+
+    def get_serializer_class(self):
+        # if self.request.method == "POST":  # TODO: implement AbstractLocationCreateSerializer
+        #     return AbstractLocationCreateSerializer
+        return AbstractLocationPolymorphicSerializer
+
+
+@extend_schema(
+    description="Retrieve a list of all Section objects, filterable by title and part. Results are paginated by default.",
+    parameters=LocationExplorerViewSetMixin.PARAMETERS,
+)
+class SectionViewSet(LocationExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    serializer_class = FullSectionSerializer
+    queryset = Section.objects.all().prefetch_related(
+        Prefetch("parent", AbstractLocation.objects.all().select_subclasses()),
+    )
+
+
+@extend_schema(
+    description="Retrieve a list of all Subpart objects, filterable by title and part. Results are paginated by default.",
+    parameters=LocationExplorerViewSetMixin.PARAMETERS,
+)
+class SubpartViewSet(LocationExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    serializer_class = FullSubpartSerializer
+    queryset = Subpart.objects.all().prefetch_related(
+        Prefetch("children", Section.objects.all()),
+    )

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -1,0 +1,128 @@
+from rest_framework import viewsets
+from drf_spectacular.utils import extend_schema
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from django.db import transaction
+from django.db.models import Case, When, F
+from django.http import JsonResponse
+
+from .mixins import ResourceExplorerViewSetMixin, OptionalPaginationMixin, PAGINATION_PARAMS
+
+from resources.models import (
+    AbstractResource,
+    SupplementalContent,
+    FederalRegisterDocument,
+)
+
+from resources.v3serializers.resources import (
+    AbstractResourcePolymorphicSerializer,
+    SupplementalContentSerializer,
+    FederalRegisterDocumentCreateSerializer,
+    FederalRegisterDocumentSerializer,
+    StringListSerializer,
+    AbstractResourceSerializer,
+)
+
+from regcore.views import SettingsAuthentication
+
+
+@extend_schema(
+    description="Retrieve a list of all resources. "
+                "Includes all types e.g. supplemental content, Federal Register Documents, etc. "
+                "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
+                "Results are paginated by default.",
+    parameters=ResourceExplorerViewSetMixin.PARAMETERS,
+    responses=AbstractResourceSerializer,
+)
+class AbstractResourceViewSet(ResourceExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    serializer_class = AbstractResourcePolymorphicSerializer
+    model = AbstractResource
+
+    def get_annotated_date(self):
+        return Case(
+            When(supplementalcontent__isnull=False, then=F("supplementalcontent__date")),
+            When(federalregisterdocument__isnull=False, then=F("federalregisterdocument__date")),
+            default=None,
+        )
+
+    def get_annotated_group(self):
+        return Case(
+            When(federalregisterdocument__isnull=False, then=F("federalregisterdocument__group")),
+            default=-1*F("pk"),
+        )
+
+    def get_search_fields(self):
+        return {
+            "supplementalcontent": ["name", "description"],
+            "federalregisterdocument": ["name", "description", "document_number"],
+        }
+
+
+@extend_schema(
+    description="Retrieve a list of all supplemental content. "
+                "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
+                "Results are paginated by default.",
+    parameters=ResourceExplorerViewSetMixin.PARAMETERS,
+)
+class SupplementalContentViewSet(ResourceExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    serializer_class = SupplementalContentSerializer
+    model = SupplementalContent
+
+    def get_search_fields(self):
+        return ["name", "description"]
+
+
+class FederalRegisterDocsViewSet(ResourceExplorerViewSetMixin, viewsets.ModelViewSet):
+    model = FederalRegisterDocument
+
+    authentication_classes = [SettingsAuthentication]
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    @extend_schema(
+        description="Retrieve a list of all Federal Register Documents. "
+                    "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
+                    "Results are paginated by default.",
+        parameters=ResourceExplorerViewSetMixin.PARAMETERS,
+    )
+    def list(self, request, **kwargs):
+        return super(FederalRegisterDocsViewSet, self).list(request, **kwargs)
+
+    @transaction.atomic
+    @extend_schema(description="Upload a Federal Register Document to the eRegs Resources system. "
+                               "If the document already exists, it will be updated.")
+    def update(self, request, **kwargs):
+        data = request.data
+        frdoc, created = FederalRegisterDocument.objects.get_or_create(document_number=data["document_number"])
+        data["id"] = frdoc.pk
+        sc = self.get_serializer(frdoc, data=data)
+        try:
+            if sc.is_valid(raise_exception=True):
+                sc.save()
+                response = sc.validated_data
+                return JsonResponse(response)
+        except Exception as e:
+            if created:
+                frdoc.delete()
+            raise e
+
+    def get_serializer_class(self):
+        if self.request.method == "PUT":
+            return FederalRegisterDocumentCreateSerializer
+        return FederalRegisterDocumentSerializer
+
+    def get_search_fields(self):
+        return ["name", "description", "document_number"]
+
+    def get_annotated_group(self):
+        return F("group")
+
+
+@extend_schema(
+    description="Retrieve a list of document numbers from all Federal Register Documents. "
+                "Pagination is disabled by default.",
+    parameters=OptionalPaginationMixin.PARAMETERS + PAGINATION_PARAMS,
+    responses={(200, "application/json"): {"type": "string"}},
+)
+class FederalRegisterDocsNumberViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
+    paginate_by_default = False
+    queryset = FederalRegisterDocument.objects.all().values_list("document_number", flat=True).distinct()
+    serializer_class = StringListSerializer

--- a/solution/backend/resources/v3views/utils.py
+++ b/solution/backend/resources/v3views/utils.py
@@ -1,0 +1,13 @@
+from drf_spectacular.utils import OpenApiParameter
+
+
+def OpenApiQueryParameter(name, description, type, required):
+    return OpenApiParameter(name=name, description=description, required=required, type=type, location=OpenApiParameter.QUERY)
+
+
+def is_int(x):
+    try:
+        _ = int(x)
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
Resolves #1262

**Description-**

FR endpoints are fully moved to V3, and resources app V3 serializers and viewsets are split into more manageable files.

**Steps to manually verify this change...**

1. Verify Pythin Lint (flake8) tests pass (no import errors etc)
2. Verify cypress tests pass (200 OK on all API endpoints)

