### PR TITLE
EREGCSC-1642  Error on search

### DIFF
--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -89,7 +89,7 @@ urlpatterns = [
         path("part", parser.PartUploadViewSet.as_view({
             "put": "update",
         })),
-        path("synonym/<synonym>", synonyms.SynonymViewSet.as_view({
+        path("synonym/<path:synonym>", synonyms.SynonymViewSet.as_view({
             "get": "list",
         })),
         path("parser_config", parser.ParserConfigurationViewSet.as_view({


### PR DESCRIPTION
Resolves #616 

**Description-**

So when you do a search it errors out not because of search but because of synonyms.  We pass in synonyms as a parameter and if it has a character like "/" it thinks that there is another paramater in django.  The solution is just to add <path: synonym> on the url.
**This pull request changes...**

- expected change 1

Searching wont error out anymore with a "/" in the search.

**Steps to manually verify this change...**

1. steps to view and verify change

Search for ICF/IID.  There should be no error on the Synonym endpoint.