### PR TITLE
Tech Debt: Update print API test to be less flaky

### DIFF
--- a/solution/ui/e2e/cypress/integration/print.spec.js
+++ b/solution/ui/e2e/cypress/integration/print.spec.js
@@ -7,6 +7,7 @@ describe("Print Styles", () => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         }).as("headers");
+        cy.intercept("**/v3/ecfr_parser_result/**").as("parserResult");
 
         cy.setCssMedia("screen");
     });
@@ -23,11 +24,9 @@ describe("Print Styles", () => {
     });
 
     it("has proper print styles for latest version", () => {
-        cy.intercept(
-            "**/v3/ecfr_parser_result/**"
-        ).as("parserResult");
         cy.viewport("macbook-15");
         cy.visit(destination);
+        cy.wait("@parserResult");
 
         cy.get(".right-sidebar").should("be.visible");
         cy.get(".view-resources-link").should(($link) => {
@@ -53,7 +52,6 @@ describe("Print Styles", () => {
         cy.get("header").should("have.css", "border-top-color", "rgb(2, 102, 102)");
         cy.get("header").should("have.css", "border-bottom-color", "rgb(2, 102, 102)");
 
-        cy.wait("@parserResult");
         cy.get(".last-updated-date-print")
             .invoke('text')
             .should("match", /^\w{3} (\d{1}|\d{2}), \d{4}$/);


### PR DESCRIPTION
**Description**
An intercept and assertion was added to the print test suite to test the format of the date in the footer. 

The problem: it is very flaky and unreliable.

**This pull request changes:**

- Moves intercept into `beforeEach` block as suggested in one of the many Github Issue comments about this issue

**Steps to manually verify this change**

1. Run print test suite a bunch of times and see if it is more reliable than before

