### PR TITLE
EREGCSC-1615 and EREGCSC-1657 -- Combined Search Pagination and Empty State updates

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -1,26 +1,40 @@
 <template>
     <div class="empty-state-container">
-        <div class="empty-state-container-title">
-            Expand your search:
-        </div>
+        <div class="empty-state-container-title">Expand your search:</div>
         <div class="options-list">
             <div class="query-prompt">
-                See results for <span class="query-emphasis">{{ query }}</span> on:
+                See results for
+                <span class="query-emphasis">{{ query }}</span> on:
             </div>
             <ul>
                 <li v-if="showInternalLink">
                     <a :href="eregsLink">{{ eregs_url_label }}</a>
-                    <span> ({{ eregs_sublabel }})</span>
                 </li>
                 <li>
-                    <a :href="ecfrLink" class="external" target="_blank">eCFR</a>
-                    <span> (other regulations)</span>
+                    <a :href="ecfrLink" class="external" target="_blank"
+                        >eCFR</a
+                    >
                 </li>
                 <li>
-                    <a :href="federalRegisterLink" class="external" target="_blank"
+                    <a
+                        :href="federalRegisterLink"
+                        class="external"
+                        target="_blank"
                         >Federal Register</a
                     >
-                    <span> (documents)</span>
+                </li>
+                <li>
+                    <a :href="medicaidGovLink" class="external" target="_blank"
+                        >Medicaid.gov</a
+                    >
+                </li>
+                <li>
+                    <a
+                        :href="unitedStatesCodeLink"
+                        class="external"
+                        target="_blank"
+                        >United States Code</a
+                    >
                 </li>
             </ul>
         </div>
@@ -83,6 +97,12 @@ export default {
         },
         federalRegisterLink() {
             return `https://www.federalregister.gov/documents/search?conditions[agencies][]=centers-for-medicare-medicaid-services&conditions[term]=${this.query}`;
+        },
+        medicaidGovLink() {
+            return `https://search.usa.gov/search?affiliate=medicaid&query=${this.query}&commit=Search`;
+        },
+        unitedStatesCodeLink() {
+            return `https://uscode.house.gov/search.xhtml?edition=prelim&searchString=%28${this.query}+%28title%3A42+chapter%3A7+subchapter%3A19%29+OR+%28title%3A42+chapter%3A7+subchapter%3A21%29+%29&pageNumber=1&itemsPerPage=100&sortField=RELEVANCE&displayType=CONTEXT&action=search&q=dGVzdCAodGl0bGU6NDIgY2hhcHRlcjo3IHN1YmNoYXB0ZXI6MTkpIE9SICh0aXRsZTo0MiBjaGFwdGVyOjcgc3ViY2hhcHRlcjoyMSkg%7C%3A%3A%3A%3A%3A%3A%3A%3Afalse%3A%7C%3A%3A%3A%3A%3A%3A%3A%3Afalse%3A%7Ctrue%7C%5B%3A%3A%3A%3A%3A%3A%3A%3Afalse%3A%5D%7C%5BQWxsIEZpZWxkcw%3D%3D%3A%3BQWxsIEZpZWxkcw%3D%3D%3A%5D`;
         },
     },
 };

--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -1,22 +1,29 @@
 <template>
     <div class="empty-state-container">
-        Expand your search:
-        <ul>
-            <li v-if="showInternalLink">
-                <a :href="eregsLink">{{ eregs_url_label }}</a>
-                <span> ({{ eregs_sublabel }})</span>
-            </li>
-            <li>
-                <a :href="ecfrLink" class="external" target="_blank">eCFR</a>
-                <span> (other regulations)</span>
-            </li>
-            <li>
-                <a :href="federalRegisterLink" class="external" target="_blank"
-                    >Federal Register</a
-                >
-                <span> (documents)</span>
-            </li>
-        </ul>
+        <div class="empty-state-container-title">
+            Expand your search:
+        </div>
+        <div class="options-list">
+            <div class="query-prompt">
+                See results for <span class="query-emphasis">{{ query }}</span> on:
+            </div>
+            <ul>
+                <li v-if="showInternalLink">
+                    <a :href="eregsLink">{{ eregs_url_label }}</a>
+                    <span> ({{ eregs_sublabel }})</span>
+                </li>
+                <li>
+                    <a :href="ecfrLink" class="external" target="_blank">eCFR</a>
+                    <span> (other regulations)</span>
+                </li>
+                <li>
+                    <a :href="federalRegisterLink" class="external" target="_blank"
+                        >Federal Register</a
+                    >
+                    <span> (documents)</span>
+                </li>
+            </ul>
+        </div>
     </div>
 </template>
 
