### PR TITLE
EREGCSC-1520 Put in place Content Security Policy

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -213,12 +213,21 @@ LOGIN_URL = "/admin"
 
 # Settings for CSP headers
 CSP_IMG_SRC = ["'self'", STATIC_URL]
-CSP_STYLE_SRC = ["'self'", STATIC_URL]
-CSP_FONT_SRC = ["'self'", STATIC_URL]
+CSP_STYLE_SRC = [
+    "'self'",
+    "'unsafe-inline'",
+    STATIC_URL,
+    "https://cdn.jsdelivr.net/npm/@mdi/font@4.x/",
+]
+CSP_FONT_SRC = [
+    "'self'",
+    STATIC_URL,
+    "https://cdn.jsdelivr.net/npm/@mdi/font@4.x/",
+]
 CSP_SCRIPT_SRC = [
     "'self'",
-    #"'unsafe-inline'",
-    #"'unsafe-eval'",
+    "'unsafe-inline'",
+    "'unsafe-eval'",
     STATIC_URL,
     "https://www.googletagmanager.com",
 ]

--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -60,6 +60,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'csp.middleware.CSPMiddleware',
     'regulations.middleware.JsonErrors',
     'regulations.middleware.NoIndex',
     'regcore.middleware.HtmlApi',
@@ -209,6 +210,18 @@ SPECTACULAR_SETTINGS = {
 }
 
 LOGIN_URL = "/admin"
+
+# Settings for CSP headers
+CSP_IMG_SRC = ["'self'", STATIC_URL]
+CSP_STYLE_SRC = ["'self'", STATIC_URL]
+CSP_FONT_SRC = ["'self'", STATIC_URL]
+CSP_SCRIPT_SRC = [
+    "'self'",
+    #"'unsafe-inline'",
+    #"'unsafe-eval'",
+    STATIC_URL,
+    "https://www.googletagmanager.com",
+]
 
 if DEBUG:
     import os  # only if you haven't already imported this

--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -13,3 +13,4 @@ django-cors-headers
 drf-spectacular
 django-model-utils
 django-jsonform
+django-csp


### PR DESCRIPTION
Resolves #1520

**Description-**

In order to fulfill best practices that (1) scans like OWASP ZAP usually look for (2) are helpful in minimizing risk, we want to implement CSP tags on our site that add some directives about where content is supposed to come from, which should prevent XSS.

**This pull request changes...**

CSP is in place to limit requests to external sources except for those explicitly allowed

**Limitations**

This PR currently allows `unsafe-inline` and `unsafe-eval`, which is considered bad practice but the site will not work without seemingly significant changes to the way Vue is managed.

Still this is likely better than not having CSP at all. See https://security.stackexchange.com/a/232329 for why. This should be looked into further but is likely a bigger ticket.

**Steps to manually verify this change...**

1. Using your browser of choice's developer tools, inspect page headers to ensure CSP policy is in place.
2. Verify Cypress tests pass (pages load properly)
3. Visit pages in eRegs and ensure no CSP errors are in the console log.
