### PR TITLE
EREGCSC-1460 Convert polymorphic serializers into fields for Swagger docs

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -90,8 +90,7 @@ STATIC_URL = os.environ.get("STATIC_URL", None)
 STATIC_ROOT = os.environ.get("STATIC_ROOT", None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-#DEBUG = os.environ.get("DEBUG", False)
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", False)
 
 WORKING_DIR = os.environ.get("WORKING_DIR", "/var/lib/eregs")
 TEMPLATES = [

--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -90,7 +90,8 @@ STATIC_URL = os.environ.get("STATIC_URL", None)
 STATIC_ROOT = os.environ.get("STATIC_ROOT", None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", False)
+#DEBUG = os.environ.get("DEBUG", False)
+DEBUG = True
 
 WORKING_DIR = os.environ.get("WORKING_DIR", "/var/lib/eregs")
 TEMPLATES = [

--- a/solution/backend/regcore/serializers/contents.py
+++ b/solution/backend/regcore/serializers/contents.py
@@ -119,7 +119,7 @@ class SectionChildrenField(NodeChildrenField):
         }
 
 
-class SectionSerializer(PartNodeSerializer):
+class SectionContentsSerializer(PartNodeSerializer):
     title = serializers.CharField()
     label = serializers.ListField(child=serializers.CharField())
     children = serializers.ListField(child=SectionChildrenField())
@@ -149,14 +149,14 @@ class AppendixSerializer(PartNodeSerializer):
 @extend_schema_field(
     PolymorphicProxySerializer(
         component_name="SubjectGroupChildrenField",
-        serializers=[SectionSerializer, FootNoteSerializer],
+        serializers=[SectionContentsSerializer, FootNoteSerializer],
         resource_type_field_name="node_type",
     )
 )
 class SubjectGroupChildrenField(NodeChildrenField):
     def get_serializer_map(self):
         return {
-            "SECTION": SectionSerializer,
+            "SECTION": SectionContentsSerializer,
             "FootNote": FootNoteSerializer,
         }
 
@@ -171,7 +171,7 @@ class SubjectGroupSerializer(PartNodeSerializer):
     PolymorphicProxySerializer(
         component_name="SubpartChildrenField",
         serializers=[
-            SectionSerializer,
+            SectionContentsSerializer,
             SubjectGroupSerializer,
             AppendixSerializer,
             SourceSerializer,
@@ -182,14 +182,14 @@ class SubjectGroupSerializer(PartNodeSerializer):
 class SubpartChildrenField(NodeChildrenField):
     def get_serializer_map(self):
         return {
-            "SECTION": SectionSerializer,
+            "SECTION": SectionContentsSerializer,
             "SUBJGRP": SubjectGroupSerializer,
             "APPENDIX": AppendixSerializer,
             "Source": SourceSerializer,
         }
 
 
-class SubpartSerializer(PartNodeSerializer):
+class SubpartContentsSerializer(PartNodeSerializer):
     title = serializers.CharField()
     label = serializers.ListField(child=serializers.CharField())
     children = serializers.ListField(child=SubpartChildrenField())
@@ -201,15 +201,15 @@ class SubpartSerializer(PartNodeSerializer):
 @extend_schema_field(
     PolymorphicProxySerializer(
         component_name="PartChildrenField",
-        serializers=[SubpartSerializer, SectionSerializer],
+        serializers=[SubpartContentsSerializer, SectionContentsSerializer],
         resource_type_field_name="node_type",
     )
 )
 class PartChildrenField(NodeChildrenField):
     def get_serializer_map(self):
         return {
-            "SUBPART": SubpartSerializer,
-            "SECTION": SectionSerializer,
+            "SUBPART": SubpartContentsSerializer,
+            "SECTION": SectionContentsSerializer,
         }
 
 

--- a/solution/backend/regcore/serializers/parser.py
+++ b/solution/backend/regcore/serializers/parser.py
@@ -27,17 +27,17 @@ class ParserResultSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class SectionCreateSerializer(serializers.Serializer):
+class PartSectionCreateSerializer(serializers.Serializer):
     title = serializers.CharField()
     part = serializers.CharField()
     section = serializers.CharField()
 
 
-class SubpartCreateSerializer(serializers.Serializer):
+class PartSubpartCreateSerializer(serializers.Serializer):
     title = serializers.CharField()
     part = serializers.CharField()
     subpart = serializers.CharField()
-    sections = SectionCreateSerializer(many=True)
+    sections = PartSectionCreateSerializer(many=True)
 
 
 class PartUploadSerializer(serializers.Serializer):
@@ -50,8 +50,8 @@ class PartUploadSerializer(serializers.Serializer):
     depth = serializers.IntegerField()
 
     # location fields
-    sections = SectionCreateSerializer(many=True)
-    subparts = SubpartCreateSerializer(many=True)
+    sections = PartSectionCreateSerializer(many=True)
+    subparts = PartSubpartCreateSerializer(many=True)
 
     def update(self, instance, validated_data):
         instance.name = validated_data.get("name")

--- a/solution/backend/regcore/v3views/contents.py
+++ b/solution/backend/regcore/v3views/contents.py
@@ -11,8 +11,8 @@ from .mixins import (
 
 from regcore.serializers.contents import (
     V3PartSerializer,
-    SectionSerializer,
-    SubpartSerializer,
+    SectionContentsSerializer,
+    SubpartContentsSerializer,
 )
 
 
@@ -35,7 +35,7 @@ class PartViewSet(PartPropertiesMixin, viewsets.ReadOnlyModelViewSet):
     parameters=[OpenApiPathParameter("section", "Section number to retrieve.", int)] + NodeFinderMixin.PARAMETERS,
 )
 class SectionViewSet(NodeFinderMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = SectionSerializer
+    serializer_class = SectionContentsSerializer
     parameter = "section"
     node_type = "SECTION"
     label_index = 1
@@ -47,7 +47,7 @@ class SectionViewSet(NodeFinderMixin, viewsets.ReadOnlyModelViewSet):
     parameters=[OpenApiPathParameter("subpart", "Subpart to retrieve, e.g. A.", str)] + NodeFinderMixin.PARAMETERS,
 )
 class SubpartViewSet(NodeFinderMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = SubpartSerializer
+    serializer_class = SubpartContentsSerializer
     parameter = "subpart"
     node_type = "SUBPART"
     label_index = 0

--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -22,8 +22,8 @@ class HomepageView(TemplateView):
 
         today = date.today()
         parts = Part.objects.effective(today)
-        resources_config = ResourcesConfiguration.objects.first()
-        fr_docs_category_name = resources_config.fr_doc_category.name
+        fr_doc_category = ResourcesConfiguration.objects.first().fr_doc_category
+        fr_docs_category_name = fr_doc_category.name if fr_doc_category else None
 
         if not parts:
             return context

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field, OpenApiTypes, PolymorphicProxySerializer
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 from resources.models import Category, SubCategory
 from .mixins import PolymorphicSerializer, PolymorphicTypeField

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 from resources.models import Category, SubCategory
 from .mixins import PolymorphicSerializer, OptionalFieldDetailsMixin
@@ -20,6 +21,7 @@ class CategorySerializer(serializers.Serializer):
     show_if_empty = serializers.BooleanField()
     is_fr_doc_category = serializers.SerializerMethodField()
 
+    @extend_schema_field(OpenApiTypes.BOOL)
     def get_is_fr_doc_category(self, obj):
         try:
             return obj.is_fr_doc_category

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -37,7 +37,7 @@ class SubCategorySerializer(CategorySerializer):
     @extend_schema_field(CategorySerializer)
     def get_parent(self, obj):
         if self.context.get("parent_details", "true").lower() == "true":
-            return CategorySerializer(obj.category).data
+            return CategorySerializer(obj.parent).data
         return serializers.PrimaryKeyRelatedField(read_only=True)
 
 

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -3,6 +3,7 @@ from drf_spectacular.utils import extend_schema_field, OpenApiTypes, Polymorphic
 
 from resources.models import Category, SubCategory
 from .mixins import PolymorphicSerializer
+from .utils import ProxySerializerWrapper
 
 
 class AbstractCategoryPolymorphicSerializer(PolymorphicSerializer):
@@ -39,7 +40,7 @@ class SubCategorySerializer(CategorySerializer):
         return serializers.PrimaryKeyRelatedField(read_only=True)
 
 
-MetaCategorySerializer = PolymorphicProxySerializer(
+MetaCategorySerializer = ProxySerializerWrapper(
     component_name="MetaCategorySerializer",
     serializers=[CategorySerializer, SubCategorySerializer],
     resource_type_field_name="type",

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -36,9 +36,9 @@ class SubCategorySerializer(CategorySerializer):
 
     @extend_schema_field(CategorySerializer)
     def get_parent(self, obj):
-        if self.context.get("parent_details", "true").lower() == "true":
+        if self.context.get("parent_details", True):
             return CategorySerializer(obj.parent).data
-        return serializers.PrimaryKeyRelatedField(read_only=True)
+        return serializers.PrimaryKeyRelatedField(read_only=True).to_representation(obj.parent)
 
 
 MetaCategorySerializer = ProxySerializerWrapper(

--- a/solution/backend/resources/v3serializers/categories.py
+++ b/solution/backend/resources/v3serializers/categories.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field, OpenApiTypes, PolymorphicProxySerializer
 
 from resources.models import Category, SubCategory
-from .mixins import PolymorphicSerializer
+from .mixins import PolymorphicSerializer, PolymorphicTypeField
 from .utils import ProxySerializerWrapper
 
 
@@ -21,6 +21,7 @@ class CategorySerializer(serializers.Serializer):
     order = serializers.IntegerField()
     show_if_empty = serializers.BooleanField()
     is_fr_doc_category = serializers.SerializerMethodField()
+    type = PolymorphicTypeField()
 
     @extend_schema_field(OpenApiTypes.BOOL)
     def get_is_fr_doc_category(self, obj):

--- a/solution/backend/resources/v3serializers/locations.py
+++ b/solution/backend/resources/v3serializers/locations.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer
 
 from resources.models import Section, Subpart
-from .mixins import PolymorphicSerializer
+from .mixins import PolymorphicSerializer, PolymorphicTypeField
 from .utils import ProxySerializerWrapper
 
 
@@ -18,6 +18,7 @@ class AbstractLocationSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     title = serializers.IntegerField()
     part = serializers.IntegerField()
+    type = PolymorphicTypeField()
 
 
 class SubpartSerializer(AbstractLocationSerializer):

--- a/solution/backend/resources/v3serializers/locations.py
+++ b/solution/backend/resources/v3serializers/locations.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer
+from drf_spectacular.utils import extend_schema_field
 
 from resources.models import Section, Subpart
 from .mixins import PolymorphicSerializer, PolymorphicTypeField

--- a/solution/backend/resources/v3serializers/locations.py
+++ b/solution/backend/resources/v3serializers/locations.py
@@ -26,6 +26,9 @@ class SectionSerializer(AbstractLocationSerializer):
     section_id = serializers.IntegerField()
     parent = serializers.PrimaryKeyRelatedField(read_only=True)
 
+    class Meta:
+        model = Section
+
 
 class FullSectionSerializer(SectionSerializer):
     parent = AbstractLocationPolymorphicSerializer()

--- a/solution/backend/resources/v3serializers/mixins.py
+++ b/solution/backend/resources/v3serializers/mixins.py
@@ -2,21 +2,6 @@ from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 
-# Allows details of specified fields to be shown or hidden
-# Must specify "optional_details" as map of strings to 4-tuples:
-#    { "field_name": ("query_param", "default, true or false as a string", serializer class, many=True or False) }
-class OptionalFieldDetailsMixin:
-    def get_fields(self):
-        fields = super().get_fields()
-        for i in self.optional_details.items():
-            fields[i[0]] = (
-                i[1][2](many=i[1][3])
-                if self.context.get(i[1][0], i[1][1]).lower() == "true"
-                else serializers.PrimaryKeyRelatedField(many=i[1][3], read_only=True)
-            )
-        return fields
-
-
 # Retrieves automatically generated search headlines
 @extend_schema_field(OpenApiTypes.STR)
 class HeadlineField(serializers.Field):

--- a/solution/backend/resources/v3serializers/mixins.py
+++ b/solution/backend/resources/v3serializers/mixins.py
@@ -25,7 +25,18 @@ class PolymorphicSerializer(serializers.Serializer):
     def to_representation(self, instance):
         instance_type = type(instance)
         if instance_type in self.get_serializer_map():
-            data = self.get_serializer_map()[instance_type][1](instance=instance, context=self.context).data
-            data["type"] = self.get_serializer_map()[instance_type][0]
-            return data
+            setattr(instance, "type", self.get_serializer_map()[instance_type][0])
+            return self.get_serializer_map()[instance_type][1](instance=instance, context=self.context).data
         return "Serializer not available"
+
+
+# Permits a "type" field to be properly displayed by polymorphic serializers (e.g. { "type": "Section" })
+@extend_schema_field(OpenApiTypes.STR)
+class PolymorphicTypeField(serializers.Field):
+    def __init__(self, **kwargs):
+        kwargs["source"] = '*'
+        kwargs["read_only"] = True
+        super().__init__(**kwargs)
+
+    def to_representation(self, obj):
+        return getattr(obj, self.field_name, "")

--- a/solution/backend/resources/v3serializers/mixins.py
+++ b/solution/backend/resources/v3serializers/mixins.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 
 # Allows details of specified fields to be shown or hidden
@@ -17,6 +18,7 @@ class OptionalFieldDetailsMixin:
 
 
 # Retrieves automatically generated search headlines
+@extend_schema_field(OpenApiTypes.STR)
 class HeadlineField(serializers.Field):
     def __init__(self, model_name, **kwargs):
         self.model_name = model_name

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from django.urls import reverse
-from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer
+from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer, OpenApiTypes
 
 from resources.models import (
     SupplementalContent,
@@ -60,6 +60,7 @@ class TypicalResourceFieldsSerializer(DateFieldSerializer):
     url = serializers.CharField()
     internalURL = serializers.SerializerMethodField()
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_internalURL(self, obj):
         return reverse('supplemental_content', kwargs={'id': obj.pk})
 

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -20,6 +20,7 @@ from .locations import (
 )
 from .categories import AbstractCategoryPolymorphicSerializer, MetaCategorySerializer
 from .mixins import HeadlineField, PolymorphicSerializer, PolymorphicTypeField
+from .utils import ProxySerializerWrapper
 
 
 class AbstractResourcePolymorphicSerializer(PolymorphicSerializer):
@@ -97,6 +98,13 @@ class FederalRegisterDocumentSerializer(SimpleFederalRegisterDocumentSerializer)
         docs = sorted(docs, key=lambda i: i["date"] or "", reverse=True)
         docs[0]["related_docs"] = docs[1:]
         return docs[0]
+
+
+MetaResourceSerializer = ProxySerializerWrapper(
+    component_name="MetaResourceSerializer",
+    serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
+    resource_type_field_name=None,
+)
 
 
 class FederalRegisterDocumentCreateSerializer(serializers.Serializer):

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from django.urls import reverse
-from drf_spectacular.utils import extend_schema_field, PolymorphicProxySerializer, OpenApiTypes
+from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 from resources.models import (
     SupplementalContent,
@@ -12,8 +12,13 @@ from resources.models import (
     Section,
 )
 
-from .locations import SectionCreateSerializer, SectionRangeCreateSerializer, AbstractLocationPolymorphicSerializer, MetaLocationSerializer
-from .categories import AbstractCategoryPolymorphicSerializer, CategorySerializer, SubCategorySerializer, MetaCategorySerializer
+from .locations import (
+    SectionCreateSerializer,
+    SectionRangeCreateSerializer,
+    AbstractLocationPolymorphicSerializer,
+    MetaLocationSerializer,
+)
+from .categories import AbstractCategoryPolymorphicSerializer, MetaCategorySerializer
 from .mixins import HeadlineField, PolymorphicSerializer, PolymorphicTypeField
 
 

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -14,7 +14,7 @@ from resources.models import (
 
 from .locations import SectionCreateSerializer, SectionRangeCreateSerializer, AbstractLocationPolymorphicSerializer, MetaLocationSerializer
 from .categories import AbstractCategoryPolymorphicSerializer, CategorySerializer, SubCategorySerializer, MetaCategorySerializer
-from .mixins import HeadlineField, PolymorphicSerializer
+from .mixins import HeadlineField, PolymorphicSerializer, PolymorphicTypeField
 
 
 class AbstractResourcePolymorphicSerializer(PolymorphicSerializer):
@@ -33,6 +33,8 @@ class AbstractResourceSerializer(serializers.Serializer):
 
     category = serializers.SerializerMethodField()
     locations = serializers.SerializerMethodField()
+
+    type = PolymorphicTypeField()
 
     @extend_schema_field(MetaCategorySerializer.many(False))
     def get_category(self, obj):

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -44,15 +44,15 @@ class AbstractResourceSerializer(serializers.Serializer):
 
     @extend_schema_field(MetaCategorySerializer.many(False))
     def get_category(self, obj):
-        if self.context.get("category_details", "true").lower() == "true":
+        if self.context.get("category_details", True):
             return AbstractCategoryPolymorphicSerializer(obj.category).data
-        return serializers.PrimaryKeyRelatedField(read_only=True)
+        return serializers.PrimaryKeyRelatedField(read_only=True).to_representation(obj.category)
 
     @extend_schema_field(MetaLocationSerializer.many(True))
     def get_locations(self, obj):
-        if self.context.get("location_details", "true").lower() == "true":
+        if self.context.get("location_details", True):
             return AbstractLocationPolymorphicSerializer(obj.locations, many=True).data
-        return serializers.PrimaryKeyRelatedField(read_only=True)
+        return serializers.PrimaryKeyRelatedField(read_only=True, many=True).to_representation(obj.locations.all())
 
 
 class DateFieldSerializer(serializers.Serializer):

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -12,7 +12,7 @@ from resources.models import (
     Section,
 )
 
-from .locations import SectionCreateSerializer, SectionRangeCreateSerializer, AbstractLocationPolymorphicSerializer, ManyMetaLocationSerializer
+from .locations import SectionCreateSerializer, SectionRangeCreateSerializer, AbstractLocationPolymorphicSerializer, MetaLocationSerializer
 from .categories import AbstractCategoryPolymorphicSerializer, CategorySerializer, SubCategorySerializer, MetaCategorySerializer
 from .mixins import HeadlineField, PolymorphicSerializer
 
@@ -34,13 +34,13 @@ class AbstractResourceSerializer(serializers.Serializer):
     category = serializers.SerializerMethodField()
     locations = serializers.SerializerMethodField()
 
-    @extend_schema_field(MetaCategorySerializer)
+    @extend_schema_field(MetaCategorySerializer.many(False))
     def get_category(self, obj):
         if self.context.get("category_details", "true").lower() == "true":
             return AbstractCategoryPolymorphicSerializer(obj.category).data
         return serializers.PrimaryKeyRelatedField(read_only=True)
 
-    @extend_schema_field(ManyMetaLocationSerializer)
+    @extend_schema_field(MetaLocationSerializer.many(True))
     def get_locations(self, obj):
         if self.context.get("location_details", "true").lower() == "true":
             return AbstractLocationPolymorphicSerializer(obj.locations, many=True).data

--- a/solution/backend/resources/v3serializers/utils.py
+++ b/solution/backend/resources/v3serializers/utils.py
@@ -1,0 +1,13 @@
+from drf_spectacular.utils import PolymorphicProxySerializer
+
+class ProxySerializerWrapper:
+    def __init__(self, component_name, serializers, resource_type_field_name):
+        self.many_true, self.many_false = [PolymorphicProxySerializer(
+            component_name=component_name,
+            serializers=serializers,
+            resource_type_field_name=resource_type_field_name,
+            many=i,
+        ) for i in [True, False]]
+
+    def many(self, many):
+        return self.many_true if many else self.many_false

--- a/solution/backend/resources/v3serializers/utils.py
+++ b/solution/backend/resources/v3serializers/utils.py
@@ -1,5 +1,6 @@
 from drf_spectacular.utils import PolymorphicProxySerializer
 
+
 class ProxySerializerWrapper:
     def __init__(self, component_name, serializers, resource_type_field_name):
         self.many_true, self.many_false = [PolymorphicProxySerializer(

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -33,7 +33,7 @@ class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["parent_details"] = self.request.GET.get("parent_details", "true")
+        context["parent_details"] = self.request.GET.get("parent_details", "true").lower() == "true"
         return context
 
 

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -25,7 +25,7 @@ from resources.v3serializers.categories import (
                               "than just the ID.", bool, False),
     ],
     responses=PolymorphicProxySerializer(
-        component_name="AbstractCategoryPolymorphicSerializer",
+        component_name="MetaCategorySerializer",
         serializers=[CategorySerializer, SubCategorySerializer],
         resource_type_field_name=None,
     ),

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -15,6 +15,7 @@ from resources.v3serializers.categories import (
     SubCategorySerializer,
     AbstractCategoryPolymorphicSerializer,
     CategoryTreeSerializer,
+    MetaCategorySerializer,
 )
 
 
@@ -24,12 +25,7 @@ from resources.v3serializers.categories import (
         OpenApiQueryParameter("parent_details", "Show details about each sub-category's parent, rather "
                               "than just the ID.", bool, False),
     ],
-    responses=PolymorphicProxySerializer(
-        component_name="MetaCategorySerializer",
-        serializers=[CategorySerializer, SubCategorySerializer],
-        resource_type_field_name=None,
-        many=True,
-    ),
+    responses=MetaCategorySerializer.many(True),
 )
 class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
     paginate_by_default = False

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -25,7 +25,7 @@ from resources.v3serializers.categories import (
                               "than just the ID.", bool, False),
     ],
     responses=PolymorphicProxySerializer(
-        component_name="MetaCategorySerializer",
+        component_name="AbstractCategoryPolymorphicSerializer",
         serializers=[CategorySerializer, SubCategorySerializer],
         resource_type_field_name=None,
     ),

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, PolymorphicProxySerializer
 from django.db.models import Prefetch
 
 from .mixins import OptionalPaginationMixin, OpenApiQueryParameter, PAGINATION_PARAMS
@@ -11,6 +11,7 @@ from resources.models import (
 )
 
 from resources.v3serializers.categories import (
+    CategorySerializer,
     SubCategorySerializer,
     AbstractCategoryPolymorphicSerializer,
     CategoryTreeSerializer,
@@ -23,7 +24,11 @@ from resources.v3serializers.categories import (
         OpenApiQueryParameter("parent_details", "Show details about each sub-category's parent, rather "
                               "than just the ID.", bool, False),
     ],
-    responses=SubCategorySerializer,
+    responses=PolymorphicProxySerializer(
+        component_name="AbstractCategoryPolymorphicSerializer",
+        serializers=[CategorySerializer, SubCategorySerializer],
+        resource_type_field_name=None,
+    ),
 )
 class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):
     paginate_by_default = False

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -28,6 +28,7 @@ from resources.v3serializers.categories import (
         component_name="AbstractCategoryPolymorphicSerializer",
         serializers=[CategorySerializer, SubCategorySerializer],
         resource_type_field_name=None,
+        many=True,
     ),
 )
 class CategoryViewSet(OptionalPaginationMixin, viewsets.ReadOnlyModelViewSet):

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -25,7 +25,7 @@ from resources.v3serializers.categories import (
                               "than just the ID.", bool, False),
     ],
     responses=PolymorphicProxySerializer(
-        component_name="AbstractCategoryPolymorphicSerializer",
+        component_name="MetaCategorySerializer",
         serializers=[CategorySerializer, SubCategorySerializer],
         resource_type_field_name=None,
         many=True,

--- a/solution/backend/resources/v3views/categories.py
+++ b/solution/backend/resources/v3views/categories.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema, PolymorphicProxySerializer
+from drf_spectacular.utils import extend_schema
 from django.db.models import Prefetch
 
 from .mixins import OptionalPaginationMixin, OpenApiQueryParameter, PAGINATION_PARAMS
@@ -11,8 +11,6 @@ from resources.models import (
 )
 
 from resources.v3serializers.categories import (
-    CategorySerializer,
-    SubCategorySerializer,
     AbstractCategoryPolymorphicSerializer,
     CategoryTreeSerializer,
     MetaCategorySerializer,

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -27,7 +27,7 @@ from regcore.views import SettingsAuthentication
     description="Retrieve a list of all resource locations, filterable by title and part. Results are paginated by default.",
     parameters=LocationExplorerViewSetMixin.PARAMETERS,
     responses=PolymorphicProxySerializer(
-        component_name="MetaLocationSerializer",
+        component_name="AbstractLocationPolymorphicSerializer",
         serializers=[SectionSerializer, SubpartSerializer],
         resource_type_field_name="type",
     ),
@@ -43,6 +43,7 @@ class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):
 @extend_schema(
     description="Retrieve a list of all Section objects, filterable by title and part. Results are paginated by default.",
     parameters=LocationExplorerViewSetMixin.PARAMETERS,
+    responses=FullSectionSerializer,
 )
 class SectionViewSet(LocationExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = FullSectionSerializer

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -15,8 +15,6 @@ from resources.v3serializers.locations import (
     AbstractLocationPolymorphicSerializer,
     FullSectionSerializer,
     FullSubpartSerializer,
-    SectionSerializer,
-    SubpartSerializer,
     MetaLocationSerializer,
 )
 

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -12,7 +12,6 @@ from resources.models import (
 )
 
 from resources.v3serializers.locations import (
-    AbstractLocationSerializer,
     AbstractLocationPolymorphicSerializer,
     FullSectionSerializer,
     FullSubpartSerializer,

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -28,7 +28,8 @@ from regcore.views import SettingsAuthentication
     responses=PolymorphicProxySerializer(
         component_name="AbstractLocationPolymorphicSerializer",
         serializers=[SectionSerializer, SubpartSerializer],
-        resource_type_field_name="type",
+        resource_type_field_name=None,
+        many=True,
     ),
 )
 class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -26,7 +26,7 @@ from regcore.views import SettingsAuthentication
     description="Retrieve a list of all resource locations, filterable by title and part. Results are paginated by default.",
     parameters=LocationExplorerViewSetMixin.PARAMETERS,
     responses=PolymorphicProxySerializer(
-        component_name="AbstractLocationPolymorphicSerializer",
+        component_name="MetaLocationSerializer",
         serializers=[SectionSerializer, SubpartSerializer],
         resource_type_field_name=None,
         many=True,

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -27,7 +27,7 @@ from regcore.views import SettingsAuthentication
     description="Retrieve a list of all resource locations, filterable by title and part. Results are paginated by default.",
     parameters=LocationExplorerViewSetMixin.PARAMETERS,
     responses=PolymorphicProxySerializer(
-        component_name="AbstractLocationPolymorphicSerializer",
+        component_name="MetaLocationSerializer",
         serializers=[SectionSerializer, SubpartSerializer],
         resource_type_field_name="type",
     ),

--- a/solution/backend/resources/v3views/locations.py
+++ b/solution/backend/resources/v3views/locations.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from drf_spectacular.utils import extend_schema, PolymorphicProxySerializer
+from drf_spectacular.utils import extend_schema
 from django.db.models import Prefetch
 
 from .mixins import LocationExplorerViewSetMixin
@@ -17,6 +17,7 @@ from resources.v3serializers.locations import (
     FullSubpartSerializer,
     SectionSerializer,
     SubpartSerializer,
+    MetaLocationSerializer,
 )
 
 from regcore.views import SettingsAuthentication
@@ -25,12 +26,7 @@ from regcore.views import SettingsAuthentication
 @extend_schema(
     description="Retrieve a list of all resource locations, filterable by title and part. Results are paginated by default.",
     parameters=LocationExplorerViewSetMixin.PARAMETERS,
-    responses=PolymorphicProxySerializer(
-        component_name="MetaLocationSerializer",
-        serializers=[SectionSerializer, SubpartSerializer],
-        resource_type_field_name=None,
-        many=True,
-    ),
+    responses=MetaLocationSerializer.many(True),
 )
 class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):
     queryset = AbstractLocation.objects.all().select_subclasses()
@@ -43,7 +39,6 @@ class LocationViewSet(LocationExplorerViewSetMixin, viewsets.ModelViewSet):
 @extend_schema(
     description="Retrieve a list of all Section objects, filterable by title and part. Results are paginated by default.",
     parameters=LocationExplorerViewSetMixin.PARAMETERS,
-    responses=FullSectionSerializer,
 )
 class SectionViewSet(LocationExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = FullSectionSerializer

--- a/solution/backend/resources/v3views/mixins.py
+++ b/solution/backend/resources/v3views/mixins.py
@@ -136,9 +136,9 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context["category_details"] = self.request.GET.get("category_details", "true")
-        context["location_details"] = self.request.GET.get("location_details", "true")
-        context["fr_grouping"] = self.request.GET.get("fr_grouping", "true")
+        context["category_details"] = self.request.GET.get("category_details", "true").lower() == "true"
+        context["location_details"] = self.request.GET.get("location_details", "true").lower() == "true"
+        context["fr_grouping"] = self.request.GET.get("fr_grouping", "true").lower() == "true"
         return context
 
     def get_search_vectors(self):

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, PolymorphicProxySerializer
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from django.db import transaction
 from django.db.models import Case, When, F
@@ -31,7 +31,11 @@ from regcore.views import SettingsAuthentication
                 "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
                 "Results are paginated by default.",
     parameters=ResourceExplorerViewSetMixin.PARAMETERS,
-    responses=AbstractResourceSerializer,
+    responses=PolymorphicProxySerializer(
+        component_name="AbstractResourcePolymorphicSerializer",
+        serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
+        resource_type_field_name="type",
+    ),
 )
 class AbstractResourceViewSet(ResourceExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = AbstractResourcePolymorphicSerializer

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -32,7 +32,7 @@ from regcore.views import SettingsAuthentication
                 "Results are paginated by default.",
     parameters=ResourceExplorerViewSetMixin.PARAMETERS,
     responses=PolymorphicProxySerializer(
-        component_name="AbstractResourcePolymorphicSerializer",
+        component_name="MetaResourceSerializer",
         serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
         resource_type_field_name="type",
     ),

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -19,7 +19,6 @@ from resources.v3serializers.resources import (
     FederalRegisterDocumentCreateSerializer,
     FederalRegisterDocumentSerializer,
     StringListSerializer,
-    AbstractResourceSerializer,
 )
 
 from regcore.views import SettingsAuthentication

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema, PolymorphicProxySerializer
+from drf_spectacular.utils import extend_schema
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from django.db import transaction
 from django.db.models import Case, When, F
@@ -19,6 +19,7 @@ from resources.v3serializers.resources import (
     FederalRegisterDocumentCreateSerializer,
     FederalRegisterDocumentSerializer,
     StringListSerializer,
+    MetaResourceSerializer,
 )
 
 from regcore.views import SettingsAuthentication
@@ -30,12 +31,7 @@ from regcore.views import SettingsAuthentication
                 "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
                 "Results are paginated by default.",
     parameters=ResourceExplorerViewSetMixin.PARAMETERS,
-    responses=PolymorphicProxySerializer(
-        component_name="MetaResourceSerializer",
-        serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
-        resource_type_field_name=None,
-        many=True,
-    ),
+    responses=MetaResourceSerializer.many(True),
 )
 class AbstractResourceViewSet(ResourceExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = AbstractResourcePolymorphicSerializer

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -32,7 +32,7 @@ from regcore.views import SettingsAuthentication
                 "Results are paginated by default.",
     parameters=ResourceExplorerViewSetMixin.PARAMETERS,
     responses=PolymorphicProxySerializer(
-        component_name="MetaResourceSerializer",
+        component_name="AbstractResourcePolymorphicSerializer",
         serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
         resource_type_field_name="type",
     ),

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -31,7 +31,7 @@ from regcore.views import SettingsAuthentication
                 "Results are paginated by default.",
     parameters=ResourceExplorerViewSetMixin.PARAMETERS,
     responses=PolymorphicProxySerializer(
-        component_name="AbstractResourcePolymorphicSerializer",
+        component_name="MetaResourceSerializer",
         serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
         resource_type_field_name=None,
         many=True,

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -33,7 +33,8 @@ from regcore.views import SettingsAuthentication
     responses=PolymorphicProxySerializer(
         component_name="AbstractResourcePolymorphicSerializer",
         serializers=[SupplementalContentSerializer, FederalRegisterDocumentSerializer],
-        resource_type_field_name="type",
+        resource_type_field_name=None,
+        many=True,
     ),
 )
 class AbstractResourceViewSet(ResourceExplorerViewSetMixin, viewsets.ReadOnlyModelViewSet):

--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -10,6 +10,6 @@ django-solo
 django-opensearch-dsl
 python-dateutil~=2.8.2
 django-cors-headers
-drf-spectacular
+drf-spectacular==0.24.2
 django-model-utils
 django-jsonform

--- a/solution/ui/e2e/cypress/integration/api.spec.js
+++ b/solution/ui/e2e/cypress/integration/api.spec.js
@@ -7,6 +7,7 @@ const SYNONYM = "synonym";
 
 const API_ENDPOINTS_V3 = [
     `/v3/ecfr_parser_result/${TITLE}`,
+    `/v3/parser_config`,
     `/v3/resources/`,
     `/v3/resources/categories`,
     `/v3/resources/categories/tree`,


### PR DESCRIPTION
Resolves #1460

**Description-**

As a developer integrating with eRegs' API, I want accurate OpenAPI documentation available to me. Currently, when a field may return more than one data type, this is not accurately reflected in Swagger. Using drf-spectacular's "PolymorphicProxySerializer", we can include this information.

**This pull request changes...**

_For V3 only_:
- Fixes serializer name conflicts between regcore and resources apps
    - Serializers in ALL apps must be named differently to not confused Swagger.
- Resources viewsets use PolymorphicProxySerializer to properly serialize endpoints. These changed:
    - /v3/resources
    - /v3/resources/locations
    - /v3/resources/categories
- Fixed Swagger conflicts (i.e. duplicate component names, etc.)
- Fixes bugs caused by drf-spectacular updates
- Pinned drf-spectacular package to version `0.24.2` as recommended by https://drf-spectacular.readthedocs.io/en/latest/readme.html#release-management: "For production we strongly recommend pinning the version and inspecting a schema diff on update."
    - Prevents future bugs from suddenly popping up due to schema breaking changes to drf-spectacular.
- Incidental: fixed exception on homepage if no FR Doc Category is set in the configuration

**Steps to manually verify this change...**

1. Verify Cypress tests pass (no API errors)
2. Visit `/api/swagger` and read through response examples for v3 endpoints for accuracy

**Future work...**

Debugging Swagger revealed a large number of warnings or errors in the logs. Many are caused by outdated V2 endpoints and these will be resolved naturally when V2 support is dropped. However, there are some that should be addressed related to field hints and authentication in V3. Only in-scope warnings are fixed by this ticket.