### PR TITLE
EREGCSC-1596 -- Scroll to first highlighted term

### DIFF
--- a/solution/ui/regulations/js/main.js
+++ b/solution/ui/regulations/js/main.js
@@ -57,22 +57,20 @@ function onPageShow() {
             : 0;
 
         const headerHeight =
-            window.innerWidth >= 1024
-                ? HEADER_HEIGHT
-                : HEADER_HEIGHT_MOBILE;
+            window.innerWidth >= 1024 ? HEADER_HEIGHT : HEADER_HEIGHT_MOBILE;
 
-        const heights = { headerHeight, versionSelectHeight };
+        const offsetPx = headerHeight - versionSelectHeight;
 
         if (isHighlighted) {
             const highlightedEls = document.getElementsByClassName("highlight");
             const highlightedEl = highlightedEls[0];
             if (highlightedEl) {
-                scrollToElement(highlightedEl, heights)
+                scrollToElement(highlightedEl, offsetPx);
             }
         } else if (hasHash) {
             const el = document.getElementById(elId.substr(1));
             if (el) {
-                scrollToElement(el, heights)
+                scrollToElement(el, offsetPx);
             }
         }
     }

--- a/solution/ui/regulations/js/main.js
+++ b/solution/ui/regulations/js/main.js
@@ -14,7 +14,7 @@ import LastParserSuccessDate from "../dist/LastParserSuccessDate";
 // #### HYGEN IMPORT INSERTION POINT DO NOT REMOVE ####
 
 import { goToVersion } from "./go-to-version";
-import { highlightText, getQueryParam, scrollToElement} from "./utils";
+import { highlightText, getQueryParam, scrollToElement } from "./utils";
 
 Vue.config.devtools = true;
 

--- a/solution/ui/regulations/js/main.js
+++ b/solution/ui/regulations/js/main.js
@@ -14,7 +14,7 @@ import LastParserSuccessDate from "../dist/LastParserSuccessDate";
 // #### HYGEN IMPORT INSERTION POINT DO NOT REMOVE ####
 
 import { goToVersion } from "./go-to-version";
-import { highlightText } from "./utils";
+import { highlightText, getQueryParam, scrollToElement} from "./utils";
 
 Vue.config.devtools = true;
 