@@ -81,4 +88,36 @@ export default {
 };
 </script>
 
-<style></style>
+<style lang="scss">
+.empty-state-container {
+    border: 2px solid $lightest_gray;
+
+    > * {
+        padding: 0 25px;
+    }
+
+    .empty-state-container-title {
+        display: flex;
+        align-items: center;
+        height: 41px;
+        font-size: $font-size-xs;
+        font-weight: bold;
+        text-transform: uppercase;
+        background-color: $lightest_gray;
+        margin-bottom: 10px;
+    }
+
+    .options-list {
+        font-size: $font-size-sm;
+        line-height: 18px;
+
+        .query-emphasis {
+            font-weight: bold;
+        }
+
+        ul {
+            margin: 10px 0 20px;
+        }
+    }
+}
+</style>

--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="empty-state-container">
-        <div class="empty-state-container-title">Expand your search:</div>
+        <div class="empty-state-container-title">Expand your search</div>
         <div class="options-list">
             <div class="query-prompt">
                 See results for

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResultsContainer.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResultsContainer.vue
@@ -87,6 +87,8 @@ import PaginationController from "@/components/pagination/PaginationController.v
 import ResourceExportBtn from "@/components/resources/ResourceExportBtn.vue";
 import ResourcesResults from "@/components/resources/ResourcesResults.vue";
 
