### PR TITLE
EREGCSC-1536 Keyboard navigability on resources page

### DIFF
--- a/solution/backend/regulations/templates/regulations/resources.html
+++ b/solution/backend/regulations/templates/regulations/resources.html
@@ -11,6 +11,10 @@
 
 {% block flash_banner %}{% endblock %}
 
+{% block pre_header %}
+    <a class="ds-c-skip-nav" href="#main-content">Skip to main content</a>
+{% endblock %}
+
 {% block body %}
 <div
     id="vite-app"

--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -23,7 +23,7 @@ class HomepageView(TemplateView):
         today = date.today()
         parts = Part.objects.effective(today)
         resources_config = ResourcesConfiguration.objects.first()
-        fr_docs_category_name = resources_config.fr_doc_category.name
+        fr_docs_category_name = resources_config.fr_doc_category.name if resources_config.fr_doc_category else ""
 
         if not parts:
             return context

--- a/solution/ui/e2e/cypress/fixtures/no-resources-results.json
+++ b/solution/ui/e2e/cypress/fixtures/no-resources-results.json
@@ -1,0 +1,6 @@
+{
+    "count": 0,
+    "next": null,
+    "previous": null,
+    "results": []
+}

--- a/solution/ui/e2e/cypress/fixtures/resources-page-2.json
+++ b/solution/ui/e2e/cypress/fixtures/resources-page-2.json
@@ -1,0 +1,2108 @@
+{
+    "count": 2101,
+    "next": "https://regulations-pilot.cms.gov/v3/resources/?category_details=true&fr_grouping=false&location_details=true&locations=42&max_results=100&page=3&page_size=10&paginate=true&sort=newest&start=0",
+    "previous": "https://regulations-pilot.cms.gov/v3/resources/?category_details=true&fr_grouping=false&location_details=true&locations=42&max_results=100&page_size=10&paginate=true&sort=newest&start=0",
+    "results": [
+        {
+            "id": 2578,
+            "created_at": "2022-07-22 11:30:41.035075",
+            "updated_at": "2022-07-22 11:30:41.035093",
+            "approved": true,
+            "date": "2022-07-21",
+            "name": null,
+            "description": "Beneficiary Protections and Medicaid Drug Coverage - Under Value Based Purchasing (VBP) and Other Innovative Payment Arrangements",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib07212022.pdf",
+            "internalURL": "/supplemental_content/2578/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 23,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 52,
+                    "parent": 985,
+                    "type": "section"
+                },
+                {
+                    "id": 56,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 240,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 60,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 347,
+                    "parent": 1128,
+                    "type": "section"
+                },
+                {
+                    "id": 473,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 502,
+                    "parent": 1210,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2579,
+            "created_at": "2022-07-22 14:03:54.594320",
+            "updated_at": "2022-07-22 14:03:54.594340",
+            "approved": true,
+            "date": "2022-07-21",
+            "name": "SMD# 22-003",
+            "description": "RE: Home and Community-Based Services Quality Measure Set",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/smd22003.pdf",
+            "internalURL": "/supplemental_content/2579/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 180,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 181,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 182,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 426,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 303,
+                    "parent": 1149,
+                    "type": "section"
+                },
+                {
+                    "id": 1168,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 474,
+                    "parent": 1158,
+                    "type": "section"
+                },
+                {
+                    "id": 697,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 585,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 456,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 745,
+                    "parent": 1177,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2577,
+            "created_at": "2022-07-14 17:40:23.565281",
+            "updated_at": "2022-07-14 17:40:23.565301",
+            "approved": true,
+            "date": "2022-07-13",
+            "name": "Fact Sheet",
+            "description": "Health Coverage Options for Certain Ukrainian Nationals",
+            "url": "https://www.medicaid.gov/medicaid/eligibility/downloads/hlth-cov-opt-fr-cer-ukrainian-natnls.pdf",
+            "internalURL": "/supplemental_content/2577/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 236,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 403,
+                    "parent": 1499,
+                    "type": "section"
+                },
+                {
+                    "id": 113,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 406,
+                    "parent": 1499,
+                    "type": "section"
+                },
+                {
+                    "id": 271,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 904,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 120,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 908,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 956,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 255,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1110,
+                    "parent": 1525,
+                    "type": "section"
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1200,
+                    "parent": 1526,
+                    "type": "section"
+                },
+                {
+                    "id": 307,
+                    "title": 42,
+                    "part": 436,
+                    "section_id": 406,
+                    "parent": 1078,
+                    "type": "section"
+                },
+                {
+                    "id": 166,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 110,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 548,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 320,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 170,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 350,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 380,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 1591,
+                    "title": 45,
+                    "part": 155,
+                    "section_id": 420,
+                    "parent": null,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2576,
+            "created_at": "2022-07-07 16:51:20.996920",
+            "updated_at": "2022-07-07 16:51:20.996941",
+            "approved": true,
+            "date": "2022-07-06",
+            "name": null,
+            "description": "Medicaid and CHIP Managed Care Monitoring and Oversight Tools",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib07062022.pdf",
+            "internalURL": "/supplemental_content/2576/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 360,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 7,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 349,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 14,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 334,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 66,
+                    "parent": 1086,
+                    "type": "section"
+                },
+                {
+                    "id": 362,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 68,
+                    "parent": 1086,
+                    "type": "section"
+                },
+                {
+                    "id": 658,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 74,
+                    "parent": 1086,
+                    "type": "section"
+                },
+                {
+                    "id": 365,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 207,
+                    "parent": 1112,
+                    "type": "section"
+                },
+                {
+                    "id": 719,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 602,
+                    "parent": 858,
+                    "type": "section"
+                },
+                {
+                    "id": 784,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1209,
+                    "parent": 1407,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2377,
+            "created_at": "2022-06-08 15:56:56.825341",
+            "updated_at": "2022-06-08 15:56:56.825361",
+            "approved": true,
+            "date": "2022-06-03",
+            "name": "SMD# 22-002",
+            "description": "RE: Updated Reporting Requirements and Extension of Deadline to Fully Expend State Funds Under American Rescue Plan Act of 2021 Section 9817",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/smd22002.pdf",
+            "internalURL": "/supplemental_content/2377/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 3,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 30,
+                    "parent": 857,
+                    "type": "section"
+                },
+                {
+                    "id": 16,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 16,
+                    "parent": 851,
+                    "type": "section"
+                },
+                {
+                    "id": 380,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 4,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 368,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 5,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 6,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 57,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 70,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 15,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 80,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 130,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 1,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 167,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 180,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 181,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 182,
+                    "parent": 1124,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2378,
+            "created_at": "2022-06-08 15:59:52.072477",
+            "updated_at": "2022-06-08 15:59:52.072495",
+            "approved": true,
+            "date": "2022-06-02",
+            "name": null,
+            "description": "Top 10 Fundamental Actions to Prepare for Unwinding and Resources to Support \r\nState Efforts",
+            "url": "https://www.medicaid.gov/resources-for-states/downloads/top-10-fundamental-actions-to-prepare-for-unwinding-and-resources-to-support-state-efforts.pdf",
+            "internalURL": "/supplemental_content/2378/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 40,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 206,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 125,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 220,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 706,
+                    "title": 42,
+                    "part": 432,
+                    "section_id": 30,
+                    "parent": 1020,
+                    "type": "section"
+                },
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 112,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 75,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 116,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 271,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 904,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 95,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 905,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 120,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 908,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 912,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 916,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 917,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 945,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 103,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 948,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 952,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 956,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1200,
+                    "parent": 1526,
+                    "type": "section"
+                },
+                {
+                    "id": 547,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 90,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 340,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 343,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 170,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 350,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 380,
+                    "parent": 1376,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2379,
+            "created_at": "2022-06-08 16:01:13.308474",
+            "updated_at": "2022-06-08 16:01:13.308498",
+            "approved": true,
+            "date": "2022-06-02",
+            "name": null,
+            "description": "Updated 2022 SSI and Spousal Impoverishment Standards",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib06022022.pdf",
+            "internalURL": "/supplemental_content/2379/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 259,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 120,
+                    "parent": 876,
+                    "type": "section"
+                },
+                {
+                    "id": 114,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 217,
+                    "parent": 875,
+                    "type": "section"
+                },
+                {
+                    "id": 109,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 602,
+                    "parent": 1506,
+                    "type": "section"
+                },
+                {
+                    "id": 115,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 700,
+                    "parent": 1510,
+                    "type": "section"
+                },
+                {
+                    "id": 116,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 726,
+                    "parent": 1510,
+                    "type": "section"
+                },
+                {
+                    "id": 117,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 735,
+                    "parent": 1510,
+                    "type": "section"
+                },
+                {
+                    "id": 774,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 811,
+                    "parent": 1511,
+                    "type": "section"
+                },
+                {
+                    "id": 683,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 831,
+                    "parent": 1511,
+                    "type": "section"
+                },
+                {
+                    "id": 180,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 832,
+                    "parent": 1511,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2573,
+            "created_at": "2022-06-27 10:13:28.224681",
+            "updated_at": "2022-06-27 10:13:28.224701",
+            "approved": true,
+            "date": "2022-06",
+            "name": null,
+            "description": "Preparedness and Response Toolkit for State Medicaid and CHIP Agencies in the Event of a Public Health Emergency or Disaster",
+            "url": "https://www.medicaid.gov/state-resource-center/downloads/mac-learning-collaboratives/medicaid-chip-disastertoolkit.pdf",
+            "internalURL": "/supplemental_content/2573/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 15,
+                "name": "Toolkits",
+                "description": "",
+                "order": 500,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 850,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 10,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 675,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 12,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 122,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 20,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 671,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 25,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 6,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 10,
+                    "parent": 851,
+                    "type": "section"
+                },
+                {
+                    "id": 23,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 52,
+                    "parent": 985,
+                    "type": "section"
+                },
+                {
+                    "id": 47,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 211,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 130,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 231,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 137,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 244,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 853,
+                    "title": 42,
+                    "part": 431,
+                    "subpart_id": "E",
+                    "type": "subpart"
+                },
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 112,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 849,
+                    "title": 42,
+                    "part": 433,
+                    "subpart_id": "C",
+                    "type": "subpart"
+                },
+                {
+                    "id": 238,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 119,
+                    "parent": 876,
+                    "type": "section"
+                },
+                {
+                    "id": 243,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 218,
+                    "parent": 875,
+                    "type": "section"
+                },
+                {
+                    "id": 236,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 403,
+                    "parent": 1499,
+                    "type": "section"
+                },
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 601,
+                    "parent": 1506,
+                    "type": "section"
+                },
+                {
+                    "id": 111,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 907,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 912,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 926,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 945,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 103,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 948,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 952,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 956,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 255,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1110,
+                    "parent": 1525,
+                    "type": "section"
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1200,
+                    "parent": 1526,
+                    "type": "section"
+                },
+                {
+                    "id": 1525,
+                    "title": 42,
+                    "part": 435,
+                    "subpart_id": "L",
+                    "type": "subpart"
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 6,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 756,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 60,
+                    "parent": 1086,
+                    "type": "section"
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 206,
+                    "parent": 1112,
+                    "type": "section"
+                },
+                {
+                    "id": 370,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 210,
+                    "parent": 1112,
+                    "type": "section"
+                },
+                {
+                    "id": 339,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 402,
+                    "parent": 1117,
+                    "type": "section"
+                },
+                {
+                    "id": 342,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 408,
+                    "parent": 1117,
+                    "type": "section"
+                },
+                {
+                    "id": 57,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 70,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 2,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 90,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 55,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 230,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 56,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 240,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 10,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 250,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 69,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 386,
+                    "parent": 1128,
+                    "type": "section"
+                },
+                {
+                    "id": 392,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 301,
+                    "parent": 1149,
+                    "type": "section"
+                },
+                {
+                    "id": 428,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 351,
+                    "parent": 1150,
+                    "type": "section"
+                },
+                {
+                    "id": 433,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 510,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 437,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 540,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 440,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 555,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 398,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 715,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 441,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 720,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 442,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 725,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 445,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 730,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 662,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 40,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 491,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 45,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 469,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 52,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 495,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 53,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 496,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 54,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 488,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 55,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 497,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 57,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 472,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 205,
+                    "parent": 1198,
+                    "type": "section"
+                },
+                {
+                    "id": 461,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 410,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 522,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 412,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 462,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 414,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 531,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 432,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 523,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 434,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 464,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 450,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 532,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 460,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 859,
+                    "title": 42,
+                    "part": 455,
+                    "subpart_id": "E",
+                    "type": "subpart"
+                },
+                {
+                    "id": 551,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 50,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 572,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 60,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 340,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 556,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 342,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 557,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 355,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 380,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 602,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 510,
+                    "parent": 1384,
+                    "type": "section"
+                },
+                {
+                    "id": 682,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 515,
+                    "parent": 1384,
+                    "type": "section"
+                },
+                {
+                    "id": 588,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1160,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 589,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1170,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1230,
+                    "parent": 1407,
+                    "type": "section"
+                },
+                {
+                    "id": 653,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1260,
+                    "parent": 1407,
+                    "type": "section"
+                },
+                {
+                    "id": 954,
+                    "title": 42,
+                    "part": 457,
+                    "subpart_id": "K",
+                    "type": "subpart"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2574,
+            "created_at": "2022-06-29 17:23:15.143417",
+            "updated_at": "2022-06-29 17:23:15.143438",
+            "approved": true,
+            "date": "2022-06",
+            "name": "Medicaid and CHIP Coverage Learning Collaborative",
+            "description": "Inventory of Medicaid and CHIP Flexibilities and Authorities in the Event of a Public Health Emergency or Disaster",
+            "url": "https://www.medicaid.gov/state-resource-center/downloads/mac-learning-collaboratives/medicaid-chip-inventory.pdf",
+            "internalURL": "/supplemental_content/2574/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 850,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 10,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 675,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 12,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 122,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 20,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 6,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 10,
+                    "parent": 851,
+                    "type": "section"
+                },
+                {
+                    "id": 23,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 52,
+                    "parent": 985,
+                    "type": "section"
+                },
+                {
+                    "id": 47,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 211,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 126,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 221,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 130,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 231,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 137,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 244,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 156,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 416,
+                    "parent": 991,
+                    "type": "section"
+                },
+                {
+                    "id": 853,
+                    "title": 42,
+                    "part": 431,
+                    "subpart_id": "E",
+                    "type": "subpart"
+                },
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 112,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 849,
+                    "title": 42,
+                    "part": 433,
+                    "subpart_id": "C",
+                    "type": "subpart"
+                },
+                {
+                    "id": 243,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 218,
+                    "parent": 875,
+                    "type": "section"
+                },
+                {
+                    "id": 236,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 403,
+                    "parent": 1499,
+                    "type": "section"
+                },
+                {
+                    "id": 111,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 907,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 912,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 916,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 926,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 945,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 103,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 948,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 952,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 956,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 255,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1110,
+                    "parent": 1525,
+                    "type": "section"
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1200,
+                    "parent": 1526,
+                    "type": "section"
+                },
+                {
+                    "id": 1525,
+                    "title": 42,
+                    "part": 435,
+                    "subpart_id": "L",
+                    "type": "subpart"
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 6,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 206,
+                    "parent": 1112,
+                    "type": "section"
+                },
+                {
+                    "id": 370,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 210,
+                    "parent": 1112,
+                    "type": "section"
+                },
+                {
+                    "id": 342,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 408,
+                    "parent": 1117,
+                    "type": "section"
+                },
+                {
+                    "id": 57,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 70,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 2,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 90,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 55,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 230,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 69,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 386,
+                    "parent": 1128,
+                    "type": "section"
+                },
+                {
+                    "id": 392,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 301,
+                    "parent": 1149,
+                    "type": "section"
+                },
+                {
+                    "id": 425,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 302,
+                    "parent": 1149,
+                    "type": "section"
+                },
+                {
+                    "id": 433,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 510,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 437,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 540,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 440,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 555,
+                    "parent": 1174,
+                    "type": "section"
+                },
+                {
+                    "id": 441,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 720,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 442,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 725,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 445,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 730,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 662,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 40,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 491,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 45,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 469,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 52,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 495,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 53,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 496,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 54,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 488,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 55,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 497,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 57,
+                    "parent": 1195,
+                    "type": "section"
+                },
+                {
+                    "id": 472,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 205,
+                    "parent": 1198,
+                    "type": "section"
+                },
+                {
+                    "id": 522,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 412,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 462,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 414,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 531,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 432,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 523,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 434,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 464,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 450,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 532,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 460,
+                    "parent": 859,
+                    "type": "section"
+                },
+                {
+                    "id": 859,
+                    "title": 42,
+                    "part": 455,
+                    "subpart_id": "E",
+                    "type": "subpart"
+                },
+                {
+                    "id": 551,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 50,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 572,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 60,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 168,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 330,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 340,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 556,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 342,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 606,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 351,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 557,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 355,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 380,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 602,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 510,
+                    "parent": 1384,
+                    "type": "section"
+                },
+                {
+                    "id": 588,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1160,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 589,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1170,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1230,
+                    "parent": 1407,
+                    "type": "section"
+                },
+                {
+                    "id": 653,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1260,
+                    "parent": 1407,
+                    "type": "section"
+                },
+                {
+                    "id": 954,
+                    "title": 42,
+                    "part": 457,
+                    "subpart_id": "K",
+                    "type": "subpart"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2597,
+            "created_at": "2022-08-24 22:00:42.079159",
+            "updated_at": "2022-08-31 10:58:52.849547",
+            "approved": true,
+            "date": "2022-05-25",
+            "name": "87 FR 31815",
+            "description": "Basic Health Program; Federal Funding Methodology for Program Year 2023 and Proposed Changes to Basic Health Program Regulations",
+            "url": "https://www.federalregister.gov/documents/2022/05/25/2022-11047/basic-health-program-federal-funding-methodology-for-program-year-2023-and-proposed-changes-to-basic",
+            "internalURL": "/supplemental_content/2597/",
+            "docket_numbers": ["CMS-2441-P"],
+            "document_number": "2022-11047",
+            "doc_type": "NPRM",
+            "name_headline": null,
+            "description_headline": null,
+            "document_number_headline": null,
+            "related_docs": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": true,
+                "type": "category"
+            },
+            "locations": [
+                {
+                    "id": 3096,
+                    "title": 42,
+                    "part": 600,
+                    "section_id": 605,
+                    "parent": 3109,
+                    "type": "section"
+                },
+                {
+                    "id": 3054,
+                    "title": 42,
+                    "part": 600,
+                    "section_id": 610,
+                    "parent": 3109,
+                    "type": "section"
+                }
+            ],
+            "type": "federal_register_doc"
+        }
+    ]
+}

