### PR TITLE
EREGCSC-1578 Re-running FR parser: Endpoints

### DIFF
--- a/solution/backend/regcore/admin.py
+++ b/solution/backend/regcore/admin.py
@@ -39,12 +39,6 @@ class ParserConfigurationAdmin(SingletonModelAdmin):
         }),
     )
 
-    # TODO: Remove this method when FR parser work is complete (EREGCSC-1390)
-    def get_form(self, request, obj=None, **kwargs):
-        form = super().get_form(request, obj, **kwargs)
-        form.base_fields["skip_fr_documents"].disabled = True
-        return form
-
 
 @admin.register(Synonym)
 class SynonymAdmin(BaseAdmin):

--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -268,9 +268,8 @@ class LocationHistoryWidget(Textarea):
     def locations_to_strings(self, locations):
         strings = []
         for i in locations:
-            key = ([x for x in i.keys() if "_id" in x] or [None])[0]
-            if key:
-                strings.append(f"{i['title']} CFR {i['part']}.{i[key]}")
+            key = f"{i['type']}_id"
+            strings.append(f"{i['title']} CFR {i['part']}.{i[key]}")
         if not strings:
             return None
         if len(strings) == 1:

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -196,8 +196,8 @@ class FederalRegisterDocumentCreateSerializer(serializers.Serializer):
                 all_removals.remove(i) if i in all_removals else all_additions.append(i)
             for i in removals:
                 all_additions.remove(i) if i in all_additions else all_removals.append(i)
-        [instance.locations.remove(i) for i in self.get_location_objects(all_removals)]
-        [instance.locations.add(i) for i in self.get_location_objects(all_additions)]
+        instance.locations.remove(*self.get_location_objects(all_removals))
+        instance.locations.add(*self.get_location_objects(all_additions))
 
     def set_locations(self, instance, raw_sections, raw_ranges):
         locations = []

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -196,12 +196,8 @@ class FederalRegisterDocumentCreateSerializer(serializers.Serializer):
                 all_removals.remove(i) if i in all_removals else all_additions.append(i)
             for i in removals:
                 all_additions.remove(i) if i in all_additions else all_removals.append(i)
-        all_additions = self.get_location_objects(all_additions)
-        all_removals = self.get_location_objects(all_removals)
-        for i in all_removals:
-            instance.locations.remove(i)
-        for i in all_additions:
-            instance.locations.add(i)
+        [instance.locations.remove(i) for i in self.get_location_objects(all_removals)]
+        [instance.locations.add(i) for i in self.get_location_objects(all_additions)]
 
     def set_locations(self, instance, raw_sections, raw_ranges):
         locations = []

--- a/solution/backend/resources/v3serializers/resources.py
+++ b/solution/backend/resources/v3serializers/resources.py
@@ -171,7 +171,7 @@ class FederalRegisterDocumentCreateSerializer(serializers.Serializer):
         # save and return
         instance.save()
         return instance
-        
+
     def get_location_objects(self, locations):
         queries = []
         for i in locations:

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -93,7 +93,7 @@ class FederalRegisterDocsViewSet(ResourceExplorerViewSetMixin, viewsets.ModelVie
         data = request.data
         frdoc, created = FederalRegisterDocument.objects.get_or_create(document_number=data["document_number"])
         data["id"] = frdoc.pk
-        sc = self.get_serializer(frdoc, data=data)
+        sc = self.get_serializer(frdoc, data=data, context={**self.get_serializer_context(), **{"created": created}})
         try:
             if sc.is_valid(raise_exception=True):
                 sc.save()


### PR DESCRIPTION
Resolves #1578

**Description-**

FR doc post endpoint needs to be updated to not overwrite any data exception locations, and apply the changelog after locations are updated (ideally done in one step, because this is an atomic endpoint).

**This pull request changes...**

- FR doc post endpoint parses and applies the changelog if a doc is updated
- Everything else about an FR doc is maintained if it already exists (`create` variable passed through to serializer context)
- `update` method of FR doc create serializer is simplified (sections of code moved to class methods)
- Semi-related: improved location key retrieval method on admin panel changelog representation

**Steps to manually verify this change...**

_Testing is best done locally so that you can re-run the FR parser immediately, or mock the request using e.g. Postman._

1. Run the FR parser or mock the request to create a fake FR doc.
2. Visit the FR doc on the admin panel and add/remove several locations through multiple save operations. Rerun the parser and verify locations are as expected.
3. Try adding a location that has been removed in a previous save. Rerun the parser and verify locations are expected.
4. Bulk add one or more locations and rerun the parser.
5. If using Postman, add a section manually to the data and verify that it shows as expected.

