### PR TITLE
EREGCSC-1609 -- Increase Search Field bottom space

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -55,6 +55,7 @@
             margin: $spacer-6 0 $spacer-2;
         }
     }
+
     .search-suggestion{
         margin: 0px;
         font-size: $font-size-sm;
@@ -161,12 +162,15 @@
 
 // Search Text Box
 
+main .search-box {
+    margin-bottom: 16px;
+}
+
 .search-header,
 .search-box {
     width: 100%;
     position: relative;
     display: flex;
-    margin-bottom: 16px;
 
     input {
         width: 100%;

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -166,6 +166,7 @@
     width: 100%;
     position: relative;
     display: flex;
+    margin-bottom: 16px;
 
     input {
         width: 100%;

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -834,8 +834,8 @@ export default {
             }
         }
         .search-suggestion{
-            margin-top: -50px;
-            margin-bottom: 50px;
+            margin-top: -34px;
+            margin-bottom: 34px;
             font-size: 14px;
         }
     }


### PR DESCRIPTION
Resolves [EREGCSC-1609](https://jiraent.cms.gov/browse/EREGCSC-1609)

**Description**

On the Search page, the space between the search box and the helper text is too small/non-existant.  There should be more space below the search box to add separation between the search box and the helper text.

**This pull request changes:**

- Adds 16px margin below `.search-box`
   - 16px matches the space above the search box
   - Since margins collapse, this will not affect the spacing between the search box and the results count if there is no helper text

**Steps to manually verify this change**

1. Visit the experimental deployment and make three searches:
   - medicaid management information system
   - nursing home
   - "medicaid management information system"
2. Ensure the search box has 16px bottom margin
3. Compare how each search looks to the screenshots attached to the JIRA story

