### PR TITLE
Eregcsc-1675 Display custom message for serachwhen out of range

### DIFF
--- a/solution/backend/common/mixins.py
+++ b/solution/backend/common/mixins.py
@@ -1,5 +1,5 @@
 from rest_framework.pagination import PageNumberPagination
-
+from django.core.paginator import Paginator
 from .api import OpenApiQueryParameter
 
 
@@ -25,6 +25,22 @@ class OptionalPaginationMixin:
     ]
 
     paginate_by_default = True
+
+    def pagination_details(self, results, query):
+        page = self.request.GET.get('page', 1)
+        page_size = self.request.GET.get('page_size', 100)
+
+        paginator = Paginator(results, page_size)
+        last_page = int(paginator.num_pages)
+        valid_url = self.request.build_absolute_uri(f"/v3/search?page={last_page}&page_size={page_size}&q={query}")
+        valid = last_page >= int(page)
+        context = {
+            "valid": valid,
+            "count": int(paginator.count),
+            "detail": "Valid page." if valid else "Invalid page.",
+            "last_available_page": int(paginator.num_pages),
+            "last_page_url": valid_url}
+        return context
 
     @property
     def pagination_class(self):

--- a/solution/backend/resources/v3views/mixins.py
+++ b/solution/backend/resources/v3views/mixins.py
@@ -1,6 +1,7 @@
 from django.db.models import Q, F, Prefetch, OuterRef, Subquery
 from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchVector, SearchRank
 from django.core.exceptions import BadRequest
+from rest_framework.exceptions import ValidationError
 
 from common.api import OpenApiQueryParameter
 from resources.models import (
@@ -236,6 +237,9 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         )
 
         if search_query:
+            details = self.pagination_details(query, search_query)
+            if not details['valid']:
+                raise ValidationError(detail=details)
             (search_type, cover_density) = (
                 ("phrase", True)
                 if search_query.startswith('"') and search_query.endswith('"')


### PR DESCRIPTION
Resolves #EREGCSC-1675

**Description-**

When an api call for search of either resources or text is in an invalid page number it gives a generic error.  This gives a more verbose definition of the error.

**This pull request changes...**

- expected change 1

When an api call is made to either v3/resources or v3/search and pagination of results is happening, if a page number is out of range it will give an api response with details  of 
        context = {
            "valid": valid,
            "count": page count
            "detail": "Valid page." if valid else "Invalid page.",
            "last_available_page":  total pages
            "last_page_url": valid_url}

**Steps to manually verify this change...**

1. steps to view and verify change

use v3/search and v3/resources.  Select pages that are both valid and valid.  If valid normal response if inavlid will give the error json above