### PR TITLE
EREGCSC-1520c -- GTM CSP nonces

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -212,7 +212,12 @@ SPECTACULAR_SETTINGS = {
 LOGIN_URL = "/admin"
 
 # Settings for CSP headers
-CSP_IMG_SRC = ["'self'", STATIC_URL]
+CSP_IMG_SRC = [
+    "'self'",
+    STATIC_URL,
+    "https://www.googletagmanager.com",
+    "https://www.google-analytics.com",
+]
 CSP_STYLE_SRC = [
     "'self'",
     "'unsafe-inline'",
@@ -231,6 +236,8 @@ CSP_SCRIPT_SRC = [
     STATIC_URL,
     "https://www.googletagmanager.com",
 ]
+CSP_INCLUDE_NONCE_IN = ["script-src"]
+
 
 if DEBUG:
     import os  # only if you haven't already imported this

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -9,8 +9,8 @@ CSS/Javascript etc., should inherit from this template.
 <html class="no-js" lang="en">
     <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ID }}"></script>
-    <script>
+    <script nonce="{{ request.csp_nonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ID }}"></script>
+    <script nonce="{{ request.csp_nonce }}">
         window["ga-disable-{{ GA_ID }}"] = {{ AUTOMATED_TEST | yesno:"true,false" }};
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Resolves EREGCSC-1520

**Description**

Follows django-csp documentation to add nonces to script tags for GTM scripts in base template.

See: https://django-csp.readthedocs.io/en/latest/nonce.html

**This pull request changes...**

- Adds nonce to script tags for GTM scripts in base template.

**Steps to manually verify this change**

1. Go to Experimental Deployment and View Source.
   - Paste this into a new tab: `view-source:https://lxs2ofoctb.execute-api.us-east-1.amazonaws.com/dev587` or
   - Press Option + CMD-U on Mac or
   - Right click and select "View Page Source"
3. Check GTM script tags for a nonce

> **Note**
> You can only see the nonce if you View Source for the page.  Nonces are stripped from the DOM inspector in Chrome/FF devtools by design: https://stackoverflow.com/questions/55670985/google-chrome-stripping-nonce-values-from-script-tags

