### PR TITLE
EREGCSC-1652 Going to appendix of 441 subpart F returns error

### DIFF
--- a/solution/ui/regulations/js/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContent.vue
@@ -215,7 +215,11 @@ export default {
             this.fetch_content(this.title, this.part, location)
         },
         parseHash(locationHash) {
-            if (window.location.hash === "#main-content" || locationHash.toLowerCase().includes("appendix")) return "";
+            if (window.location.hash === "#main-content") return "";
+            if (locationHash.toLowerCase().includes("appendix")) {
+                this.selectedPart = undefined;
+                return "";
+            }
 
             let section = locationHash.substring(1).replace("-", ".");
 

--- a/solution/ui/regulations/js/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/js/src/components/SupplementalContent.vue
@@ -215,7 +215,7 @@ export default {
             this.fetch_content(this.title, this.part, location)
         },
         parseHash(locationHash) {
-            if (window.location.hash === "#main-content") return "";
+            if (window.location.hash === "#main-content" || locationHash.toLowerCase().includes("appendix")) return "";
 
             let section = locationHash.substring(1).replace("-", ".");
 


### PR DESCRIPTION
Resolves #1652

**Description-**

Issue is that location hash for appendices is, e.g. `#Appendix-to-Subpart-F-of-Part-441`. When parsed into a location string, it is `42.Appendix.to` which is not valid. Since we are not currently linking resources to appendices, this PR just disables the right sidebar from requesting resources from an appendix.

**This pull request changes...**

- If location hash contains the word "appendix", the right sidebar defaults to resources for the entire part or subpart.

**Steps to manually verify this change...**

1. Visit `/42/441/Subpart-F/2021-11-05/#Appendix-to-Subpart-F-of-Part-441` on the experimental deploy and verify the right sidebar loads and displays "Subpart F Resources" instead of "Appendix.to resources".

