### PR TITLE
add env variable for base_url paths so we do not hard code them anymore

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -21,6 +21,7 @@ provider:
     DJANGO_ADMIN_PASSWORD: ${ssm:/eregulations/http/password}
     ALLOWED_HOST: '.amazonaws.com'
     STATIC_URL: ${self:custom.settings.static_url}
+    BASE_URL: ${ssm:/eregulations/base_url}
   vpc:
     securityGroupIds:
       - !Ref ServerlessSecurityGroup


### PR DESCRIPTION
Resolves #
Access to production base url with out /prod that was causing issues with cypress tests. 

**Description-**
To allow the code to know the base_url with out it being hardcoded, we add it to AWS param store. 
**This pull request changes...**

- expected change 1


