### PR TITLE
EREGCSC-1520d -- Better handle GTM CSP paths

### DIFF
--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -215,8 +215,8 @@ LOGIN_URL = "/admin"
 CSP_IMG_SRC = [
     "'self'",
     STATIC_URL,
-    "https://www.googletagmanager.com",
-    "https://www.google-analytics.com",
+    "https://*.googletagmanager.com",
+    "https://*.google-analytics.com",
     "https://images.federalregister.gov/",
 ]
 CSP_STYLE_SRC = [
@@ -239,7 +239,12 @@ CSP_SCRIPT_SRC = [
     "'unsafe-inline'",
     "'unsafe-eval'",
     STATIC_URL,
-    "https://www.googletagmanager.com",
+    "https://*.googletagmanager.com",
+]
+CSP_CONNECT_SRC = [
+    "https://*.googletagmanager.com",
+    "https://*.google-analytics.com",
+    "http://*.analytics.google.com",
 ]
 CSP_INCLUDE_NONCE_IN = ["script-src"]
 


### PR DESCRIPTION
Resolves EREGCSC-1520

**Description**

Follows recommendations from official Google link below:

https://developers.google.com/tag-platform/tag-manager/web/csp#google_analytics_4_google_analytics


