### PR TITLE
Flaky ECFR Parser Result test fix for homepage

### DIFF
--- a/solution/ui/e2e/cypress/integration/homepage.spec.js
+++ b/solution/ui/e2e/cypress/integration/homepage.spec.js
@@ -10,6 +10,9 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
             "**/v3/resources/federal_register_docs?page=1&page_size=3&paginate=true",
             { fixture: "frdocs.json" }
         ).as("frdocs");
+        cy.intercept(
+            "**/v3/ecfr_parser_result/**"
+        ).as("parserResult");
     });
 
     it("loads the homepage", () => {
@@ -253,9 +256,6 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
     })
 
     it("loads the last parser success date from the API endpoint and displays it in footer", () => {
-        cy.intercept(
-            "**/v3/ecfr_parser_result/**"
-        ).as("parserResult");
         cy.viewport("macbook-15");
         cy.visit("/");
         cy.wait("@parserResult");


### PR DESCRIPTION
**Description**
ECFR parser result test is flaky on the homepage.

**This pull request changes**

- Moves intercept for ECFR parser result endpoint into `beforeEach` block in the homepage test suite to mirror the successful strategy used to fix flaky tests in the print test suite.

**Steps to manually verify this change**

1. Redeploy this a bunch to see if it's flaky or not.