--- a/solution/ui/e2e/cypress/fixtures/resources.json
+++ b/solution/ui/e2e/cypress/fixtures/resources.json
@@ -1,1946 +1,1932 @@
 {
-  "count": 2097,
-  "next": null,
-  "previous": null,
-  "results": [
-    {
-      "id": 2576,
-      "created_at": "2022-07-07 16:51:20.996000",
-      "updated_at": "2022-07-07 16:51:20.996000",
-      "approved": true,
-      "date": "2022-07-06",
-      "name": null,
-      "description": "Medicaid and CHIP Managed Care Monitoring and Oversight Tools",
-      "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib07062022.pdf",
-      "internalURL": "/supplemental_content/2576/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 9,
-        "name": "CMCS Informational Bulletin (CIB)",
-        "description": "",
-        "order": 300,
-        "show_if_empty": false,
-        "parent": {
-          "id": 5,
-          "name": "Subregulatory Guidance",
-          "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
-          "order": 400,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
+    "count": 2101,
+    "next": "https://regulations-pilot.cms.gov/v3/resources/?category_details=true&fr_grouping=false&location_details=true&locations=42&max_results=100&page=2&page_size=10&paginate=true&sort=newest&start=0",
+    "previous": null,
+    "results": [
         {
-          "id": 360,
-          "title": 42,
-          "part": 438,
-          "section_id": 7,
-          "parent": 1071,
-          "type": "section"
-        },
-        {
-          "id": 349,
-          "title": 42,
-          "part": 438,
-          "section_id": 14,
-          "parent": 1071,
-          "type": "section"
+            "id": 2615,
+            "created_at": "2022-09-26 15:27:01.412540",
+            "updated_at": "2022-09-26 15:44:20.173351",
+            "approved": true,
+            "date": "2022-09-21",
+            "name": "SMD# 22-005",
+            "description": "RE: Guidance on Nursing Facility State Plan Payment and Upper Payment Limit Approaches in \r\nMedicaid Relying on the Medicare Patient-Driven Payment Model",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/smd22005.pdf",
+            "internalURL": "/supplemental_content/2615/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 481,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 272,
+                    "parent": 1200,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
         },
         {
-          "id": 334,
-          "title": 42,
-          "part": 438,
-          "section_id": 66,
-          "parent": 1086,
-          "type": "section"
+            "id": 2614,
+            "created_at": "2022-09-12 14:51:19.729990",
+            "updated_at": "2022-09-12 14:51:19.730012",
+            "approved": true,
+            "date": "2022-09-12",
+            "name": null,
+            "description": "Opportunities to Support Unwinding Efforts for States with Integrated Eligibility Systems and/or Workforces",
+            "url": "https://www.medicaid.gov/resources-for-states/downloads/opp-unwind-eff-st-integ-elig-sys-workfor.pdf",
+            "internalURL": "/supplemental_content/2614/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 6,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 10,
+                    "parent": 851,
+                    "type": "section"
+                },
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 112,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 75,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 116,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 110,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 603,
+                    "parent": 1506,
+                    "type": "section"
+                },
+                {
+                    "id": 111,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 907,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 911,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 916,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 917,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 945,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 103,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 948,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 956,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 555,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 315,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 168,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 330,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 340,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 343,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 380,
+                    "parent": 1376,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
         },
         {
-          "id": 362,
-          "title": 42,
-          "part": 438,
-          "section_id": 68,
-          "parent": 1086,
-          "type": "section"
+            "id": 2613,
+            "created_at": "2022-09-07 22:00:37.965656",
+            "updated_at": "2022-09-13 14:27:20.120406",
+            "approved": true,
+            "date": "2022-09-07",
+            "name": "87 FR 54760",
+            "description": "Streamlining the Medicaid, Children's Health Insurance Program, and Basic Health Program Application, Eligibility Determination, Enrollment, and Renewal Processes",
+            "url": "https://www.federalregister.gov/documents/2022/09/07/2022-18875/streamlining-the-medicaid-childrens-health-insurance-program-and-basic-health-program-application",
+            "internalURL": "/supplemental_content/2613/",
+            "docket_numbers": ["CMS-2421-P"],
+            "document_number": "2022-18875",
+            "doc_type": "NPRM",
+            "name_headline": null,
+            "description_headline": null,
+            "document_number_headline": null,
+            "related_docs": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": true,
+                "type": "category"
+            },
+            "locations": [
+                {
+                    "id": 1635,
+                    "title": 42,
+                    "part": 406,
+                    "section_id": 21,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 6,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 10,
+                    "parent": 851,
+                    "type": "section"
+                },
+                {
+                    "id": 19,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 17,
+                    "parent": 851,
+                    "type": "section"
+                },
+                {
+                    "id": 49,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 213,
+                    "parent": 853,
+                    "type": "section"
+                },
+                {
+                    "id": 241,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 4,
+                    "parent": 1046,
+                    "type": "section"
+                },
+                {
+                    "id": 258,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 222,
+                    "parent": 875,
+                    "type": "section"
+                },
+                {
+                    "id": 1562,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 223,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 245,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 407,
+                    "parent": 1499,
+                    "type": "section"
+                },
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 601,
+                    "parent": 1506,
+                    "type": "section"
+                },
+                {
+                    "id": 680,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 608,
+                    "parent": 1506,
+                    "type": "section"
+                },
+                {
+                    "id": 683,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 831,
+                    "parent": 1511,
+                    "type": "section"
+                },
+                {
+                    "id": 111,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 907,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 690,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 909,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 911,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 912,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 260,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 914,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 916,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 1566,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 919,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 101,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 940,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 952,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 956,
+                    "parent": 888,
+                    "type": "section"
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "section_id": 1200,
+                    "parent": 1526,
+                    "type": "section"
+                },
+                {
+                    "id": 165,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 65,
+                    "parent": 1361,
+                    "type": "section"
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 340,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 3102,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 344,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 561,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 348,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 170,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 350,
+                    "parent": 1376,
+                    "type": "section"
+                },
+                {
+                    "id": 592,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 480,
+                    "parent": 1377,
+                    "type": "section"
+                },
+                {
+                    "id": 579,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 570,
+                    "parent": 1384,
+                    "type": "section"
+                },
+                {
+                    "id": 582,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 805,
+                    "parent": 1393,
+                    "type": "section"
+                },
+                {
+                    "id": 571,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 810,
+                    "parent": 1393,
+                    "type": "section"
+                },
+                {
+                    "id": 1403,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 960,
+                    "parent": 1395,
+                    "type": "section"
+                },
+                {
+                    "id": 1404,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 965,
+                    "parent": 1395,
+                    "type": "section"
+                },
+                {
+                    "id": 586,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1140,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 589,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1170,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 590,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 1180,
+                    "parent": 954,
+                    "type": "section"
+                },
+                {
+                    "id": 3078,
+                    "title": 42,
+                    "part": 600,
+                    "section_id": 330,
+                    "parent": 3106,
+                    "type": "section"
+                },
+                {
+                    "id": 3094,
+                    "title": 42,
+                    "part": 600,
+                    "section_id": 525,
+                    "parent": 3108,
+                    "type": "section"
+                }
+            ],
+            "type": "federal_register_doc"
         },
         {
-          "id": 658,
-          "title": 42,
-          "part": 438,
-          "section_id": 74,
-          "parent": 1086,
-          "type": "section"
+            "id": 2589,
+            "created_at": "2022-08-20 22:00:37.519246",
+            "updated_at": "2022-08-31 10:58:52.822042",
+            "approved": true,
+            "date": "2022-08-22",
+            "name": "87 FR 51303",
+            "description": "Medicaid Program and CHIP; Mandatory Medicaid and Children's Health Insurance Program (CHIP) Core Set Reporting",
+            "url": "https://www.federalregister.gov/documents/2022/08/22/2022-17810/medicaid-program-and-chip-mandatory-medicaid-and-childrens-health-insurance-program-chip-core-set",
+            "internalURL": "/supplemental_content/2589/",
+            "docket_numbers": ["CMS-2440-P"],
+            "document_number": "2022-17810",
+            "doc_type": "NPRM",
+            "name_headline": null,
+            "description_headline": null,
+            "document_number_headline": null,
+            "related_docs": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": true,
+                "type": "category"
+            },
+            "locations": [
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 112,
+                    "parent": 849,
+                    "type": "section"
+                },
+                {
+                    "id": 3048,
+                    "title": 42,
+                    "part": 437,
+                    "section_id": 1,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3049,
+                    "title": 42,
+                    "part": 437,
+                    "section_id": 5,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3050,
+                    "title": 42,
+                    "part": 437,
+                    "section_id": 10,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3051,
+                    "title": 42,
+                    "part": 437,
+                    "section_id": 15,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3052,
+                    "title": 42,
+                    "part": 437,
+                    "section_id": 20,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1392,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 700,
+                    "parent": 1391,
+                    "type": "section"
+                },
+                {
+                    "id": 3053,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 770,
+                    "parent": null,
+                    "type": "section"
+                }
+            ],
+            "type": "federal_register_doc"
         },
         {
-          "id": 365,
-          "title": 42,
-          "part": 438,
-          "section_id": 207,
-          "parent": 1112,
-          "type": "section"
+            "id": 2596,
+            "created_at": "2022-08-23 13:57:08.963482",
+            "updated_at": "2022-08-23 13:57:08.963503",
+            "approved": true,
+            "date": "2022-08-22",
+            "name": null,
+            "description": "Medicaid nursing facility payment approaches to advance health equity and improve health outcomes",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib08222022.pdf",
+            "internalURL": "/supplemental_content/2596/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 36,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 40,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 775,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 155,
+                    "parent": 1124,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
         },
         {
-          "id": 719,
-          "title": 42,
-          "part": 438,
-          "section_id": 602,
-          "parent": 858,
-          "type": "section"
+            "id": 2590,
+            "created_at": "2022-08-21 21:20:06.084483",
+            "updated_at": "2022-08-21 21:20:06.084502",
+            "approved": true,
+            "date": "2022-08-18",
+            "name": null,
+            "description": "Information on School-Based Services in Medicaid: Funding, Documentation and Expanding Services",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/sbscib081820222.pdf",
+            "internalURL": "/supplemental_content/2590/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 160,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 107,
+                    "parent": 986,
+                    "type": "section"
+                },
+                {
+                    "id": 202,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 137,
+                    "parent": 901,
+                    "type": "section"
+                },
+                {
+                    "id": 77,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 138,
+                    "parent": 901,
+                    "type": "section"
+                },
+                {
+                    "id": 214,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 139,
+                    "parent": 901,
+                    "type": "section"
+                },
+                {
+                    "id": 36,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 40,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 50,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 110,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 55,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 230,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 405,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 56,
+                    "parent": 889,
+                    "type": "section"
+                },
+                {
+                    "id": 449,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 57,
+                    "parent": 889,
+                    "type": "section"
+                },
+                {
+                    "id": 889,
+                    "title": 42,
+                    "part": 441,
+                    "subpart_id": "B",
+                    "type": "subpart"
+                },
+                {
+                    "id": 728,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 200,
+                    "parent": 1198,
+                    "type": "section"
+                },
+                {
+                    "id": 660,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 201,
+                    "parent": 1198,
+                    "type": "section"
+                },
+                {
+                    "id": 1199,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 202,
+                    "parent": 1198,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
         },
         {
-          "id": 784,
-          "title": 42,
-          "part": 457,
-          "subpart_id": "I",
-          "type": "subpart"
+            "id": 2583,
+            "created_at": "2022-08-17 16:24:06.552482",
+            "updated_at": "2022-08-17 16:24:06.552501",
+            "approved": true,
+            "date": "2022-08-17",
+            "name": null,
+            "description": "Applicable Federal Cost Principles for Ground Emergency Medical Transportation (GEMT)",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib08172022.pdf",
+            "internalURL": "/supplemental_content/2583/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 850,
+                    "title": 42,
+                    "part": 430,
+                    "section_id": 10,
+                    "parent": 960,
+                    "type": "section"
+                },
+                {
+                    "id": 28,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 53,
+                    "parent": 985,
+                    "type": "section"
+                },
+                {
+                    "id": 160,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 107,
+                    "parent": 986,
+                    "type": "section"
+                },
+                {
+                    "id": 48,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 170,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 660,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 201,
+                    "parent": 1198,
+                    "type": "section"
+                },
+                {
+                    "id": 839,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 300,
+                    "parent": 1223,
+                    "type": "section"
+                },
+                {
+                    "id": 2973,
+                    "title": 45,
+                    "part": 75,
+                    "section_id": 2,
+                    "parent": null,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2581,
+            "created_at": "2022-08-04 22:00:41.980242",
+            "updated_at": "2022-08-31 10:58:52.834985",
+            "approved": true,
+            "date": "2022-08-04",
+            "name": "87 FR 47824",
+            "description": "Nondiscrimination in Health Programs and Activities",
+            "url": "https://www.federalregister.gov/documents/2022/08/04/2022-16217/nondiscrimination-in-health-programs-and-activities",
+            "internalURL": "/supplemental_content/2581/",
+            "docket_numbers": ["HHS-OS-2022-0012"],
+            "document_number": "2022-16217",
+            "doc_type": "NPRM",
+            "name_headline": null,
+            "description_headline": null,
+            "document_number_headline": null,
+            "related_docs": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": true,
+                "type": "category"
+            },
+            "locations": [
+                {
+                    "id": 3016,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 1,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3017,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 2,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3018,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 3,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3019,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 4,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3020,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 5,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3021,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 6,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3022,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 7,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3023,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 8,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3024,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 9,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3025,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 10,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3026,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 11,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3027,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 101,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3028,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 201,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3029,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 202,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3030,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 203,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3031,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 204,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3032,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 205,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3033,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 206,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3034,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 207,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3035,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 208,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3036,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 209,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3037,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 210,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3038,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 211,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3039,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 301,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3040,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 302,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3041,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 303,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3042,
+                    "title": 42,
+                    "part": 92,
+                    "section_id": 304,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3043,
+                    "title": 42,
+                    "part": 147,
+                    "section_id": 104,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3044,
+                    "title": 42,
+                    "part": 155,
+                    "section_id": 120,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3045,
+                    "title": 42,
+                    "part": 155,
+                    "section_id": 220,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3046,
+                    "title": 42,
+                    "part": 156,
+                    "section_id": 200,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3047,
+                    "title": 42,
+                    "part": 156,
+                    "section_id": 1230,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 3,
+                    "parent": 1071,
+                    "type": "section"
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "section_id": 206,
+                    "parent": 1112,
+                    "type": "section"
+                },
+                {
+                    "id": 763,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 262,
+                    "parent": 1125,
+                    "type": "section"
+                },
+                {
+                    "id": 575,
+                    "title": 42,
+                    "part": 457,
+                    "section_id": 495,
+                    "parent": 1377,
+                    "type": "section"
+                },
+                {
+                    "id": 1450,
+                    "title": 42,
+                    "part": 460,
+                    "section_id": 98,
+                    "parent": 1446,
+                    "type": "section"
+                },
+                {
+                    "id": 1457,
+                    "title": 42,
+                    "part": 460,
+                    "section_id": 112,
+                    "parent": 1455,
+                    "type": "section"
+                }
+            ],
+            "type": "federal_register_doc"
+        },
+        {
+            "id": 2612,
+            "created_at": "2022-08-29 13:33:00.042932",
+            "updated_at": "2022-08-29 13:33:00.042952",
+            "approved": true,
+            "date": "2022-08-01",
+            "name": "SMD # 22-004",
+            "description": "Health Homes for Children with Medically Complex Conditions",
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/smd22004.pdf",
+            "internalURL": "/supplemental_content/2612/",
+            "name_headline": null,
+            "description_headline": null,
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false
+                },
+                "type": "subcategory"
+            },
+            "locations": [
+                {
+                    "id": 23,
+                    "title": 42,
+                    "part": 431,
+                    "section_id": 52,
+                    "parent": 985,
+                    "type": "section"
+                },
+                {
+                    "id": 200,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 10,
+                    "parent": 1026,
+                    "type": "section"
+                },
+                {
+                    "id": 221,
+                    "title": 42,
+                    "part": 433,
+                    "section_id": 32,
+                    "parent": 1026,
+                    "type": "section"
+                },
+                {
+                    "id": 42,
+                    "title": 42,
+                    "part": 440,
+                    "section_id": 168,
+                    "parent": 1124,
+                    "type": "section"
+                },
+                {
+                    "id": 442,
+                    "title": 42,
+                    "part": 441,
+                    "section_id": 725,
+                    "parent": 1177,
+                    "type": "section"
+                },
+                {
+                    "id": 472,
+                    "title": 42,
+                    "part": 447,
+                    "section_id": 205,
+                    "parent": 1198,
+                    "type": "section"
+                }
+            ],
+            "type": "supplemental_content"
+        },
+        {
+            "id": 2580,
+            "created_at": "2022-07-29 10:02:16.977484",
+            "updated_at": "2022-08-31 10:58:52.842284",
+            "approved": true,
+            "date": "2022-07-29",
+            "name": "87 FR 45860",
+            "description": "Medicare and Medicaid Programs; CY 2023 Payment Policies Under the Physician Fee Schedule and Other Changes to Part B Payment Policies; Medicare Shared Savings Program Requirements; Medicare and Medicaid Provider Enrollment Policies, Including for Skilled Nursing Facilities; Conditions of Payment for Suppliers of Durable Medicaid Equipment, Prosthetics, Orthotics, and Supplies (DMEPOS); and Implementing Requirements for Manufacturers of Certain Single-Dose Container or Single-Use Package Drugs To Provide Refunds With Respect to Discarded Amounts",
+            "url": "https://www.federalregister.gov/documents/2022/07/29/2022-14562/medicare-and-medicaid-programs-cy-2023-payment-policies-under-the-physician-fee-schedule-and-other",
+            "internalURL": "/supplemental_content/2580/",
+            "docket_numbers": ["CMS-1770-P"],
+            "document_number": "2022-14562",
+            "doc_type": "NPRM",
+            "name_headline": null,
+            "description_headline": null,
+            "document_number_headline": null,
+            "related_docs": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": true,
+                "type": "category"
+            },
+            "locations": [
+                {
+                    "id": 2982,
+                    "title": 42,
+                    "part": 405,
+                    "section_id": 2463,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2983,
+                    "title": 42,
+                    "part": 405,
+                    "section_id": 2469,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2985,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 3,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2984,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 10,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2797,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 26,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2986,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 37,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2087,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 40,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1830,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 57,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2987,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 63,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2056,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 67,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2057,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 78,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1831,
+                    "title": 42,
+                    "part": 410,
+                    "section_id": 152,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1833,
+                    "title": 42,
+                    "part": 411,
+                    "section_id": 15,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2438,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 502,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2439,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 504,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2440,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 507,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2988,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 523,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2989,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 626,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1835,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 707,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2990,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 902,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1837,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 904,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2991,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 940,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2441,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1305,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2992,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1318,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2993,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1340,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2994,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1365,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2089,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1380,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2064,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1400,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2995,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1405,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2996,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1415,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2997,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1420,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2998,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1430,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2999,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1440,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2451,
+                    "title": 42,
+                    "part": 414,
+                    "section_id": 1450,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3000,
+                    "title": 42,
+                    "part": 415,
+                    "section_id": 140,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2453,
+                    "title": 42,
+                    "part": 423,
+                    "section_id": 160,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1976,
+                    "title": 42,
+                    "part": 424,
+                    "section_id": 57,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1977,
+                    "title": 42,
+                    "part": 424,
+                    "section_id": 502,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1980,
+                    "title": 42,
+                    "part": 424,
+                    "section_id": 518,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1982,
+                    "title": 42,
+                    "part": 424,
+                    "section_id": 530,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 1797,
+                    "title": 42,
+                    "part": 424,
+                    "section_id": 535,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3001,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 20,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2455,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 100,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2457,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 204,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2458,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 224,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2459,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 302,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3002,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 308,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3003,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 310,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3004,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 312,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2460,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 316,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2070,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 400,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2811,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 402,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2464,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 512,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2071,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 600,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2465,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 601,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2469,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 605,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2471,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 610,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2072,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 611,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2814,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 612,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3005,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 614,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3006,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 630,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3007,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 631,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3008,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 650,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3009,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 652,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3010,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 654,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3011,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 656,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3012,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 658,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3013,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 660,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3014,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 702,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 3015,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 704,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 2472,
+                    "title": 42,
+                    "part": 425,
+                    "section_id": 800,
+                    "parent": null,
+                    "type": "section"
+                },
+                {
+                    "id": 520,
+                    "title": 42,
+                    "part": 455,
+                    "section_id": 107,
+                    "parent": 1216,
+                    "type": "section"
+                }
+            ],
+            "type": "federal_register_doc"
         }
