### PR TITLE
EREGCSC-1665-public-access-parsers

### DIFF
--- a/solution/parser/serverless-ecfr.yml
+++ b/solution/parser/serverless-ecfr.yml
@@ -13,6 +13,8 @@ provider:
     EREGS_USERNAME: ${ssm:/eregulations/http/user}
     EREGS_PASSWORD: ${ssm:/eregulations/http/password}
     EREGS_API_URL_V3: ${self:custom.settings.eregs_url}
+  deploymentBucket:
+    blockPublicAccess: true
 
 custom:
   stage: ${opt:stage, self:provider.stage}

--- a/solution/parser/serverless-fr.yml
+++ b/solution/parser/serverless-fr.yml
@@ -13,6 +13,8 @@ provider:
     EREGS_USERNAME: ${ssm:/eregulations/http/user}
     EREGS_PASSWORD: ${ssm:/eregulations/http/password}
     EREGS_API_URL_V3: ${self:custom.settings.eregs_url}
+  deploymentBucket:
+    blockPublicAccess: true
 
 custom:
   stage: ${opt:stage, self:provider.stage}


### PR DESCRIPTION
Resolves #
- blocks public access to the fr and ecfr parsers

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**
1. Log into aws and check the fr and ecfr buckets, make sure that they are set to not being public. 
2. Visit experimental website and check everything looks like its working.
3. Make sure that the deployment went ok. 


