### PR TITLE
Hotfix -- add two retries to failing Cypress tests

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -16,7 +16,7 @@ jobs:
     environment:
       name: "dev"
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the code
       - name: Checkout
@@ -79,7 +79,7 @@ jobs:
       name: "dev"
     outputs:
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: deploy-static
     steps:
       # Checkout the code
@@ -131,7 +131,7 @@ jobs:
   deploy-prototype:
     environment:
       name: "dev"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: deploy-django
     outputs:
       url: ${{ steps.deploy-prototype.outputs.url }}
@@ -201,7 +201,7 @@ jobs:
   build-and-deploy-vue:
     environment:
       name: "dev"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: deploy-django
     steps:
       # Checkout the code
@@ -259,7 +259,7 @@ jobs:
   deploy-go:
     environment:
       name: "dev"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: deploy-django
     steps:
       # Checkout the code
@@ -315,7 +315,7 @@ jobs:
   notify:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [deploy-go, deploy-django, deploy-prototype]
     steps:
       - name: Find PR number
@@ -343,7 +343,7 @@ jobs:
           reactions: '+1'
   test-cypress:
     needs: [deploy-go, deploy-django, build-and-deploy-vue]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy-prototype.yml
+++ b/.github/workflows/deploy-prototype.yml
@@ -14,7 +14,7 @@ jobs:
     environment:
       name: "dev"
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/load-regulations.yml
+++ b/.github/workflows/load-regulations.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
     environment:
       name: ${{ matrix.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/load-supp-content.yml
+++ b/.github/workflows/load-supp-content.yml
@@ -19,7 +19,7 @@ jobs:
   load:
     environment:
       name: ${{ github.event.inputs.env }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -14,7 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   parser-checks:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -13,7 +13,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -14,7 +14,7 @@ jobs:
   remove:
     environment:
       name: "dev"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # gettign PR is trivial here because the only tirgger is closing a PR
       - name: Echo PR#

--- a/.github/workflows/remove-prototype.yml
+++ b/.github/workflows/remove-prototype.yml
@@ -14,7 +14,7 @@ jobs:
   remove:
     environment:
       name: "dev"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # gettign PR is trivial here because the only tirgger is closing a PR
       - name: Echo PR#

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   remove:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/solution/ui/e2e/cypress.json
+++ b/solution/ui/e2e/cypress.json
@@ -1,6 +1,6 @@
 {
   "baseUrl" : "http://localhost:8000",
   "videoUploadOnPasses": false,
-  "defaultCommandTimeout": 8000,
+  "defaultCommandTimeout": 10000,
   "retries": 2
 }

--- a/solution/ui/e2e/cypress.json
+++ b/solution/ui/e2e/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl" : "http://localhost:8000",
   "videoUploadOnPasses": false,
-  "defaultCommandTimeout": 8000
+  "defaultCommandTimeout": 8000,
+  "retries": 2
 }

--- a/solution/ui/e2e/cypress/integration/homepage.spec.js
+++ b/solution/ui/e2e/cypress/integration/homepage.spec.js
@@ -16,7 +16,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.viewport("macbook-15");
         cy.visit("/");
         cy.injectAxe();
-        cy.contains("Medicaid & CHIP eRegulations");
+        cy.contains("Medicaid & CHIP2 eRegulations");
         cy.checkAccessibility();
     });
 

--- a/solution/ui/e2e/cypress/integration/homepage.spec.js
+++ b/solution/ui/e2e/cypress/integration/homepage.spec.js
@@ -16,7 +16,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.viewport("macbook-15");
         cy.visit("/");
         cy.injectAxe();
-        cy.contains("Medicaid & CHIP2 eRegulations");
+        cy.contains("Medicaid & CHIP eRegulations");
         cy.checkAccessibility();
     });
 


### PR DESCRIPTION
**Description**

Another strategy to help mitigate flaky tests: allow up to two additional retries for every test that fails.  This may help with tests that fail for unknown reasons.   Also bumps up a timeout value from eight seconds to ten seconds.

See documentation here: https://docs.cypress.io/guides/guides/test-retries

This PR also changes all references to `ubuntu-latest` in our Github Action workflow yml files to `ubuntu-20.04` to fix a deployment issue.  See this link for more information:

https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

**This pull request changes...**

- adds global `retries` config variable and sets it to `2`
- bumps `defaultCommandTimeout` from `8000` to `10000`
- changes `ubuntu-latest` to `ubuntu-20.04` in all `.github/workflows/*.yml` files

**Steps to manually verify this change:**

1. Explicitly break a test to make it fail
2. run `npm run cypress:open` and run broken test
3. In the Cypress GUI, watch to see if the broken test is retried

