### PR TITLE
EREGCSC-1642 -- Improve resources page handling of slash characters

### DIFF
--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import path, re_path, include
 
 from regcore.views import (
     EffectivePartView,
@@ -89,6 +89,9 @@ urlpatterns = [
             "put": "update",
         })),
         path("synonym/<synonym>", synonyms.SynonymViewSet.as_view({
+            "get": "list",
+        })),
+        re_path(r"synonym/(?P<synonym>\w+)", synonyms.SynonymViewSet.as_view({
             "get": "list",
         })),
         path("parser_config", parser.ParserConfigurationViewSet.as_view({


### PR DESCRIPTION
Resolves [EREGCSC-1642](https://jiraent.cms.gov/browse/EREGCSC-1642)

**Description**

When you enter a slash or backslash in the resources page search box, you get a Javascript error.

**This pull request changes:**

- TBD

**Steps to manually verify this change:**

1. TBD

