### PR TITLE
Fix text of eCFR link on About page

### DIFF
--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -237,7 +237,7 @@
                         class="external"
                         target="_blank"
                         rel="noopener noreferrer"
-                        >Federal Register regulation text</a
+                        >eCFR regulation text</a
                     >
                 </li>
                 <li>


### PR DESCRIPTION
This is @brittag on an old test account being curious about #1581 - seeing what happens if an external contributor creates a PR.

**Description-**

**This pull request changes...**

Update a minor typo on the "about" page that I noticed recently.