### PR TITLE
Hotfix: remove flaky API tests

### DIFF
--- a/solution/ui/e2e/cypress/integration/homepage.spec.js
+++ b/solution/ui/e2e/cypress/integration/homepage.spec.js
@@ -251,16 +251,4 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
                });
         });
     })
-
-    it("loads the last parser success date from the API endpoint and displays it in footer", () => {
-        cy.intercept(
-            "**/v3/ecfr_parser_result/**"
-        ).as("parserResult");
-        cy.viewport("macbook-15");
-        cy.visit("/");
-        cy.wait("@parserResult");
-        cy.get(".last-updated-date")
-            .invoke('text')
-            .should("match", /^\w{3} (\d{1}|\d{2}), \d{4}$/)
-    });
 });

--- a/solution/ui/e2e/cypress/integration/print.spec.js
+++ b/solution/ui/e2e/cypress/integration/print.spec.js
@@ -7,7 +7,6 @@ describe("Print Styles", () => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         }).as("headers");
-        cy.intercept("**/v3/ecfr_parser_result/**").as("parserResult");
 
         cy.setCssMedia("screen");
     });
@@ -26,7 +25,6 @@ describe("Print Styles", () => {
     it("has proper print styles for latest version", () => {
         cy.viewport("macbook-15");
         cy.visit(destination);
-        cy.wait("@parserResult");
 
         cy.get(".right-sidebar").should("be.visible");
         cy.get(".view-resources-link").should(($link) => {
@@ -51,10 +49,6 @@ describe("Print Styles", () => {
         cy.get("header").should("have.css", "height", "48px");
         cy.get("header").should("have.css", "border-top-color", "rgb(2, 102, 102)");
         cy.get("header").should("have.css", "border-bottom-color", "rgb(2, 102, 102)");
-
-        cy.get(".last-updated-date-print")
-            .invoke('text')
-            .should("match", /^\w{3} (\d{1}|\d{2}), \d{4}$/);
     })
 
     it("has proper print styles for a previous version", () => {


### PR DESCRIPTION
**Description:**

Cypress tests were added to test the response from actual API within the app.  These tests were added in response to an incident that broke production: a change to our Content Security Policy blocked all API calls by response.  The after action report illuminated a lack of integration test coverage: we did not have any integration tests that tested actual API responses in the app -- all API responses were being mocked with Cypress fixtures.

Unfortunately, these new tests are very flaky and are causing delays and frustration when attempting to deploy to all environments.  As a result, they are being removed for now.

**This pull request changes...**

- Removes all tests and assertions related to the `parser_last_updated` API endpoint.

**Steps to manually verify this change:**

1. Ensure all tests pass

