### PR TITLE
EREGCSC-1520-B Add Federal Register images to CSP policy

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -228,6 +228,10 @@ CSP_FONT_SRC = [
     STATIC_URL,
     "https://cdn.jsdelivr.net/npm/@mdi/font@4.x/",
 ]
+CSP_MANIFEST_SRC = [
+    "'self'",
+    STATIC_URL,
+]
 CSP_SCRIPT_SRC = [
     "'self'",
     "'unsafe-inline'",

--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -212,7 +212,11 @@ SPECTACULAR_SETTINGS = {
 LOGIN_URL = "/admin"
 
 # Settings for CSP headers
-CSP_IMG_SRC = ["'self'", STATIC_URL]
+CSP_IMG_SRC = [
+    "'self'",
+    STATIC_URL,
+    "https://images.federalregister.gov/",
+]
 CSP_STYLE_SRC = [
     "'self'",
     "'unsafe-inline'",


### PR DESCRIPTION
Follow-up to #1520

**Description-**

`https://images.federalregister.gov/*` was not in the CSP, so images loaded directly from that site were blocked.

**This pull request changes...**

- Add the above URL to the CSP

**Steps to manually verify this change...**

1. Visit `/42/433/Subpart-A/2021-03-01/#433-10-c-8` on the experimental deploy and verify the image within the reg text loads

