### PR TITLE
Hotfix: re-enable flaky API tests in homepage test suite

### DIFF
--- a/solution/ui/e2e/cypress/integration/homepage.spec.js
+++ b/solution/ui/e2e/cypress/integration/homepage.spec.js
@@ -251,4 +251,14 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
                });
         });
     })
+
+    it("loads the last parser success date from the API endpoint and displays it in footer", () => {
+        cy.intercept("**/v3/ecfr_parser_result/**").as("parserResult");
+        cy.viewport("macbook-15");
+        cy.visit("/");
+        cy.wait("@parserResult");
+        cy.get(".last-updated-date")
+            .invoke("text")
+            .should("match", /^\w{3} (\d{1}|\d{2}), \d{4}$/);
+    });
 });

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -1,6 +1,6 @@
 const SEARCH_TERM = "telemedicine";
 
-describe.skip("Search flow", () => {
+describe("Search flow", () => {
     beforeEach(() => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");


### PR DESCRIPTION
**Description:**

Cypress tests were added to test the response from actual API within the app.  These tests were added in response to an incident that broke production: a change to our Content Security Policy blocked all API calls by response.  The after action report illuminated a lack of integration test coverage: we did not have any integration tests that tested actual API responses in the app -- all API responses were being mocked with Cypress fixtures.

[These tests were previously removed because they were flaky.](https://github.com/CMSgov/cmcs-eregulations/pull/618)

However, we've since added the ability for Cypress to retry flaky tests that fail.  It's likely that these retries will allow the test suite to consistently pass even if the tests themselves are still flaky -- they can simply be retried.

**This pull request changes...**

- Adds back assertions related to the `parser_last_updated` API endpoint to the homepage test suite

**Steps to manually verify this change:**

1. Ensure all tests pass