-      ],
-      "type": "supplemental_content"
-    },
-    {
-      "id": 2377,
-      "created_at": "2022-06-08 15:56:56.825000",
-      "updated_at": "2022-06-08 15:56:56.825000",
-      "approved": true,
-      "date": "2022-06-03",
-      "name": "SMD# 22-002",
-      "description": "RE: Updated Reporting Requirements and Extension of Deadline to Fully Expend State Funds Under American Rescue Plan Act of 2021 Section 9817",
-      "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/smd22002.pdf",
-      "internalURL": "/supplemental_content/2377/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 7,
-        "name": "State Medicaid Director Letter (SMDL)",
-        "description": "",
-        "order": 100,
-        "show_if_empty": false,
-        "parent": {
-          "id": 5,
-          "name": "Subregulatory Guidance",
-          "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
-          "order": 400,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
-        {
-          "id": 3,
-          "title": 42,
-          "part": 430,
-          "section_id": 30,
-          "parent": 857,
-          "type": "section"
-        },
-        {
-          "id": 16,
-          "title": 42,
-          "part": 431,
-          "section_id": 16,
-          "parent": 851,
-          "type": "section"
-        },
-        {
-          "id": 380,
-          "title": 42,
-          "part": 438,
-          "section_id": 4,
-          "parent": 1071,
-          "type": "section"
-        },
-        {
-          "id": 368,
-          "title": 42,
-          "part": 438,
-          "section_id": 5,
-          "parent": 1071,
-          "type": "section"
-        },
-        {
-          "id": 359,
-          "title": 42,
-          "part": 438,
-          "section_id": 6,
-          "parent": 1071,
-          "type": "section"
-        },
-        {
-          "id": 57,
-          "title": 42,
-          "part": 440,
-          "section_id": 70,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 15,
-          "title": 42,
-          "part": 440,
-          "section_id": 80,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 51,
-          "title": 42,
-          "part": 440,
-          "section_id": 130,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 1,
-          "title": 42,
-          "part": 440,
-          "subpart_id": "A",
-          "type": "subpart"
-        },
-        {
-          "id": 73,
-          "title": 42,
-          "part": 440,
-          "section_id": 180,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 17,
-          "title": 42,
-          "part": 440,
-          "section_id": 181,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 18,
-          "title": 42,
-          "part": 440,
-          "section_id": 182,
-          "parent": 1124,
-          "type": "section"
-        }
-      ],
-      "type": "supplemental_content"
-    },
-    {
-      "id": 2378,
-      "created_at": "2022-06-08 15:59:52.072000",
-      "updated_at": "2022-06-08 15:59:52.072000",
-      "approved": true,
-      "date": "2022-06-02",
-      "name": null,
-      "description": "Top 10 Fundamental Actions to Prepare for Unwinding and Resources to Support \r\nState Efforts",
-      "url": "https://www.medicaid.gov/resources-for-states/downloads/top-10-fundamental-actions-to-prepare-for-unwinding-and-resources-to-support-state-efforts.pdf",
-      "internalURL": "/supplemental_content/2378/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 13,
-        "name": "Technical Assistance for States",
-        "description": "",
-        "order": 200,
-        "show_if_empty": false,
-        "parent": {
-          "id": 11,
-          "name": "Implementation Resources",
-          "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
-          "order": 500,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
-        {
-          "id": 40,
-          "title": 42,
-          "part": 431,
-          "section_id": 206,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 125,
-          "title": 42,
-          "part": 431,
-          "section_id": 220,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 706,
-          "title": 42,
-          "part": 432,
-          "section_id": 30,
-          "parent": 1020,
-          "type": "section"
-        },
-        {
-          "id": 79,
-          "title": 42,
-          "part": 433,
-          "section_id": 112,
-          "parent": 849,
-          "type": "section"
-        },
-        {
-          "id": 75,
-          "title": 42,
-          "part": 433,
-          "section_id": 116,
-          "parent": 849,
-          "type": "section"
-        },
-        {
-          "id": 271,
-          "title": 42,
-          "part": 435,
-          "section_id": 904,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 95,
-          "title": 42,
-          "part": 435,
-          "section_id": 905,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 120,
-          "title": 42,
-          "part": 435,
-          "section_id": 908,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 98,
-          "title": 42,
-          "part": 435,
-          "section_id": 912,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 96,
-          "title": 42,
-          "part": 435,
-          "section_id": 916,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 99,
-          "title": 42,
-          "part": 435,
-          "section_id": 917,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 102,
-          "title": 42,
-          "part": 435,
-          "section_id": 945,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 103,
-          "title": 42,
-          "part": 435,
-          "section_id": 948,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 105,
-          "title": 42,
-          "part": 435,
-          "section_id": 952,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 106,
-          "title": 42,
-          "part": 435,
-          "section_id": 956,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 97,
-          "title": 42,
-          "part": 435,
-          "section_id": 1200,
-          "parent": 1526,
-          "type": "section"
-        },
-        {
-          "id": 547,
-          "title": 42,
-          "part": 457,
-          "section_id": 90,
-          "parent": 1361,
-          "type": "section"
-        },
-        {
-          "id": 169,
-          "title": 42,
-          "part": 457,
-          "section_id": 340,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 577,
-          "title": 42,
-          "part": 457,
-          "section_id": 343,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 170,
-          "title": 42,
-          "part": 457,
-          "section_id": 350,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 171,
-          "title": 42,
-          "part": 457,
-          "section_id": 380,
-          "parent": 1376,
-          "type": "section"
-        }
-      ],
-      "type": "supplemental_content"
-    },
-    {
-      "id": 2379,
-      "created_at": "2022-06-08 16:01:13.308000",
-      "updated_at": "2022-06-08 16:01:13.308000",
-      "approved": true,
-      "date": "2022-06-02",
-      "name": null,
-      "description": "Updated 2022 SSI and Spousal Impoverishment Standards",
-      "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib06022022.pdf",
-      "internalURL": "/supplemental_content/2379/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 9,
-        "name": "CMCS Informational Bulletin (CIB)",
-        "description": "",
-        "order": 300,
-        "show_if_empty": false,
-        "parent": {
-          "id": 5,
-          "name": "Subregulatory Guidance",
-          "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
-          "order": 400,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
-        {
-          "id": 259,
-          "title": 42,
-          "part": 435,
-          "section_id": 120,
-          "parent": 876,
-          "type": "section"
-        },
-        {
-          "id": 114,
-          "title": 42,
-          "part": 435,
-          "section_id": 217,
-          "parent": 875,
-          "type": "section"
-        },
-        {
-          "id": 109,
-          "title": 42,
-          "part": 435,
-          "section_id": 602,
-          "parent": 1506,
-          "type": "section"
-        },
-        {
-          "id": 115,
-          "title": 42,
-          "part": 435,
-          "section_id": 700,
-          "parent": 1510,
-          "type": "section"
-        },
-        {
-          "id": 116,
-          "title": 42,
-          "part": 435,
-          "section_id": 726,
-          "parent": 1510,
-          "type": "section"
-        },
-        {
-          "id": 117,
-          "title": 42,
-          "part": 435,
-          "section_id": 735,
-          "parent": 1510,
-          "type": "section"
-        },
-        {
-          "id": 774,
-          "title": 42,
-          "part": 435,
-          "section_id": 811,
-          "parent": 1511,
-          "type": "section"
-        },
-        {
-          "id": 683,
-          "title": 42,
-          "part": 435,
-          "section_id": 831,
-          "parent": 1511,
-          "type": "section"
-        },
-        {
-          "id": 180,
-          "title": 42,
-          "part": 435,
-          "section_id": 832,
-          "parent": 1511,
-          "type": "section"
-        }
-      ],
-      "type": "supplemental_content"
-    },
-    {
-      "id": 2573,
-      "created_at": "2022-06-27 10:13:28.224000",
-      "updated_at": "2022-06-27 10:13:28.224000",
-      "approved": true,
-      "date": "2022-06",
-      "name": null,
-      "description": "Preparedness and Response Toolkit for State Medicaid and CHIP Agencies in the Event of a Public Health Emergency or Disaster",
-      "url": "https://www.medicaid.gov/state-resource-center/downloads/mac-learning-collaboratives/medicaid-chip-disastertoolkit.pdf",
-      "internalURL": "/supplemental_content/2573/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 15,
-        "name": "Toolkits",
-        "description": "",
-        "order": 500,
-        "show_if_empty": false,
-        "parent": {
-          "id": 11,
-          "name": "Implementation Resources",
-          "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
-          "order": 500,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
-        {
-          "id": 850,
-          "title": 42,
-          "part": 430,
-          "section_id": 10,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 675,
-          "title": 42,
-          "part": 430,
-          "section_id": 12,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 122,
-          "title": 42,
-          "part": 430,
-          "section_id": 20,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 671,
-          "title": 42,
-          "part": 430,
-          "section_id": 25,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 6,
-          "title": 42,
-          "part": 431,
-          "section_id": 10,
-          "parent": 851,
-          "type": "section"
-        },
-        {
-          "id": 853,
-          "title": 42,
-          "part": 431,
-          "subpart_id": "E",
-          "type": "subpart"
-        },
-        {
-          "id": 23,
-          "title": 42,
-          "part": 431,
-          "section_id": 52,
-          "parent": 985,
-          "type": "section"
-        },
-        {
-          "id": 47,
-          "title": 42,
-          "part": 431,
-          "section_id": 211,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 130,
-          "title": 42,
-          "part": 431,
-          "section_id": 231,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 137,
-          "title": 42,
-          "part": 431,
-          "subpart_id": "H-L",
-          "type": "subpart"
-        },
-        {
-          "id": 849,
-          "title": 42,
-          "part": 433,
-          "subpart_id": "C",
-          "type": "subpart"
-        },
-        {
-          "id": 79,
-          "title": 42,
-          "part": 433,
-          "section_id": 112,
-          "parent": 849,
-          "type": "section"
-        },
-        {
-          "id": 238,
-          "title": 42,
-          "part": 435,
-          "section_id": 119,
-          "parent": 876,
-          "type": "section"
-        },
-        {
-          "id": 243,
-          "title": 42,
-          "part": 435,
-          "section_id": 218,
-          "parent": 875,
-          "type": "section"
-        },
-        {
-          "id": 1525,
-          "title": 42,
-          "part": 435,
-          "subpart_id": "L",
-          "type": "subpart"
-        },
-        {
-          "id": 236,
-          "title": 42,
-          "part": 435,
-          "section_id": 403,
-          "parent": 1499,
-          "type": "section"
-        },
-        {
-          "id": 108,
-          "title": 42,
-          "part": 435,
-          "section_id": 601,
-          "parent": 1506,
-          "type": "section"
-        },
-        {
-          "id": 111,
-          "title": 42,
-          "part": 435,
-          "section_id": 907,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 98,
-          "title": 42,
-          "part": 435,
-          "section_id": 912,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 100,
-          "title": 42,
-          "part": 435,
-          "section_id": 926,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 102,
-          "title": 42,
-          "part": 435,
-          "section_id": 945,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 103,
-          "title": 42,
-          "part": 435,
-          "section_id": 948,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 105,
-          "title": 42,
-          "part": 435,
-          "section_id": 952,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 106,
-          "title": 42,
-          "part": 435,
-          "section_id": 956,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 255,
-          "title": 42,
-          "part": 435,
-          "section_id": 1110,
-          "parent": 1525,
-          "type": "section"
-        },
-        {
-          "id": 97,
-          "title": 42,
-          "part": 435,
-          "section_id": 1200,
-          "parent": 1526,
-          "type": "section"
-        },
-        {
-          "id": 359,
-          "title": 42,
-          "part": 438,
-          "section_id": 6,
-          "parent": 1071,
-          "type": "section"
-        },
-        {
-          "id": 756,
-          "title": 42,
-          "part": 438,
-          "section_id": 60,
-          "parent": 1086,
-          "type": "section"
-        },
-        {
-          "id": 364,
-          "title": 42,
-          "part": 438,
-          "section_id": 206,
-          "parent": 1112,
-          "type": "section"
-        },
-        {
-          "id": 370,
-          "title": 42,
-          "part": 438,
-          "section_id": 210,
-          "parent": 1112,
-          "type": "section"
-        },
-        {
-          "id": 339,
-          "title": 42,
-          "part": 438,
-          "section_id": 402,
-          "parent": 1117,
-          "type": "section"
-        },
-        {
-          "id": 342,
-          "title": 42,
-          "part": 438,
-          "section_id": 408,
-          "parent": 1117,
-          "type": "section"
-        },
-        {
-          "id": 57,
-          "title": 42,
-          "part": 440,
-          "section_id": 70,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 2,
-          "title": 42,
-          "part": 440,
-          "subpart_id": "A",
-          "type": "subpart"
-        },
-        {
-          "id": 55,
-          "title": 42,
-          "part": 440,
-          "section_id": 230,
-          "parent": 1125,
-          "type": "section"
-        },
-        {
-          "id": 56,
-          "title": 42,
-          "part": 440,
-          "section_id": 240,
-          "parent": 1125,
-          "type": "section"
-        },
-        {
-          "id": 10,
-          "title": 42,
-          "part": 440,
-          "subpart_id": "B",
-          "type": "subpart"
-        },
-        {
-          "id": 69,
-          "title": 42,
-          "part": 440,
-          "section_id": 386,
-          "parent": 1128,
-          "type": "section"
-        },
-        {
-          "id": 392,
-          "title": 42,
-          "part": 441,
-          "section_id": 301,
-          "parent": 1149,
-          "type": "section"
-        },
-        {
-          "id": 428,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "L",
-          "type": "subpart"
-        },
-        {
-          "id": 433,
-          "title": 42,
-          "part": 441,
-          "section_id": 510,
-          "parent": 1174,
-          "type": "section"
-        },
-        {
-          "id": 437,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "A",
-          "type": "subpart"
-        },
-        {
-          "id": 440,
-          "title": 42,
-          "part": 441,
-          "section_id": 555,
-          "parent": 1174,
-          "type": "section"
-        },
-        {
-          "id": 398,
-          "title": 42,
-          "part": 441,
-          "section_id": 715,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 441,
-          "title": 42,
-          "part": 441,
-          "section_id": 720,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 442,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "B",
-          "type": "subpart"
-        },
-        {
-          "id": 445,
-          "title": 42,
-          "part": 441,
-          "section_id": 730,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 662,
-          "title": 42,
-          "part": 447,
-          "subpart_id": "B",
-          "type": "subpart"
-        },
-        {
-          "id": 491,
-          "title": 42,
-          "part": 447,
-          "section_id": 45,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 469,
-          "title": 42,
-          "part": 447,
-          "section_id": 52,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 495,
-          "title": 42,
-          "part": 447,
-          "section_id": 53,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 496,
-          "title": 42,
-          "part": 447,
-          "section_id": 54,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 488,
-          "title": 42,
-          "part": 447,
-          "section_id": 55,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 497,
-          "title": 42,
-          "part": 447,
-          "section_id": 57,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 472,
-          "title": 42,
-          "part": 447,
-          "section_id": 205,
-          "parent": 1198,
-          "type": "section"
-        },
-        {
-          "id": 859,
-          "title": 42,
-          "part": 455,
-          "subpart_id": "E",
-          "type": "subpart"
-        },
-        {
-          "id": 461,
-          "title": 42,
-          "part": 455,
-          "section_id": 410,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 522,
-          "title": 42,
-          "part": 455,
-          "section_id": 412,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 462,
-          "title": 42,
-          "part": 455,
-          "section_id": 414,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 531,
-          "title": 42,
-          "part": 455,
-          "section_id": 432,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 523,
-          "title": 42,
-          "part": 455,
-          "section_id": 434,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 464,
-          "title": 42,
-          "part": 455,
-          "section_id": 450,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 532,
-          "title": 42,
-          "part": 455,
-          "section_id": 460,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 551,
-          "title": 42,
-          "part": 457,
-          "subpart_id": "C",
-          "type": "subpart"
-        },
-        {
-          "id": 572,
-          "title": 42,
-          "part": 457,
-          "section_id": 60,
-          "parent": 1361,
-          "type": "section"
-        },
-        {
-          "id": 169,
-          "title": 42,
-          "part": 457,
-          "section_id": 340,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 556,
-          "title": 42,
-          "part": 457,
-          "section_id": 342,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 557,
-          "title": 42,
-          "part": 457,
-          "section_id": 355,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 171,
-          "title": 42,
-          "part": 457,
-          "section_id": 380,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 602,
-          "title": 42,
-          "part": 457,
-          "section_id": 510,
-          "parent": 1384,
-          "type": "section"
-        },
-        {
-          "id": 954,
-          "title": 42,
-          "part": 457,
-          "subpart_id": "K",
-          "type": "subpart"
-        },
-        {
-          "id": 682,
-          "title": 42,
-          "part": 457,
-          "section_id": 515,
-          "parent": 1384,
-          "type": "section"
-        },
-        {
-          "id": 588,
-          "title": 42,
-          "part": 457,
-          "section_id": 1160,
-          "parent": 954,
-          "type": "section"
-        },
-        {
-          "id": 589,
-          "title": 42,
-          "part": 457,
-          "section_id": 1170,
-          "parent": 954,
-          "type": "section"
-        },
-        {
-          "id": 576,
-          "title": 42,
-          "part": 457,
-          "section_id": 1230,
-          "parent": 1407,
-          "type": "section"
-        },
-        {
-          "id": 653,
-          "title": 42,
-          "part": 457,
-          "section_id": 1260,
-          "parent": 1407,
-          "type": "section"
-        }
-      ],
-      "type": "supplemental_content"
-    },
-    {
-      "id": 2574,
-      "created_at": "2022-06-29 17:23:15.143000",
-      "updated_at": "2022-06-29 17:23:15.143000",
-      "approved": true,
-      "date": "2022-06",
-      "name": "Medicaid and CHIP Coverage Learning Collaborative",
-      "description": "Inventory of Medicaid and CHIP Flexibilities and Authorities in the Event of a Public Health Emergency or Disaster",
-      "url": "https://www.medicaid.gov/state-resource-center/downloads/mac-learning-collaboratives/medicaid-chip-inventory.pdf",
-      "internalURL": "/supplemental_content/2574/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 13,
-        "name": "Technical Assistance for States",
-        "description": "",
-        "order": 200,
-        "show_if_empty": false,
-        "parent": {
-          "id": 11,
-          "name": "Implementation Resources",
-          "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
-          "order": 500,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
-        {
-          "id": 850,
-          "title": 42,
-          "part": 430,
-          "section_id": 10,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 675,
-          "title": 42,
-          "part": 430,
-          "section_id": 12,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 122,
-          "title": 42,
-          "part": 430,
-          "section_id": 20,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 6,
-          "title": 42,
-          "part": 431,
-          "section_id": 10,
-          "parent": 851,
-          "type": "section"
-        },
-        {
-          "id": 853,
-          "title": 42,
-          "part": 431,
-          "subpart_id": "E",
-          "type": "subpart"
-        },
-        {
-          "id": 23,
-          "title": 42,
-          "part": 431,
-          "section_id": 52,
-          "parent": 985,
-          "type": "section"
-        },
-        {
-          "id": 47,
-          "title": 42,
-          "part": 431,
-          "section_id": 211,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 126,
-          "title": 42,
-          "part": 431,
-          "section_id": 221,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 130,
-          "title": 42,
-          "part": 431,
-          "section_id": 231,
-          "parent": 853,
-          "type": "section"
-        },
-        {
-          "id": 137,
-          "title": 42,
-          "part": 431,
-          "subpart_id": "H-L",
-          "type": "subpart"
-        },
-        {
-          "id": 156,
-          "title": 42,
-          "part": 431,
-          "section_id": 416,
-          "parent": 991,
-          "type": "section"
-        },
-        {
-          "id": 849,
-          "title": 42,
-          "part": 433,
-          "subpart_id": "C",
-          "type": "subpart"
-        },
-        {
-          "id": 79,
-          "title": 42,
-          "part": 433,
-          "section_id": 112,
-          "parent": 849,
-          "type": "section"
-        },
-        {
-          "id": 243,
-          "title": 42,
-          "part": 435,
-          "section_id": 218,
-          "parent": 875,
-          "type": "section"
-        },
-        {
-          "id": 1525,
-          "title": 42,
-          "part": 435,
-          "subpart_id": "L",
-          "type": "subpart"
-        },
-        {
-          "id": 236,
-          "title": 42,
-          "part": 435,
-          "section_id": 403,
-          "parent": 1499,
-          "type": "section"
-        },
-        {
-          "id": 111,
-          "title": 42,
-          "part": 435,
-          "section_id": 907,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 98,
-          "title": 42,
-          "part": 435,
-          "section_id": 912,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 96,
-          "title": 42,
-          "part": 435,
-          "section_id": 916,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 100,
-          "title": 42,
-          "part": 435,
-          "section_id": 926,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 102,
-          "title": 42,
-          "part": 435,
-          "section_id": 945,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 103,
-          "title": 42,
-          "part": 435,
-          "section_id": 948,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 105,
-          "title": 42,
-          "part": 435,
-          "section_id": 952,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 106,
-          "title": 42,
-          "part": 435,
-          "section_id": 956,
-          "parent": 888,
-          "type": "section"
-        },
-        {
-          "id": 255,
-          "title": 42,
-          "part": 435,
-          "section_id": 1110,
-          "parent": 1525,
-          "type": "section"
-        },
-        {
-          "id": 97,
-          "title": 42,
-          "part": 435,
-          "section_id": 1200,
-          "parent": 1526,
-          "type": "section"
-        },
-        {
-          "id": 359,
-          "title": 42,
-          "part": 438,
-          "section_id": 6,
-          "parent": 1071,
-          "type": "section"
-        },
-        {
-          "id": 364,
-          "title": 42,
-          "part": 438,
-          "section_id": 206,
-          "parent": 1112,
-          "type": "section"
-        },
-        {
-          "id": 370,
-          "title": 42,
-          "part": 438,
-          "section_id": 210,
-          "parent": 1112,
-          "type": "section"
-        },
-        {
-          "id": 342,
-          "title": 42,
-          "part": 438,
-          "section_id": 408,
-          "parent": 1117,
-          "type": "section"
-        },
-        {
-          "id": 57,
-          "title": 42,
-          "part": 440,
-          "section_id": 70,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 2,
-          "title": 42,
-          "part": 440,
-          "subpart_id": "A",
-          "type": "subpart"
-        },
-        {
-          "id": 55,
-          "title": 42,
-          "part": 440,
-          "section_id": 230,
-          "parent": 1125,
-          "type": "section"
-        },
-        {
-          "id": 69,
-          "title": 42,
-          "part": 440,
-          "section_id": 386,
-          "parent": 1128,
-          "type": "section"
-        },
-        {
-          "id": 392,
-          "title": 42,
-          "part": 441,
-          "section_id": 301,
-          "parent": 1149,
-          "type": "section"
-        },
-        {
-          "id": 425,
-          "title": 42,
-          "part": 441,
-          "section_id": 302,
-          "parent": 1149,
-          "type": "section"
-        },
-        {
-          "id": 433,
-          "title": 42,
-          "part": 441,
-          "section_id": 510,
-          "parent": 1174,
-          "type": "section"
-        },
-        {
-          "id": 437,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "A",
-          "type": "subpart"
-        },
-        {
-          "id": 440,
-          "title": 42,
-          "part": 441,
-          "section_id": 555,
-          "parent": 1174,
-          "type": "section"
-        },
-        {
-          "id": 441,
-          "title": 42,
-          "part": 441,
-          "section_id": 720,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 442,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "B",
-          "type": "subpart"
-        },
-        {
-          "id": 445,
-          "title": 42,
-          "part": 441,
-          "section_id": 730,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 662,
-          "title": 42,
-          "part": 447,
-          "subpart_id": "B",
-          "type": "subpart"
-        },
-        {
-          "id": 491,
-          "title": 42,
-          "part": 447,
-          "section_id": 45,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 469,
-          "title": 42,
-          "part": 447,
-          "section_id": 52,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 495,
-          "title": 42,
-          "part": 447,
-          "section_id": 53,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 496,
-          "title": 42,
-          "part": 447,
-          "section_id": 54,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 488,
-          "title": 42,
-          "part": 447,
-          "section_id": 55,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 497,
-          "title": 42,
-          "part": 447,
-          "section_id": 57,
-          "parent": 1195,
-          "type": "section"
-        },
-        {
-          "id": 472,
-          "title": 42,
-          "part": 447,
-          "section_id": 205,
-          "parent": 1198,
-          "type": "section"
-        },
-        {
-          "id": 859,
-          "title": 42,
-          "part": 455,
-          "subpart_id": "E",
-          "type": "subpart"
-        },
-        {
-          "id": 522,
-          "title": 42,
-          "part": 455,
-          "section_id": 412,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 462,
-          "title": 42,
-          "part": 455,
-          "section_id": 414,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 531,
-          "title": 42,
-          "part": 455,
-          "section_id": 432,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 523,
-          "title": 42,
-          "part": 455,
-          "section_id": 434,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 464,
-          "title": 42,
-          "part": 455,
-          "section_id": 450,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 532,
-          "title": 42,
-          "part": 455,
-          "section_id": 460,
-          "parent": 859,
-          "type": "section"
-        },
-        {
-          "id": 551,
-          "title": 42,
-          "part": 457,
-          "subpart_id": "C",
-          "type": "subpart"
-        },
-        {
-          "id": 572,
-          "title": 42,
-          "part": 457,
-          "section_id": 60,
-          "parent": 1361,
-          "type": "section"
-        },
-        {
-          "id": 168,
-          "title": 42,
-          "part": 457,
-          "section_id": 330,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 169,
-          "title": 42,
-          "part": 457,
-          "section_id": 340,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 556,
-          "title": 42,
-          "part": 457,
-          "section_id": 342,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 606,
-          "title": 42,
-          "part": 457,
-          "subpart_id": "I",
-          "type": "subpart"
-        },
-        {
-          "id": 557,
-          "title": 42,
-          "part": 457,
-          "section_id": 355,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 171,
-          "title": 42,
-          "part": 457,
-          "section_id": 380,
-          "parent": 1376,
-          "type": "section"
-        },
-        {
-          "id": 602,
-          "title": 42,
-          "part": 457,
-          "section_id": 510,
-          "parent": 1384,
-          "type": "section"
-        },
-        {
-          "id": 954,
-          "title": 42,
-          "part": 457,
-          "subpart_id": "K",
-          "type": "subpart"
-        },
-        {
-          "id": 588,
-          "title": 42,
-          "part": 457,
-          "section_id": 1160,
-          "parent": 954,
-          "type": "section"
-        },
-        {
-          "id": 589,
-          "title": 42,
-          "part": 457,
-          "section_id": 1170,
-          "parent": 954,
-          "type": "section"
-        },
-        {
-          "id": 576,
-          "title": 42,
-          "part": 457,
-          "section_id": 1230,
-          "parent": 1407,
-          "type": "section"
-        },
-        {
-          "id": 653,
-          "title": 42,
-          "part": 457,
-          "section_id": 1260,
-          "parent": 1407,
-          "type": "section"
-        }
-      ],
-      "type": "supplemental_content"
-    },
-    {
-      "id": 2349,
-      "created_at": "2022-05-25 10:25:58.687000",
-      "updated_at": "2022-05-25 10:25:58.687000",
-      "approved": true,
-      "date": "2022-05-24",
-      "name": null,
-      "description": "HCBS Settings Rule Implementation–Moving Forward Toward March 2023 & Beyond",
-      "url": "https://www.medicaid.gov/medicaid/home-community-based-services/downloads/hcbs-settings-rule-imp.pdf",
-      "internalURL": "/supplemental_content/2349/",
-      "name_headline": null,
-      "description_headline": null,
-      "category": {
-        "id": 13,
-        "name": "Technical Assistance for States",
-        "description": "",
-        "order": 200,
-        "show_if_empty": false,
-        "parent": {
-          "id": 11,
-          "name": "Implementation Resources",
-          "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
-          "order": 500,
-          "show_if_empty": true
-        },
-        "type": "subcategory"
-      },
-      "locations": [
-        {
-          "id": 671,
-          "title": 42,
-          "part": 430,
-          "section_id": 25,
-          "parent": 960,
-          "type": "section"
-        },
-        {
-          "id": 789,
-          "title": 42,
-          "part": 431,
-          "section_id": 54,
-          "parent": 985,
-          "type": "section"
-        },
-        {
-          "id": 685,
-          "title": 42,
-          "part": 435,
-          "section_id": 219,
-          "parent": 875,
-          "type": "section"
-        },
-        {
-          "id": 694,
-          "title": 42,
-          "part": 436,
-          "section_id": 219,
-          "parent": 1060,
-          "type": "section"
-        },
-        {
-          "id": 713,
-          "title": 42,
-          "part": 440,
-          "section_id": 1,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 73,
-          "title": 42,
-          "part": 440,
-          "section_id": 180,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 18,
-          "title": 42,
-          "part": 440,
-          "section_id": 182,
-          "parent": 1124,
-          "type": "section"
-        },
-        {
-          "id": 392,
-          "title": 42,
-          "part": 441,
-          "section_id": 301,
-          "parent": 1149,
-          "type": "section"
-        },
-        {
-          "id": 425,
-          "title": 42,
-          "part": 441,
-          "section_id": 302,
-          "parent": 1149,
-          "type": "section"
-        },
-        {
-          "id": 674,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "C",
-          "type": "subpart"
-        },
-        {
-          "id": 435,
-          "title": 42,
-          "part": 441,
-          "section_id": 530,
-          "parent": 1174,
-          "type": "section"
-        },
-        {
-          "id": 711,
-          "title": 42,
-          "part": 441,
-          "section_id": 700,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 454,
-          "title": 42,
-          "part": 441,
-          "section_id": 705,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 397,
-          "title": 42,
-          "part": 441,
-          "section_id": 710,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 398,
-          "title": 42,
-          "part": 441,
-          "section_id": 715,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 441,
-          "title": 42,
-          "part": 441,
-          "section_id": 720,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 442,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "B",
-          "type": "subpart"
-        },
-        {
-          "id": 445,
-          "title": 42,
-          "part": 441,
-          "section_id": 730,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 791,
-          "title": 42,
-          "part": 441,
-          "section_id": 735,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 455,
-          "title": 42,
-          "part": 441,
-          "subpart_id": "C",
-          "type": "subpart"
-        },
-        {
-          "id": 456,
-          "title": 42,
-          "part": 441,
-          "section_id": 745,
-          "parent": 1177,
-          "type": "section"
-        },
-        {
-          "id": 467,
-          "title": 42,
-          "part": 447,
-          "section_id": 10,
-          "parent": 1195,
-          "type": "section"
-        }
-      ],
-      "type": "supplemental_content"
-    }
-  ]
+    ]
 }

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -74,6 +74,27 @@ describe("Resources page", () => {
             cy.url().should("include", "title=42");
         });
 