@@ -42,29 +42,38 @@ function onPageShow() {
     const HEADER_HEIGHT = 102;
     const HEADER_HEIGHT_MOBILE = 81;
 
-    // if version select is open, get its height
-    // and adjust scrollTo position
-    const versionSelectBar = document.getElementsByClassName(
-        "view-and-compare"
-    );
-    const versionSelectHeight = versionSelectBar.length
-        ? versionSelectBar[0].offsetHeight
-        : 0;
-
     const elId = window.location.hash;
+    const hasHash = elId.length > 1;
+    const isHighlighted = Boolean(getQueryParam(window.location, "highlight"));
 
-    if (elId.length > 1) {
-        const el = document.getElementById(elId.substr(1));
-        if (el) {
-            const position = el.getBoundingClientRect();
-            const headerHeight =
-                window.innerWidth >= 1024
-                    ? HEADER_HEIGHT
-                    : HEADER_HEIGHT_MOBILE;
-            window.scrollTo(
-                position.x,
-                el.offsetTop - headerHeight - versionSelectHeight
-            );
+    if (hasHash || isHighlighted) {
+        // if version select is open, get its height
+        // and adjust scrollTo position
+        const versionSelectBar = document.getElementsByClassName(
+            "view-and-compare"
+        );
+        const versionSelectHeight = versionSelectBar.length
+            ? versionSelectBar[0].offsetHeight
+            : 0;
+
+        const headerHeight =
+            window.innerWidth >= 1024
+                ? HEADER_HEIGHT
+                : HEADER_HEIGHT_MOBILE;
+
+        const heights = { headerHeight, versionSelectHeight };
+
+        if (isHighlighted) {
+            const highlightedEls = document.getElementsByClassName("highlight");
+            const highlightedEl = highlightedEls[0];
+            if (highlightedEl) {
+                scrollToElement(highlightedEl, heights)
+            }
+        } else if (hasHash) {
+            const el = document.getElementById(elId.substr(1));
+            if (el) {
+                scrollToElement(el, heights)
+            }
         }
     }
 }

--- a/solution/ui/regulations/js/utils.js
+++ b/solution/ui/regulations/js/utils.js
@@ -205,6 +205,24 @@ const highlightText = (location, paramKey) => {
 };
 
 /**
+ * Scroll to top of HTML element while taking
+ * heights of other elements into consideration
+ *
+ * @param {HTMLElement} element - scroll to this element
+ * @param {Object} heights - additional heights to consider
+ * @param {number} heights.headerHeight - height of header
+ * @param {number} heights.versionSelectHeight - height of Version Select control
+ */
+const scrollToElement = (element, heights) => {
+    const position = element.getBoundingClientRect();
+    const { headerHeight, versionSelectHeight } = heights;
+    window.scrollTo(
+        position.x,
+        element.offsetTop - headerHeight - versionSelectHeight
+    );
+};
+
+/**
  * Converts date from YYYY-MM-DD to MMM DD, YYYY
  *
  * @param {string} kebabDate - date in `YYYY-MM-DD` format
@@ -231,4 +249,5 @@ export {
     getQueryParam,
     niceDate,
     parseError,
+    scrollToElement,
 };

--- a/solution/ui/regulations/js/utils.js
+++ b/solution/ui/regulations/js/utils.js
@@ -209,16 +209,13 @@ const highlightText = (location, paramKey) => {
  * heights of other elements into consideration
  *
  * @param {HTMLElement} element - scroll to this element
- * @param {Object} heights - additional heights to consider
- * @param {number} heights.headerHeight - height of header
- * @param {number} heights.versionSelectHeight - height of Version Select control
+ * @param {number} [offsetPx=0] - pixels to offset scroll from top of screen
  */
-const scrollToElement = (element, heights) => {
+const scrollToElement = (element, offsetPx = 0) => {
     const position = element.getBoundingClientRect();
-    const { headerHeight, versionSelectHeight } = heights;
     window.scrollTo(
         position.x,
-        element.offsetTop - headerHeight - versionSelectHeight
+        element.offsetTop - offsetPx
     );
 };
 

--- a/solution/ui/regulations/js/utils.js
+++ b/solution/ui/regulations/js/utils.js
@@ -213,10 +213,7 @@ const highlightText = (location, paramKey) => {
  */
 const scrollToElement = (element, offsetPx = 0) => {
     const position = element.getBoundingClientRect();
-    window.scrollTo(
-        position.x,
-        element.offsetTop - offsetPx
-    );
+    window.scrollTo(position.x, element.offsetTop - offsetPx);
 };
 
 /**


### PR DESCRIPTION
Resolves [EREGCSC-1596](https://jiraent.cms.gov/browse/EREGCSC-1596)

**Description**

When executing a search, scroll down to the first instance of the  highlighted term when clicking through to the regulations text.

**This pull request changes:**

- adds `scrollToElement` utility function for scrolling to specific elements
- refactors logic to scroll to selected section
- scrolls to first highlighted term if exists.  If no highlighted terms, scrolls to section.  If no section hash in URL, doesn't scroll.

**Steps to manually verify this change:**

1. Visit a URL that has a highlighted term that doesn't appear until deep into section to ensure site scrolls to first highlighted term
   - Ex: https://c0hdgvpw35.execute-api.us-east-1.amazonaws.com/dev615/42/433/Subpart-B/2021-03-01/?highlight=test#433-68
2. Visit same section without any `highlight` query params to ensure site scrolls to top of section
   - Ex: https://c0hdgvpw35.execute-api.us-east-1.amazonaws.com/dev615/42/433/Subpart-B/2021-03-01/#433-68
3. Ensure normal section scrolling is unaffected by visiting random sections from sidebar and homepage ToC

