### PR TITLE
[HOTFIX] Increase serverless function timeout from 6s to 10s

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -62,6 +62,7 @@ functions:
     events:
       - http: ANY /
       - http: ANY {proxy+}
+    timeout: 10
   reg_core_migrate:
     handler: migrate.handler
     layers:


### PR DESCRIPTION
Resolves deployment issue

**Description**

When deploying the two column search story, a new API endpoint created to find and return reg text results is behaving unreliably when deployed to the `dev` environment.  It appears that the request can take longer than six seconds, and when it does, it times out and returns an error.  If the request takes fewer than six seconds, it successfully returns the results.

Looking at the logs on AWS and searching around the web a bit, it appears that the serverless library that we are using in this project caps the timeout value at six seconds.  See this stackoverflow conversation for a very similar issue:

https://stackoverflow.com/questions/47594168/aws-lambda-task-timed-out-after-6-00-seconds

And see the serverless library documentation to read about the default timeout value and how to change it:

https://www.serverless.com/framework/docs/providers/aws/guide/functions/

**This pull request changes:**

- adds `timeout` property with value of `10` to `functions` property in `solution/backend/serverless.yml` as per the documentation linked above

**Steps to manually verify this change**

1. Make sure the experimental deployment works as expected. 
2. Merge hotfix to main and once it deploys to dev, make sure dev works properly and reg text requests are returned consistently