+        it("Selects categories correctly", () => {
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            cy.injectAxe();
+            cy.get("button#select-resource-categories").should("not.have.attr", "disabled");
+            cy.get("#select-resource-categories").click({
+                force: true,
+            });
+            cy.checkAccessibility();
+            cy.get(
+                '[data-value="State Medicaid Director Letter (SMDL)"]'
+            ).click({ force: true });
+            cy.url().should(
+                "include",
+                "State%20Medicaid%20Director%20Letter%20%28SMDL%29"
+            );
+            cy.get(".v-chip__content").contains(
+                "State Medicaid Director Letter (SMDL)"
+            );
+        });
+
         it("Chips follow the URL values correctly", () => {
             const sectionString =
                 "433-50,433-51,433-52,433-53,433-54,433-55,433-56,433-57,433-58-433,433-66,433-67,433-68,433-70,433-72,433-74";
@@ -156,22 +177,6 @@ describe("Resources page", () => {
                 );
                 cy.get(".current-page.selected").contains("2");
             });
-        });
-
-        it.skip("Selects categories correctly", () => {
-            cy.viewport("macbook-15");
-            cy.visit("/resources");
-            cy.get("#select-resource-categories > .v-btn__content").click();
-            cy.get(
-                '[data-value="State Medicaid Director Letter (SMDL)"]'
-            ).click();
-            cy.url().should(
-                "include",
-                "State%20Medicaid%20Director%20Letter%20%28SMDL%29"
-            );
-            cy.get(".v-chip__content").contains(
-                "State Medicaid Director Letter (SMDL)"
-            );
         });
     });
 });

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -1,17 +1,28 @@
 describe("Resources page", () => {
     describe("Empty State", () => {
         it("renders correctly", () => {
-            cy.clearIndexedDB()
+            cy.intercept("**/resources/**", {
+                fixture: "no-resources-results.json",
+                delayMs: 1000,
+            }).as("resources");
+            cy.clearIndexedDB();
             cy.visit("/resources");
+            cy.get(".results-count > span").should(
+                "contain.text",
+                "Loading..."
+            );
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");
-            cy.get(".results-count > span").contains("0 results in Resources");
+            cy.get(".results-count > span").should(
+                "contain.text",
+                "0 results in Resources"
+            );
         });
     });
 
     describe("Mock Results", () => {
         beforeEach(() => {
-            cy.clearIndexedDB()
+            cy.clearIndexedDB();
             cy.intercept("/**", (req) => {
                 req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
             });
@@ -37,7 +48,9 @@ describe("Resources page", () => {
             cy.visit("/resources");
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");
-            cy.get(".results-count > span").contains("1 - 100 of 2101 results in Resources");
+            cy.get(".results-count > span").contains(
+                "1 - 100 of 2101 results in Resources"
+            );
         });
 
         it.skip("Selects parts correctly", () => {
@@ -59,10 +72,14 @@ describe("Resources page", () => {
                 `/resources?title=42&part=433&subpart=433-B&section=${sectionString}`
             );
             sectionString.split(",").forEach((ss) => {
-                cy.get(".v-chip__content").contains(`§ ${ss.replace("-", ".")}`);
+                cy.get(".v-chip__content").contains(
+                    `§ ${ss.replace("-", ".")}`
+                );
             });
             // Select an additional section
-            cy.visit("/resources?title=42&part=433&subpart=433-B&section=433-11");
+            cy.visit(
+                "/resources?title=42&part=433&subpart=433-B&section=433-11"
+            );
             cy.url().should("include", "433-11");
             cy.get(".v-chip__content").contains("§ 433.11");
             cy.go("back");
@@ -75,7 +92,9 @@ describe("Resources page", () => {
             cy.viewport("macbook-15");
             cy.visit("/resources");
             cy.get("#select-resource-categories > .v-btn__content").click();
-            cy.get('[data-value="State Medicaid Director Letter (SMDL)"]').click();
+            cy.get(
+                '[data-value="State Medicaid Director Letter (SMDL)"]'
+            ).click();
             cy.url().should(
                 "include",
                 "State%20Medicaid%20Director%20Letter%20%28SMDL%29"

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -1,70 +1,87 @@
 describe("Resources page", () => {
-    beforeEach(() => {
-        cy.clearLocalStorage();
-        cy.intercept("/**", (req) => {
-            req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
+    describe("Empty State", () => {
+        it("renders correctly", () => {
+            cy.visit("/resources");
+            cy.get("h1").contains("Resources");
+            cy.get("h3").contains("Filter Resources");
+            cy.get(".results-count > span").contains("0 results in Resources");
         });
     });
 
-    it("renders correctly", () => {
-        // THis is to prove the concept of fetching the resources not from our API, but from a cypress fixture
-        cy.intercept("**/resources/?locations=42**", {
-            fixture: "resources.json",
-        }).as("resources");
-        cy.intercept("*v2/title/42/existing", {
-            fixture: "42-existing.json",
-        }).as("existing");
-        cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
-        cy.viewport("macbook-15");
-        cy.visit("/resources");
-        cy.wait("@resources");
-        cy.get("h1").contains("Resources");
-        cy.get("h3").contains("Filter Resources");
-        cy.contains("7 results in Resources");
-    });
-
-    it("Selects parts correctly", () => {
-        cy.clearLocalStorage();
-        cy.viewport("macbook-15");
-        cy.visit("/resources");
-        // Select Title 42 part 433
-        cy.get("#select-parts > .v-btn__content").click();
-        cy.get('[data-value="433"]').click();
-        cy.url().should("include", "part=433");
-        cy.url().should("include", "title=42");
-    });
-
-    it("Chips follow the URL values correctly", () => {
-        const sectionString =
-            "433-50,433-51,433-52,433-53,433-54,433-55,433-56,433-57,433-58-433,433-66,433-67,433-68,433-70,433-72,433-74";
-        cy.viewport("macbook-15");
-        cy.visit(
-            `/resources?title=42&part=433&subpart=433-B&section=${sectionString}`
-        );
-        sectionString.split(",").forEach((ss) => {
-            cy.get(".v-chip__content").contains(`§ ${ss.replace("-", ".")}`);
+    describe("Mock Results", () => {
+        beforeEach(() => {
+            cy.clearIndexedDB()
+            cy.intercept("/**", (req) => {
+                req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
+            });
+            cy.intercept("**/resources/?locations=42**", {
+                fixture: "resources.json",
+            }).as("resources");
+            cy.intercept("*v2/title/42/existing", {
+                fixture: "42-existing.json",
+            }).as("existing");
+            cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
         });
-        // Select an additional section
-        cy.visit("/resources?title=42&part=433&subpart=433-B&section=433-11");
-        cy.url().should("include", "433-11");
-        cy.get(".v-chip__content").contains("§ 433.11");
-        cy.go("back");
-        cy.get(".v-chip__content").contains("§ 433.11").should("not.exist");
-        // Just check on a random chip again
-        cy.get(".v-chip__content").contains("§ 433.53");
-    });
 
-    it("Selects categories correctly", () => {
-        cy.viewport("macbook-15");
-        cy.visit("/resources");
-        cy.get("#select-resource-categories > .v-btn__content").click();
-        cy.get('[data-value="State Medicaid Director Letter (SMDL)"]').click();
-        cy.url().should(
-            "include",
-            "State%20Medicaid%20Director%20Letter%20%28SMDL%29"
-        );
-        cy.get(".v-chip__content").contains(
-            "State Medicaid Director Letter (SMDL)"
-        );
+        it("renders correctly", () => {
+            // THis is to prove the concept of fetching the resources not from our API, but from a cypress fixture
+            cy.intercept("**/resources/?locations=42**", {
+                fixture: "resources.json",
+            }).as("resources");
+            cy.intercept("*v2/title/42/existing", {
+                fixture: "42-existing.json",
+            }).as("existing");
+            cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            cy.get("h1").contains("Resources");
+            cy.get("h3").contains("Filter Resources");
+            cy.get(".results-count > span").contains("1 - 100 of 2101 results in Resources");
+        });
+
+        it.skip("Selects parts correctly", () => {
+            cy.clearLocalStorage();
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            // Select Title 42 part 433
+            cy.get("#select-parts > .v-btn__content").click();
+            cy.get('[data-value="433"]').click();
+            cy.url().should("include", "part=433");
+            cy.url().should("include", "title=42");
+        });
+
+        it.skip("Chips follow the URL values correctly", () => {
+            const sectionString =
+                "433-50,433-51,433-52,433-53,433-54,433-55,433-56,433-57,433-58-433,433-66,433-67,433-68,433-70,433-72,433-74";
+            cy.viewport("macbook-15");
+            cy.visit(
+                `/resources?title=42&part=433&subpart=433-B&section=${sectionString}`
+            );
+            sectionString.split(",").forEach((ss) => {
+                cy.get(".v-chip__content").contains(`§ ${ss.replace("-", ".")}`);
+            });
+            // Select an additional section
+            cy.visit("/resources?title=42&part=433&subpart=433-B&section=433-11");
+            cy.url().should("include", "433-11");
+            cy.get(".v-chip__content").contains("§ 433.11");
+            cy.go("back");
+            cy.get(".v-chip__content").contains("§ 433.11").should("not.exist");
+            // Just check on a random chip again
+            cy.get(".v-chip__content").contains("§ 433.53");
+        });
+
+        it.skip("Selects categories correctly", () => {
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            cy.get("#select-resource-categories > .v-btn__content").click();
+            cy.get('[data-value="State Medicaid Director Letter (SMDL)"]').click();
+            cy.url().should(
+                "include",
+                "State%20Medicaid%20Director%20Letter%20%28SMDL%29"
+            );
+            cy.get(".v-chip__content").contains(
+                "State Medicaid Director Letter (SMDL)"
+            );
+        });
     });
 });

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -68,10 +68,24 @@ describe("Resources page", () => {
             // Select Title 42 part 400
             cy.get("button#select-parts").should("not.have.attr", "disabled");
             cy.get("button#select-parts").click({ force: true });
-            cy.checkAccessibility();
-            cy.get('[data-value="400"]').click();
+            cy.get('[data-value="400"]').click({ force: true });
             cy.url().should("include", "part=400");
             cy.url().should("include", "title=42");
+            cy.get("button#select-parts").click({ force: true });
+            cy.checkAccessibility();
+        });
+
+        it("Sorts results correctly", () => {
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            cy.injectAxe();
+            cy.get("h1").contains("Resources");
+            cy.get("button#sortButton").should("not.have.attr", "disabled");
+            cy.get("button#sortButton").click({ force: true });
+            cy.get('[data-value="newest"]').click({ force: true });
+            cy.url().should("include", "sort=newest");
+            cy.get("button#sortButton").click({ force: true });
+            cy.checkAccessibility();
         });
 
         it("Selects categories correctly", () => {
@@ -82,7 +96,6 @@ describe("Resources page", () => {
             cy.get("#select-resource-categories").click({
                 force: true,
             });
-            cy.checkAccessibility();
             cy.get(
                 '[data-value="State Medicaid Director Letter (SMDL)"]'
             ).click({ force: true });
@@ -93,6 +106,10 @@ describe("Resources page", () => {
             cy.get(".v-chip__content").contains(
                 "State Medicaid Director Letter (SMDL)"
             );
+            cy.get("#select-resource-categories").click({
+                force: true,
+            });
+            cy.checkAccessibility();
         });
 
         it("Chips follow the URL values correctly", () => {
@@ -102,13 +119,11 @@ describe("Resources page", () => {
             cy.visit(
                 `/resources?title=42&part=433&subpart=433-B&section=${sectionString}`
             );
-            cy.injectAxe();
             sectionString.split(",").forEach((ss) => {
                 cy.get(".v-chip__content").contains(
                     `§ ${ss.replace("-", ".")}`
                 );
             });
-            cy.checkAccessibility();
             // Select an additional section
             cy.visit(
                 "/resources?title=42&part=433&subpart=433-B&section=433-11"
@@ -116,9 +131,11 @@ describe("Resources page", () => {
             cy.url().should("include", "433-11");
             cy.get(".v-chip__content").contains("§ 433.11");
             cy.go("back");
+            cy.injectAxe();
             cy.get(".v-chip__content").contains("§ 433.11").should("not.exist");
             // Just check on a random chip again
             cy.get(".v-chip__content").contains("§ 433.53");
+            cy.checkAccessibility();
         });
 
         it("Goes to the second page of results when clicking the Next button", () => {

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -33,12 +33,12 @@ describe("Resources page", () => {
     describe("Mock Results", () => {
         beforeEach(() => {
             cy.clearIndexedDB();
-            //cy.intercept("/**", (req) => {
-            //req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
-            //});
-            cy.intercept("**/resources/?locations=42**", {
+            cy.intercept("/**", (req) => {
+                req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
+            });
+            cy.intercept("**/resources/?locations=42**", /*{
                 fixture: "resources.json",
-            }).as("resources");
+            }*/).as("resources");
             //cy.intercept("*v2/title/42/existing", {
             //fixture: "42-existing.json",
             //}).as("existing");

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -1,6 +1,7 @@
 describe("Resources page", () => {
     describe("Empty State", () => {
         it("renders correctly", () => {
+            cy.clearIndexedDB()
             cy.visit("/resources");
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -36,9 +36,9 @@ describe("Resources page", () => {
             cy.intercept("/**", (req) => {
                 req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
             });
-            cy.intercept("**/resources/?locations=42**", /*{
+            cy.intercept("**/resources/?locations=42**", {
                 fixture: "resources.json",
-            }*/).as("resources");
+            }).as("resources");
         });
 
         it("renders correctly", () => {

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -14,6 +14,7 @@ describe("Resources page", () => {
             }).as("resources");
             cy.viewport("macbook-15");
             cy.visit("/resources");
+            cy.injectAxe();
             cy.get(".results-count > span").should(
                 "contain.text",
                 "Loading..."
@@ -25,6 +26,7 @@ describe("Resources page", () => {
                 "0 results in Resources"
             );
             cy.get(".empty-state-container").should("exist");
+            cy.checkAccessibility();
         });
     });
 
@@ -48,6 +50,7 @@ describe("Resources page", () => {
             //cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
             cy.viewport("macbook-15");
             cy.visit("/resources");
+            cy.injectAxe();
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");
             cy.wait("@resources").then((interception) => {
@@ -56,6 +59,7 @@ describe("Resources page", () => {
                     `1 - 100 of ${count} results in Resources`
                 );
                 cy.get(".empty-state-container").should("not.exist");
+                cy.checkAccessibility();
             });
         });
 

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -34,9 +34,9 @@ describe("Resources page", () => {
             //cy.intercept("/**", (req) => {
             //req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
             //});
-            cy.intercept("**/resources/?locations=42**"/*, {
+            cy.intercept("**/resources/?locations=42**", {
                 fixture: "resources.json",
-            }*/).as("resources");
+            }).as("resources");
             //cy.intercept("*v2/title/42/existing", {
             //fixture: "42-existing.json",
             //}).as("existing");

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -103,11 +103,12 @@ describe("Resources page", () => {
         it("Goes to the second page of results when clicking the Next button", () => {
             cy.viewport("macbook-15");
             cy.visit("/resources");
-            cy.injectAxe();
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");
             cy.wait("@resources");
             cy.get(".current-page.selected").contains("1");
+            cy.get(".pagination-control.left-control > .back-btn")
+                .should("have.class", "disabled");
             cy.get(".pagination-control.right-control")
                 .contains("Next")
                 .click({ force: true });

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -89,14 +89,12 @@ describe("Resources page", () => {
             cy.visit(
                 "/resources?title=42&part=433&subpart=433-B&section=433-11"
             );
-            cy.injectAxe();
             cy.url().should("include", "433-11");
             cy.get(".v-chip__content").contains("§ 433.11");
             cy.go("back");
             cy.get(".v-chip__content").contains("§ 433.11").should("not.exist");
             // Just check on a random chip again
             cy.get(".v-chip__content").contains("§ 433.53");
-            cy.checkAccessibility();
         });
 
         it.skip("Selects categories correctly", () => {

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -1,61 +1,70 @@
-describe.skip("Resources page", () => {
+describe("Resources page", () => {
     beforeEach(() => {
-        cy.clearLocalStorage()
+        cy.clearLocalStorage();
         cy.intercept("/**", (req) => {
-            req.headers["x-automated-test"] =
-                Cypress.env("DEPLOYING");
+            req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         });
-    })
+    });
 
     it("renders correctly", () => {
         // THis is to prove the concept of fetching the resources not from our API, but from a cypress fixture
-        cy.intercept('**/resources/?locations=42**', {fixture:'resources.json'}).as('resources')
-        cy.intercept('*v2/title/42/existing', {fixture: '42-existing.json'}).as('existing')
-        cy.intercept( '*v3/toc', {fixture: 'toc.json'}).as('toc')
+        cy.intercept("**/resources/?locations=42**", {
+            fixture: "resources.json",
+        }).as("resources");
+        cy.intercept("*v2/title/42/existing", {
+            fixture: "42-existing.json",
+        }).as("existing");
+        cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
         cy.viewport("macbook-15");
         cy.visit("/resources");
-        cy.wait("@resources")
-        cy.get("h1").contains('Resources')
-        cy.get("h3").contains('Filter Resources')
-        cy.contains("7 results in Resources")
+        cy.wait("@resources");
+        cy.get("h1").contains("Resources");
+        cy.get("h3").contains("Filter Resources");
+        cy.contains("7 results in Resources");
     });
 
     it("Selects parts correctly", () => {
-        cy.clearLocalStorage()
+        cy.clearLocalStorage();
         cy.viewport("macbook-15");
         cy.visit("/resources");
         // Select Title 42 part 433
-        cy.get('#select-parts > .v-btn__content').click();
+        cy.get("#select-parts > .v-btn__content").click();
         cy.get('[data-value="433"]').click();
         cy.url().should("include", "part=433");
         cy.url().should("include", "title=42");
-    })
+    });
 
     it("Chips follow the URL values correctly", () => {
-        const sectionString = "433-50,433-51,433-52,433-53,433-54,433-55,433-56,433-57,433-58-433,433-66,433-67,433-68,433-70,433-72,433-74"
+        const sectionString =
+            "433-50,433-51,433-52,433-53,433-54,433-55,433-56,433-57,433-58-433,433-66,433-67,433-68,433-70,433-72,433-74";
         cy.viewport("macbook-15");
-        cy.visit(`/resources?title=42&part=433&subpart=433-B&section=${sectionString}`);
-        sectionString.split(',').forEach( ss =>{
-            cy.get(".v-chip__content").contains(`§ ${ss.replace('-', '.')}`)
-        })
+        cy.visit(
+            `/resources?title=42&part=433&subpart=433-B&section=${sectionString}`
+        );
+        sectionString.split(",").forEach((ss) => {
+            cy.get(".v-chip__content").contains(`§ ${ss.replace("-", ".")}`);
+        });
         // Select an additional section
         cy.visit("/resources?title=42&part=433&subpart=433-B&section=433-11");
-        cy.url().should("include", "433-11")
-        cy.get(".v-chip__content").contains("§ 433.11")
-        cy.go('back')
-        cy.get(".v-chip__content").contains("§ 433.11").should('not.exist');
+        cy.url().should("include", "433-11");
+        cy.get(".v-chip__content").contains("§ 433.11");
+        cy.go("back");
+        cy.get(".v-chip__content").contains("§ 433.11").should("not.exist");
         // Just check on a random chip again
-        cy.get(".v-chip__content").contains("§ 433.53")
-
+        cy.get(".v-chip__content").contains("§ 433.53");
     });
 
     it("Selects categories correctly", () => {
         cy.viewport("macbook-15");
         cy.visit("/resources");
-        cy.get('#select-resource-categories > .v-btn__content').click();
+        cy.get("#select-resource-categories > .v-btn__content").click();
         cy.get('[data-value="State Medicaid Director Letter (SMDL)"]').click();
-        cy.url().should("include", "State%20Medicaid%20Director%20Letter%20%28SMDL%29")
-        cy.get(".v-chip__content").contains("State Medicaid Director Letter (SMDL)")
-
-    })
-})
+        cy.url().should(
+            "include",
+            "State%20Medicaid%20Director%20Letter%20%28SMDL%29"
+        );
+        cy.get(".v-chip__content").contains(
+            "State Medicaid Director Letter (SMDL)"
+        );
+    });
+});

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -51,7 +51,7 @@ describe("Resources page", () => {
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");
             cy.wait("@resources").then((interception) => {
-                count = interception.response.body.count;
+                const count = interception.response.body.count;
                 cy.get(".results-count > span").contains(
                     `1 - 100 of ${count} results in Resources`
                 );

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -39,15 +39,9 @@ describe("Resources page", () => {
             cy.intercept("**/resources/?locations=42**", /*{
                 fixture: "resources.json",
             }*/).as("resources");
-            //cy.intercept("*v2/title/42/existing", {
-            //fixture: "42-existing.json",
-            //}).as("existing");
-            //cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
         });
 
         it("renders correctly", () => {
-            // THis is to prove the concept of fetching the resources not from our API, but from a cypress fixture
-            //cy.intercept("*v3/toc", { fixture: "toc.json" }).as("toc");
             cy.viewport("macbook-15");
             cy.visit("/resources");
             cy.injectAxe();
@@ -66,36 +60,43 @@ describe("Resources page", () => {
         it("Selects parts correctly", () => {
             cy.viewport("macbook-15");
             cy.visit("/resources");
+            cy.injectAxe();
+            cy.get("h1").contains("Resources");
             // Select Title 42 part 400
             cy.get("button#select-parts").should("not.have.attr", "disabled");
             cy.get("button#select-parts").click({ force: true });
+            cy.checkAccessibility();
             cy.get('[data-value="400"]').click();
             cy.url().should("include", "part=400");
             cy.url().should("include", "title=42");
         });
 
-        it.skip("Chips follow the URL values correctly", () => {
+        it("Chips follow the URL values correctly", () => {
             const sectionString =
                 "433-50,433-51,433-52,433-53,433-54,433-55,433-56,433-57,433-58-433,433-66,433-67,433-68,433-70,433-72,433-74";
             cy.viewport("macbook-15");
             cy.visit(
                 `/resources?title=42&part=433&subpart=433-B&section=${sectionString}`
             );
+            cy.injectAxe();
             sectionString.split(",").forEach((ss) => {
                 cy.get(".v-chip__content").contains(
                     `§ ${ss.replace("-", ".")}`
                 );
             });
+            cy.checkAccessibility();
             // Select an additional section
             cy.visit(
                 "/resources?title=42&part=433&subpart=433-B&section=433-11"
             );
+            cy.injectAxe();
             cy.url().should("include", "433-11");
             cy.get(".v-chip__content").contains("§ 433.11");
             cy.go("back");
             cy.get(".v-chip__content").contains("§ 433.11").should("not.exist");
             // Just check on a random chip again
             cy.get(".v-chip__content").contains("§ 433.53");
+            cy.checkAccessibility();
         });
 
         it.skip("Selects categories correctly", () => {

--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -107,8 +107,10 @@ describe("Resources page", () => {
             cy.get("h3").contains("Filter Resources");
             cy.wait("@resources");
             cy.get(".current-page.selected").contains("1");
-            cy.get(".pagination-control.left-control > .back-btn")
-                .should("have.class", "disabled");
+            cy.get(".pagination-control.left-control > .back-btn").should(
+                "have.class",
+                "disabled"
+            );
             cy.get(".pagination-control.right-control")
                 .contains("Next")
                 .click({ force: true });
@@ -121,8 +123,40 @@ describe("Resources page", () => {
                 cy.get(".current-page.selected").contains("2");
             });
         });
-        // it("Goes to the second page of results when clicking on page 2")
-        // it("Goes to the second page of results on load when page=2 in the URL")
+
+        it("Goes to the second page of results when clicking on page 2", () => {
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            cy.get("h1").contains("Resources");
+            cy.get("h3").contains("Filter Resources");
+            cy.wait("@resources");
+            cy.get(".current-page.selected").contains("1");
+            cy.get(".page-number-li.unselected")
+                .contains("2")
+                .click({ force: true });
+            cy.wait("@resources2").then((interception) => {
+                const count = interception.response.body.count;
+                cy.url().should("include", "page=2");
+                cy.get(".results-count > span").contains(
+                    `101 - 200 of ${count} results in Resources`
+                );
+                cy.get(".current-page.selected").contains("2");
+            });
+        });
+
+        it("Goes to the second page of results on load when page=2 in the URL", () => {
+            cy.viewport("macbook-15");
+            cy.visit("/resources/?page=2");
+            cy.get("h1").contains("Resources");
+            cy.get("h3").contains("Filter Resources");
+            cy.wait("@resources2").then((interception) => {
+                const count = interception.response.body.count;
+                cy.get(".results-count > span").contains(
+                    `101 - 200 of ${count} results in Resources`
+                );
+                cy.get(".current-page.selected").contains("2");
+            });
+        });
 
         it.skip("Selects categories correctly", () => {
             cy.viewport("macbook-15");

--- a/solution/ui/e2e/cypress/support/commands.js
+++ b/solution/ui/e2e/cypress/support/commands.js
@@ -60,3 +60,23 @@ Cypress.Commands.add("setCssMedia", (media) => {
         },
     });
 });
+
+// https://github.com/cypress-io/cypress/issues/1208
+Cypress.Commands.add('clearIndexedDB', async () => {
+  const databases = await window.indexedDB.databases();
+
+  await Promise.all(
+    databases.map(
+      ({ name }) =>
+        new Promise((resolve, reject) => {
+          const request = window.indexedDB.deleteDatabase(name);
+
+          request.addEventListener('success', resolve);
+          // Note: we need to also listen to the "blocked" event
+          // (and resolve the promise) due to https://stackoverflow.com/a/35141818
+          request.addEventListener('blocked', resolve);
+          request.addEventListener('error', reject);
+        }),
+    ),
+  );
+});

--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="empty-state-container">
         Expand your search:
         <ul>
             <li>

--- a/solution/ui/regulations/eregs-vite/src/components/custom_elements/CategoryList.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/custom_elements/CategoryList.vue
@@ -1,30 +1,24 @@
 <template>
     <v-list class="category-list">
-        <v-list-item-group class="category-list-item-group">
-            <template v-for="item in listItems">
-                <v-list-item
-                    :key="item.id"
-                    @click="clickMethod"
-                    :data-value="item.name"
-                    class="category-list-item"
-                >
-                    <span :class="item.type">{{
-                        item.name
-                    }}</span>
-                </v-list-item>
-                <v-list-item
-                    v-for="subItem in item.subcategories"
-                    :key="subItem.id"
-                    @click="clickMethod"
-                    :data-value="subItem.name"
-                    class="category-list-item"
-                >
-                    <span :class="subItem.type">{{
-                        subItem.name
-                    }}</span>
-                </v-list-item>
-            </template>
-        </v-list-item-group>
+        <template v-for="item in listItems">
+            <v-list-item
+                :key="item.id"
+                :data-value="item.name"
+                class="category-list-item"
+                @click="clickMethod"
+            >
+                <span :class="item.type">{{ item.name }}</span>
+            </v-list-item>
+            <v-list-item
+                v-for="subItem in item.subcategories"
+                :key="subItem.id"
+                :data-value="subItem.name"
+                class="category-list-item"
+                @click="clickMethod"
+            >
+                <span :class="subItem.type">{{ subItem.name }}</span>
+            </v-list-item>
+        </template>
     </v-list>
 </template>
 
@@ -40,6 +34,10 @@ export default {
         listItems: {
             type: Array,
             required: true,
+        },
+        listId: {
+            type: String,
+            default: "",
         },
     },
 

--- a/solution/ui/regulations/eregs-vite/src/components/custom_elements/FancyDropdown.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/custom_elements/FancyDropdown.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="fancy-container" :class="containerClass">
-        <v-menu offset-y max-width="240" max-height="460">
+        <v-menu offset-y max-width="240" max-height="460" :aria-labelledby="listId">
             <template #activator="{ on, attrs }">
                 <label v-if="label" :id="listId" :for="buttonId">{{
                     label

--- a/solution/ui/regulations/eregs-vite/src/components/custom_elements/FancyDropdown.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/custom_elements/FancyDropdown.vue
@@ -1,8 +1,10 @@
 <template>
     <div class="fancy-container" :class="containerClass">
         <v-menu offset-y max-width="240" max-height="460">
-            <template v-slot:activator="{ on, attrs }">
-                <label v-if="label" :for="buttonId">{{ label }}</label>
+            <template #activator="{ on, attrs }">
+                <label v-if="label" :id="listId" :for="buttonId">{{
+                    label
+                }}</label>
                 <v-btn
                     :id="buttonId"
                     :disabled="disabled"
@@ -32,6 +34,10 @@ export default {
             type: String,
             default: "",
         },
+        listId: {
+            type: String,
+            default: "",
+        },
         buttonTitle: {
             type: String,
             default: "Select",
@@ -47,13 +53,15 @@ export default {
         type: {
             type: String,
             required: false,
-            default: ""
+            default: "",
         },
     },
 
     computed: {
         btnTypeClass() {
-            return this.type === "splitTab" ? "split-tab-btn" : "select-btn ds-c-field";
+            return this.type === "splitTab"
+                ? "split-tab-btn"
+                : "select-btn ds-c-field";
         },
         containerClass() {
             return this.type === "splitTab" ? "split-tab-container" : "";
@@ -126,7 +134,7 @@ export default {
 
             .v-btn__content {
                 height: 60%;
-                border-left: 1px solid #9D9D9D;
+                border-left: 1px solid #9d9d9d;
             }
         }
     }

--- a/solution/ui/regulations/eregs-vite/src/components/custom_elements/SectionList.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/custom_elements/SectionList.vue
@@ -1,17 +1,15 @@
 <template>
     <v-list class="section-list">
-        <v-list-item-group class="section-list-item-group">
-            <v-list-item
-                v-for="item in listItems"
-                :key="item.identifier"
-                @click="clickMethod"
-                :data-value="item.part + '-' + item.identifier"
-                class="section-list-item"
-            >
-                <span class="section-number">{{ item.label }} </span>
-                <span class="section-text">{{ item.description }}</span>
-            </v-list-item>
-        </v-list-item-group>
+        <v-list-item
+            v-for="item in listItems"
+            :key="item.identifier"
+            :data-value="item.part + '-' + item.identifier"
+            class="section-list-item"
+            @click="clickMethod"
+        >
+            <span class="section-number">{{ item.label }} </span>
+            <span class="section-text">{{ item.description }}</span>
+        </v-list-item>
     </v-list>
 </template>
 
@@ -28,18 +26,21 @@ export default {
             type: Array,
             required: true,
         },
+        listId: {
+            type: String,
+            default: "",
+        },
     },
 
     methods: {
         clickMethod(e) {
             this.filterEmitter({
                 scope: "section",
-                selectedIdentifier: e.currentTarget.dataset.value
+                selectedIdentifier: e.currentTarget.dataset.value,
             });
         },
     },
-
-}
+};
 </script>
 
 <style lang="scss">
@@ -59,4 +60,3 @@ export default {
     }
 }
 </style>
-

--- a/solution/ui/regulations/eregs-vite/src/components/custom_elements/SubpartList.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/custom_elements/SubpartList.vue
@@ -1,26 +1,24 @@
 <template>
     <v-list class="subpart-list">
-        <v-list-item-group class="subpart-list-item-group">
-            <v-list-item
-                v-for="item in listItems"
-                :key="item.part + item.identifier"
-                @click="clickMethod"
-                :data-value="item.part + '-' + item.identifier"
-                class="subpart-list-item"
-            >
-                <div>
-                    <span class="subpart-letter"
-                        >Subpart {{ item.identifier }}</span
-                    >
-                    <span class="subpart-range"> {{
-                        item.range | formatRange
-                    }}</span>
-                </div>
-                <div class="subpart-text">
-                    {{ item.label | descriptionOnly }}
-                </div>
-            </v-list-item>
-        </v-list-item-group>
+        <v-list-item
+            v-for="item in listItems"
+            :key="item.part + item.identifier"
+            :data-value="item.part + '-' + item.identifier"
+            class="subpart-list-item"
+            @click="clickMethod"
+        >
+            <div>
+                <span class="subpart-letter"
+                    >Subpart {{ item.identifier }}</span
+                >
+                <span class="subpart-range">
+                    {{ item.range | formatRange }}</span
+                >
+            </div>
+            <div class="subpart-text">
+                {{ item.label | descriptionOnly }}
+            </div>
+        </v-list-item>
     </v-list>
 </template>
 
@@ -38,6 +36,10 @@ export default {
         listItems: {
             type: Array,
             required: true,
+        },
+        listId: {
+            type: String,
+            default: "",
         },
     },
 

--- a/solution/ui/regulations/eregs-vite/src/components/custom_elements/TitlePartList.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/custom_elements/TitlePartList.vue
@@ -1,17 +1,15 @@
 <template>
-    <v-list class="title-part-list">
-        <v-list-item-group class="title-part-list-item-group">
-            <v-list-item
-                v-for="item in listItems"
-                :key="item.name"
-                @click="clickMethod"
-                :data-value="item.name"
-                class="title-part-list-item"
-            >
-                <span class="part-number">Part {{ item.name }} -</span>
-                <span class="part-text">{{ item.label | descriptionOnly }}</span>
-            </v-list-item>
-        </v-list-item-group>
+    <v-list class="title-part-list" role="group">
+        <v-list-item
+            v-for="item in listItems"
+            :key="item.name"
+            :data-value="item.name"
+            class="title-part-list-item"
+            @click="clickMethod"
+        >
+            <span class="part-number">Part {{ item.name }} -</span>
+            <span class="part-text">{{ item.label | descriptionOnly }}</span>
+        </v-list-item>
     </v-list>
 </template>
 
@@ -27,6 +25,10 @@ export default {
         listItems: {
             type: Array,
             required: true,
+        },
+        listId: {
+            type: String,
+            default: "",
         },
     },
 

--- a/solution/ui/regulations/eregs-vite/src/components/navigation/NavBtn.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/navigation/NavBtn.vue
@@ -1,10 +1,10 @@
 <template>
-    <button class="direction-btn" :class="directionClass" :disabled="isDisabled">
+    <div class="direction-btn" :class="directionClass" :disabled="isDisabled">
         <span class="label">{{ label }}</span>
         <span class="icon">
             <i class="fa" :class="chevronClass"></i>
         </span>
-    </button>
+    </div>
 </template>
 
 <script>

--- a/solution/ui/regulations/eregs-vite/src/components/navigation/NavBtn.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/navigation/NavBtn.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="direction-btn" :class="directionClass" :disabled="isDisabled">
+    <div class="direction-btn" :class="directionClass">
         <span class="label">{{ label }}</span>
         <span class="icon">
             <i class="fa" :class="chevronClass"></i>
@@ -38,7 +38,10 @@ export default {
                 : "fa-chevron-left";
         },
         directionClass() {
-            return `${this.direction}-btn`;
+            return {
+                [`${this.direction}-btn`]: true,
+                disabled: this.isDisabled,
+            };
         },
     },
 };
@@ -64,7 +67,7 @@ export default {
         margin: 0 10px -2px;
     }
 
-    &:disabled {
+    &.disabled {
         color: $mid_gray_3;
         cursor: default;
     }

--- a/solution/ui/regulations/eregs-vite/src/components/pagination/PageNumber.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/pagination/PageNumber.vue
@@ -1,21 +1,20 @@
 <template>
-    <li class="page-number-li">
+    <li
+        v-if="currentPage != number"
+        class="page-number-li"
+        :class="numberClasses"
+    >
         <router-link
-            v-if="currentPage != number"
             :to="{
                 name: view,
                 query: { ...$route.query, page: number },
             }"
         >
-            <span class="page-number" :class="numberClasses">
-                {{ number }}
-            </span>
+            {{ number }}
         </router-link>
-        <span v-else class="current-page">
-            <span class="page-number" :class="numberClasses">
-                {{ number }}
-            </span>
-        </span>
+    </li>
+    <li v-else class="page-number-li current-page" :class="numberClasses">
+        {{ number }}
     </li>
 </template>
 
@@ -89,12 +88,10 @@ li.page-number-li {
         }
     }
 
-    .page-number {
-        min-width: 44px;
+    min-width: 44px;
 
-        &.selected {
-            font-weight: bold;
-        }
+    &.selected {
+        font-weight: bold;
     }
 }
 </style>

--- a/solution/ui/regulations/eregs-vite/src/components/pagination/PageNumber.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/pagination/PageNumber.vue
@@ -64,19 +64,11 @@ export default {
             return this.currentPage == this.number ? "selected" : "unselected";
         },
     },
-
-    methods: {
-        methodName() {
-            console.log("method has been invoked");
-        },
-    },
 };
 </script>
 
 <style lang="scss" scoped>
 li.page-number-li {
-    display: inline-block;
-    list-style: none;
     width: 44px;
     text-align: center;
 

--- a/solution/ui/regulations/eregs-vite/src/components/pagination/PagesList.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/pagination/PagesList.vue
@@ -6,26 +6,26 @@
                 :current-page="currentPage"
                 :number="firstPage"
             />
-            <span
+            <li
                 v-if="pagesArray.length > 7 && currentPage > 4"
                 class="ellipses"
             >
                 …
-            </span>
+            </li>
             <PageNumber
                 v-for="pageNum in iterablePages"
                 :key="pageNum"
                 :current-page="currentPage"
                 :number="pageNum"
             />
-            <span
+            <li
                 v-if="
                     pagesArray.length > 7 && pagesArray.length > currentPage + 3
                 "
                 class="ellipses"
             >
                 …
-            </span>
+            </li>
             <PageNumber
                 v-if="pagesArray.length > 1"
                 :current-page="currentPage"
@@ -115,6 +115,16 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+li {
+    list-style: none;
+    display: inline-block;
+
+    &.ellipses {
+        width: 20px;
+        text-align: center;
+    }
+}
+
 .list-container ul.pages {
     padding-left: 0;
 }

--- a/solution/ui/regulations/eregs-vite/src/components/pagination/PagesList.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/pagination/PagesList.vue
@@ -105,12 +105,6 @@ export default {
             return this.allMiddlePages;
         },
     },
-
-    methods: {
-        methodName() {
-            console.log("method has been invoked");
-        },
-    },
 };
 </script>
 

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesFilters.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesFilters.vue
@@ -5,17 +5,19 @@
             <div class="filters">
                 <template v-for="(value, name) in filters">
                     <FancyDropdown
-                        :label="value.label"
-                        :buttonTitle="value.buttonTitle"
-                        :buttonId="value.buttonId"
                         :key="name"
+                        :label="value.label"
+                        :list-id="formatListId(value.label)"
+                        :button-title="value.buttonTitle"
+                        :button-id="value.buttonId"
                         :disabled="value.disabled || value.listItems.length === 0"
                     >
                         <component
                             :is="value.listType"
                             :key="value.buttonId"
-                            :filterEmitter="filterEmitter"
-                            :listItems=value.listItems
+                            :filter-emitter="filterEmitter"
+                            :list-items=value.listItems
+                            :list-id="formatListId(value.label)"
                         ></component>
                     </FancyDropdown>
                 </template>
@@ -25,6 +27,8 @@
 </template>
 
 <script>
+import _camelCase from "lodash/camelCase";
+
 import FancyDropdown from "@/components/custom_elements/FancyDropdown.vue";
 import TitlePartList from "@/components/custom_elements/TitlePartList.vue";
 import SubpartList from "@/components/custom_elements/SubpartList.vue";
@@ -46,31 +50,13 @@ export default {
         resourcesDisplay: {
             type: String,
             required: false,
+            default: "",
         },
         filters: {
             type: Object,
             required: true,
         },
     },
-
-    beforeCreate() {},
-
-    created() {},
-
-    beforeMount() {},
-
-    mounted() {},
-
-    beforeUpdate() {},
-
-    updated() {},
-
-    beforeDestroy() {},
-
-    destroyed() {},
-
-    /*data() {},*/
-
     computed: {
         resourcesClass() {
             return `content-with-${this.resourcesDisplay}`;
@@ -80,6 +66,9 @@ export default {
     methods: {
         filterEmitter(payload) {
             this.$emit("select-filter", payload);
+        },
+        formatListId(label) {
+            return _camelCase(`${label}List`)
         },
     },
 };

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesNav.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesNav.vue
@@ -30,36 +30,10 @@
 export default {
     name: "ResourcesNav",
 
-    components: {},
-
     props: {
         aboutUrl: {
             type: String,
             default: "/about/"
-        },
-    },
-
-    beforeCreate() {},
-
-    created() {},
-
-    beforeMount() {},
-
-    mounted() {},
-
-    beforeUpdate() {},
-
-    updated() {},
-
-    beforeDestroy() {},
-
-    destroyed() {},
-
-    computed: {},
-
-    methods: {
-        methodName() {
-            console.log("method has been invoked");
         },
     },
 };

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesNav.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesNav.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="nav-container">
+    <div id="main-content" class="nav-container" role="main">
         <div class="content">
             <h1>Resources</h1>
             <p>
@@ -9,17 +9,22 @@
                     href="https://www.federalregister.gov/agencies/centers-for-medicare-medicaid-services"
                     target="_blank"
                     class="external"
-                >in the Federal Register</a>
+                    >in the Federal Register</a
+                >
                 and subregulatory guidance and implementation resources
                 published
                 <a
                     href="https://www.medicaid.gov/federal-policy-guidance/index.html"
                     target="_blank"
                     class="external"
-                >by CMS</a>.
+                    >by CMS</a
+                >.
             </p>
             <p>
-                <a :href="aboutUrl">How these links are added and connected to regulation sections.</a>
+                <a :href="aboutUrl"
+                    >How these links are added and connected to regulation
+                    sections.</a
+                >
             </p>
             <slot></slot>
         </div>
@@ -33,7 +38,7 @@ export default {
     props: {
         aboutUrl: {
             type: String,
-            default: "/about/"
+            default: "/about/",
         },
     },
 };

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesNav.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesNav.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="main-content" class="nav-container" role="main">
+    <div class="nav-container" role="main">
         <div class="content">
             <h1>Resources</h1>
             <p>

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -5,34 +5,36 @@
             <div class="results-count">
                 <span v-if="isLoading">Loading...</span>
                 <span v-else>
-                    <span v-if="count > 0">{{ currentPageResultsRange[0] }} - {{ currentPageResultsRange[1] }} of</span>
-                    {{ count }} result<span v-if="count != 1">s</span> in Resources
+                    <span v-if="count > 0">
+                        {{ currentPageResultsRange[0] }} -
+                        {{ currentPageResultsRange[1] }} of
+                    </span>
+                    {{ count }} result<span v-if="count != 1">s</span> in
+                    Resources
                 </span>
                 <div class="sort-control">
-                    <span class="sort-control-label">Sort by</span>
+                    <span id="resultsSortLabel" class="sort-control-label">
+                        Sort by
+                    </span>
                     <FancyDropdown
                         :button-title="sortMethodTitle"
                         :disabled="sortDisabled"
+                        list-id="resultsSortLabel"
                     >
                         <v-list class="sort-options-list">
-                            <v-list-item-group
-                                v-model="sortOptions"
-                                class="sort-options-list-item-group"
+                            <template
+                                v-for="(sortOption, index) in sortOptions"
                             >
-                                <template
-                                    v-for="(sortOption, index) in sortOptions"
+                                <v-list-item
+                                    :key="sortOption.value + index"
+                                    :data-value="sortOption.value"
+                                    :disabled="sortOption.disabled"
+                                    :inactive="sortOption.disabled"
+                                    @click="clickMethod"
                                 >
-                                    <v-list-item
-                                        :key="sortOption.value + index"
-                                        :data-value="sortOption.value"
-                                        :disabled="sortOption.disabled"
-                                        :inactive="sortOption.disabled"
-                                        @click="clickMethod"
-                                    >
-                                        <span>{{ sortOption.label }}</span>
-                                    </v-list-item>
-                                </template>
-                            </v-list-item-group>
+                                    <span>{{ sortOption.label }}</span>
+                                </v-list-item>
+                            </template>
                         </v-list>
                     </FancyDropdown>
                 </div>

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -19,6 +19,7 @@
                     <FancyDropdown
                         :button-title="sortMethodTitle"
                         :disabled="sortDisabled"
+                        button-id="sortButton"
                         list-id="resultsSortLabel"
                     >
                         <v-list class="sort-options-list">

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesSelections.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesSelections.vue
@@ -26,7 +26,9 @@
                 v-if="showClearAll"
                 class="clear-all-chip"
                 outlined
+                tabindex="0"
                 @click="handleCloseAll"
+                @keydown.enter.space.prevent="handleCloseAll"
                 >Clear All</v-chip
             >
         </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -7,6 +7,7 @@
                     @submit.prevent="executeSearch"
                 >
                     <v-text-field
+                        id="main-content"
                         v-model="searchInputValue"
                         outlined
                         flat

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -14,6 +14,7 @@
                         solo
                         clearable
                         label="Search resources using keywords or citations."
+                        aria-label="Search resources using keywords or citations."
                         type="text"
                         class="search-field"
                         append-icon="mdi-magnify"
@@ -25,12 +26,20 @@
                     <div v-if="synonyms.length > 0 || multiWordQuery" class="search-suggestion">
                         <div v-if="multiWordQuery">
                             Didn't find what you were looking for? Try searching for
-                            <a @click="doQuoteSearch">"{{this.searchQuery}}"</a>
+                            <a
+                                tabindex="0"
+                                @click="doQuoteSearch"
+                                @keydown.enter.space.prevent="doQuoteSearch"
+                            >"{{ searchQuery }}"</a>
                         </div>
-                        <div class="synonyms" v-if="synonyms.length > 0"> 
+                        <div v-if="synonyms.length > 0" class="synonyms">
                             <span v-if="multiWordQuery">Or s</span><span v-else>S</span>earch for similar terms:
-                            <span v-bind:key=a v-for="a in synonyms">
-                                <a @click="synonymLinks(a)">{{a}}</a>
+                            <span v-for="a in synonyms" :key=a>
+                                <a
+                                    tabindex=0
+                                    @click="synonymLinks(a)"
+                                    @keydown.enter.space.prevent="synonymLinks(a)"
+                                >{{ a }}</a>
                                 <span v-if="synonyms[synonyms.length-1] != a">, </span>
                             </span>
                         </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -1,7 +1,7 @@
 <template>
     <body class="ds-base">
-        <div id="app" class="resources-view">
-            <ResourcesNav :aboutUrl="aboutUrl">
+        <div id="resourcesApp" class="resources-view">
+            <ResourcesNav :about-url="aboutUrl">
                 <form
                     class="search-resources-form"
                     @submit.prevent="executeSearch"
@@ -786,7 +786,7 @@ export default {
 </script>
 
 <style lang="scss">
-#app.resources-view {
+#resourcesApp.resources-view {
     display: flex;
     flex-direction: column;
     .resources-content-container {

--- a/solution/ui/regulations/js/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContent.vue
@@ -215,18 +215,21 @@ export default {
             this.fetch_content(this.title, this.part, location)
         },
         parseHash(locationHash) {
+            if (window.location.hash === "#main-content") return "";
+
             let section = locationHash.substring(1).replace("-", ".");
+
             if (section.includes("-")) {
                 // eslint-prefer-destructuring, kinda cool
                 [section] = section.split("-");
             }
+
             if (Number.isNaN(section)) {
-                return `locations=${this.title}.${this.part}.${section}`
+                return `locations=${this.title}.${this.part}.${section}`;
             }
-            else {
-              this.selectedPart = `§ ${section}`;
-              return `locations=${this.title}.${section}`
-            }
+
+            this.selectedPart = `§ ${section}`;
+            return `locations=${this.title}.${section}`;
         },
         async fetch_content(title, part, location) {
             try {


### PR DESCRIPTION
Resolves [EREGCSC-1536](https://jiraent.cms.gov/browse/EREGCSC-1536)

**Description**

The Resources page needs some TLC to get it closer to/within 508 and screen reader compliance.  This PR will ensure that all parts of the page are accessible via keyboard navigation.

**This pull request changes:**

- Adds Skip to Main Content tab-navigable button to Resources page
- Adds and updates Cypress fixtures for Resources API call results:
   - adds fixture that mocks no/zero results
   - updates fixture that mocks page 1 of paginated results
   - adds fixture that mocks page 2 of paginated results
- Re-enables all existing tests in Resources test suite that were previously being skipped
- Adds additional resources test to provide coverage for a11y, pagination, loading state, and empty state
- adds `clearIndexedDB` Cypress command to reliably clear all cached network calls between tests.  This will be very useful.
- Refactors several components used in the Resources view to fix serious and critical a11y issues and to improve keyboard navigability
- Reformats code with prettier and corrects various eslint warnings

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://bstpsibijc.execute-api.us-east-1.amazonaws.com/dev564) or run locally
2. Visit resources page and use keyboard to tab through and interact with the resources page
   - Note: if you're on a Mac, you will need to explicitly enable keyboard navigation if you have not already done so
   - https://dequeuniversity.com/mac/keyboard-access-mac
3. Run tests locally or view test results in Github actions
4. Use a11y dev tools plugin like https://www.deque.com/axe/devtools/ to ensure no critical or serious a11y issues are found