+import { getCurrentPageResultsRange } from "@/utilities/utils";
+
 const SORT_METHODS = {
     newest: "Date (Newest)",
     oldest: "Date (Oldest)",
@@ -208,16 +210,11 @@ export default {
             }));
         },
         currentPageResultsRange() {
-            const maxInRange = this.page * this.pageSize;
-            const minInRange = maxInRange - this.pageSize;
-
-            const firstInRange = minInRange + 1;
-            const lastInRange =
-                maxInRange > this.count
-                    ? (this.count % this.pageSize) + minInRange
-                    : maxInRange;
-
-            return [firstInRange, lastInRange];
+            return getCurrentPageResultsRange({
+                count: this.count,
+                page: this.page,
+                pageSize: this.pageSize
+            });
         },
         regulationsSearchUrl() {
             return `${this.base}/search/`;

--- a/solution/ui/regulations/eregs-vite/src/utilities/api.js
+++ b/solution/ui/regulations/eregs-vite/src/utilities/api.js
@@ -749,8 +749,14 @@ const getSupplementalContent = async (
 /**
  *
  */
-const getRegSearchResults = async (q = "") => {
-    const response = await httpApiGetV3(`search?q=${q}`);
+const getRegSearchResults = async ({
+    q = "",
+    paginate = true,
+    page = 1,
+    page_size = 100,
+}) => {
+    const response = await httpApiGetV3(`search?q=${q}&paginate=${paginate}&page_size=${page_size}&page=${page}`);
+
     return response;
 };
 

--- a/solution/ui/regulations/eregs-vite/src/utilities/utils.js
+++ b/solution/ui/regulations/eregs-vite/src/utilities/utils.js
@@ -487,6 +487,25 @@ const getTagContent = (htmlString, tagClass) => {
     return uniqTermsArray.join(",");
 };
 
+/**
+ * @param count {number} - total number of results
+ * @param page {number} - current page number
+ * @param pageSize {number} - number of results per page
+ * @returns  {Array<number>} - an array containing two entries: firstInRange at index 0 and lastInRange at index 1
+ */
+const getCurrentPageResultsRange = ({ count, page = 1, pageSize }) => {
+    const maxInRange = page * pageSize;
+    const minInRange = maxInRange - pageSize;
+
+    const firstInRange = minInRange + 1;
+    const lastInRange =
+        maxInRange > count
+            ? (count % pageSize) + minInRange
+            : maxInRange;
+
+    return [firstInRange, lastInRange];
+};
+
 export {
     mapToArray,
     parseError,
@@ -521,4 +540,5 @@ export {
     createOneIndexedArray,
     stripQuotes,
     getTagContent,
+    getCurrentPageResultsRange,
 };

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -19,7 +19,16 @@
                     <div class="search-results-count">
                         <h2>Regulations</h2>
                         <span v-if="regsLoading">Loading...</span>
-                        <span v-else>{{ totalRegResultsCount }} results</span>
+                        <span v-else>
+                            <span v-if="totalRegResultsCount > 0">
+                                {{ currentPageRegResultsRange[0] }} -
+                                {{ currentPageRegResultsRange[1] }} of
+                            </span>
+                            {{ totalRegResultsCount }} result<span
+                                v-if="totalRegResultsCount != 1"
+                                >s</span
+                            >
+                        </span>
                     </div>
                     <template v-if="!regsLoading">
                         <RegResults :base="base" :results="regResults">
@@ -44,9 +53,16 @@
                     <div class="search-results-count">
                         <h2>Resources</h2>
                         <span v-if="resourcesLoading">Loading...</span>
-                        <span v-else
-                            >{{ totalResourcesResultsCount }} results</span
-                        >
+                        <span v-else>
+                            <span v-if="totalResourcesResultsCount > 0">
+                                {{ currentPageResourcesResultsRange[0] }} -
+                                {{ currentPageResourcesResultsRange[1] }} of
+                            </span>
+                            {{ totalResourcesResultsCount }} result<span
+                                v-if="totalResourcesResultsCount != 1"
+                                >s</span
+                            >
+                        </span>
                     </div>
                     <template v-if="!resourcesLoading">
                         <ResourcesResults
@@ -107,7 +123,7 @@
 import _isEmpty from "lodash/isEmpty";
 import _isUndefined from "lodash/isUndefined";
 
-import { stripQuotes } from "@/utilities/utils";
+import { getCurrentPageResultsRange, stripQuotes } from "@/utilities/utils";
 import {
     getFormattedPartsList,
     getLastUpdatedDates,
@@ -228,6 +244,20 @@ export default {
         },
         totalCount() {
             return this.totalRegResultsCount + this.totalResourcesResultsCount;
+        },
+        currentPageRegResultsRange() {
+            return getCurrentPageResultsRange({
+                count: this.totalRegResultsCount,
+                page: this.page,
+                pageSize: this.pageSize,
+            });
+        },
+        currentPageResourcesResultsRange() {
+            return getCurrentPageResultsRange({
+                count: this.totalResourcesResultsCount,
+                page: this.page,
+                pageSize: this.pageSize,
+            });
         },
     },
 

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -285,6 +285,7 @@ export default {
                     error
                 );
                 this.regResults = [];
+                this.totalRegResultsCount = 0;
             }
         },
         async retrieveResourcesResults({ query, page, pageSize }) {
@@ -299,11 +300,13 @@ export default {
                 this.resourcesResults = response?.results ?? [];
                 this.totalResourcesResultsCount = response?.count ?? 0;
             } catch (error) {
+                console.log("in the error");
                 console.error(
                     "Error retrieving regulation search results: ",
                     error
                 );
                 this.resourcesResults = [];
+                this.totalResourcesResultsCount = 0;
             }
         },
         async retrieveAllResults({ query, page, pageSize }) {

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -183,7 +183,7 @@ export default {
                 import.meta.env.VITE_ENV && import.meta.env.VITE_ENV !== "prod"
                     ? `/${import.meta.env.VITE_ENV}`
                     : "",
-            pageSize: 3,
+            pageSize: 50,
             regsLoading: true,
             resourcesLoading: true,
             partsLastUpdated: {},
@@ -300,7 +300,6 @@ export default {
                 this.resourcesResults = response?.results ?? [];
                 this.totalResourcesResultsCount = response?.count ?? 0;
             } catch (error) {
-                console.log("in the error");
                 console.error(
                     "Error retrieving regulation search results: ",
                     error

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -101,18 +101,19 @@
                         :page-size="pageSize"
                         view="search"
                     />
-                    <template
+                    <div
                         v-if="
                             (regResults.length > 0 &&
                                 resourcesResults.length > 0) ||
                             totalCount == 0
                         "
+                        class="pagination-expand-cta"
                     >
                         <SearchEmptyState
                             :query="searchQuery"
                             :show-internal-link="false"
                         />
-                    </template>
+                    </div>
                 </div>
             </div>
         </div>
@@ -425,7 +426,7 @@ export default {
 
     .combined-results-container {
         overflow: auto;
-        margin-bottom: 30px;
+        margin-bottom: 16px;
         padding: 0 45px;
         display: flex;
         justify-content: space-between;
@@ -503,6 +504,10 @@ export default {
             width: 100%;
             max-width: 521px;
             margin: 0 45px;
+
+            .pagination-expand-cta {
+                margin-top: 14px;
+            }
         }
     }
 }

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -79,6 +79,7 @@
             <div v-if="!isLoading" class="pagination-expand-row">
                 <div class="pagination-expand-container">
                     <PaginationController
+                        v-if="totalCount > 0"
                         :count="paginationCount"
                         :page="page"
                         :page-size="pageSize"
@@ -88,8 +89,7 @@
                         v-if="
                             (regResults.length > 0 &&
                                 resourcesResults.length > 0) ||
-                            (regResults.length == 0 &&
-                                resourcesResults.length == 0)
+                            totalCount == 0
                         "
                     >
                         <SearchEmptyState
@@ -221,7 +221,13 @@ export default {
             return this.regResults.length + this.resourcesResults.length;
         },
         paginationCount() {
-            return Math.max(this.totalRegResultsCount, this.totalResourcesResultsCount);
+            return Math.max(
+                this.totalRegResultsCount,
+                this.totalResourcesResultsCount
+            );
+        },
+        totalCount() {
+            return this.totalRegResultsCount + this.totalResourcesResultsCount;
         },
     },
 
@@ -326,6 +332,8 @@ export default {
         },
         clearSearchQuery() {
             this.synonyms = [];
+            this.totalRegResultsCount = 0;
+            this.totalResourcesResultsCount = 0;
             this.$router.push({
                 name: "search",
                 query: {
@@ -357,6 +365,9 @@ export default {
                     }
 
                     this.retrieveSynonyms(this.searchQuery);
+                }
+
+                if (queryChanged || pageChanged) {
                     this.retrieveAllResults({
                         query: this.searchQuery,
                         page: this.page,
@@ -457,6 +468,12 @@ export default {
         flex-direction: row;
         justify-content: center;
         margin-bottom: 100px;
+
+        .pagination-expand-container {
+            width: 100%;
+            max-width: 521px;
+            margin: 0 45px;
+        }
     }
 }
 </style>

--- a/solution/ui/regulations/js/main.js
+++ b/solution/ui/regulations/js/main.js
@@ -8,7 +8,6 @@ import CopyBtn from "../dist/CopyBtn";
 import PrintBtn from "../dist/PrintBtn";
 import TableComponent from "../dist/TableComponent";
 import ViewResourcesLink from "../dist/ViewResourcesLink";
-import SearchEmptyState from "../dist/SearchEmptyState";
 import RecentChangesContainer from "../dist/RecentChangesContainer";
 import LastParserSuccessDate from "../dist/LastParserSuccessDate";
 // #### HYGEN IMPORT INSERTION POINT DO NOT REMOVE ####
@@ -166,7 +165,6 @@ function main() {
             TableComponent,
             PrintBtn,
             ViewResourcesLink,
-            SearchEmptyState,
             RecentChangesContainer,
             LastParserSuccessDate,
             // #### HYGEN COMPONENT INSERTION POINT DO NOT REMOVE ####

--- a/solution/ui/regulations/rollup.config.js
+++ b/solution/ui/regulations/rollup.config.js
@@ -81,14 +81,6 @@ export default [
         plugins,
     },
     {
-        input: "eregs-vite/src/components/SearchEmptyState.vue",
-        output: {
-            format: "esm",
-            file: "dist/SearchEmptyState.js",
-        },
-        plugins,
-    },
-    {
         input: "js/src/components/RecentChangesContainer.vue",
         output: {
             format: "esm",


### PR DESCRIPTION
Resolves [EREGCSC-1615](https://jiraent.cms.gov/browse/EREGCSC-1615) and [EREGCSC-1657](https://jiraent.cms.gov/browse/EREGCSC-1657)

**Description**

Adds pagination to combined search page.  Updates Search Empty State/Explore More call to action with new styling and new links.

Figma comp [here](https://www.figma.com/file/iZFh6UhvGVEHw1D4IAt3Bw/eRegs-Combined-Search?node-id=3295%3A11315&t=gKSa5jdbnSNEPCRK-0)

**This pull request changes:**

- Restyles and refactors `SearchEmptyState` component used in Resources Search and Combined Search to match "Expand Your Search" box in Figma Comp (EREGCSC-1657)
- Adds `PaginationController` to combined search page and paginates results from Reg Search and Resources Search (EREGCSC-1615) to 50 results per page

> **Note**
> If the columns have an unequal number of pages of results -- that is, if the Regs column has one page of results and the Resources column has two pages of results -- then on page 2, the Regs column will show zero results, since it does not have a second page of results.  This behavior may be changed in the future to show the last available page of results with styles/messages to communicate this fact to the user.

**Steps to manually verify this change**

1. Visit the experimental deployment [here](https://yve5e6u1k0.execute-api.us-east-1.amazonaws.com/dev645)
2. Search for various search terms and test out combined search pagination, empty states, etc.

