### PR TITLE
EREGCSC-1569 Resources page missing FR-docs

### DIFF
--- a/solution/backend/resources/v3views/mixins.py
+++ b/solution/backend/resources/v3views/mixins.py
@@ -195,7 +195,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
             id_query = id_query.filter(category__id__in=categories)
 
         if not search_query:
-            id_query = id_query.order_by("group_annotated").distinct("group_annotated")
+            id_query = id_query.order_by("group_annotated")
 
         annotations = {}
         ids = [i[0] for i in id_query.values_list("id", "group_annotated")]


### PR DESCRIPTION
Resolves #EREGCSC-1569

**Description-**

Federal register documents were sometimes missing on the front page sidebar and in the search results.  This bug adesss that.

What is happening is on the search results a distinct based on "group_annotated" was grouping stuff up and  eliminating things it thought were duplictates.  Removing the distinct fixes that.  This was only an issue if the resources endpoint did not have a search query.

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

Go to the admin panel and get the total amount of supplemental content, and fr-docs for title 42 that was approved.

Go to the resources page

The total of those two should equal the amount of resources returned. 

Filter out for proposed and final rules.  Should equal the fr-doc total.
