### PR TITLE
EREGCSC-1694 -- Trim header input placeholder text

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/header/search-input.html
+++ b/solution/backend/regulations/templates/regulations/partials/header/search-input.html
@@ -2,8 +2,8 @@
 
 <form class="{{ class }}" action="{% url 'search' %}">
 
-    <input type=search name="q" placeholder="Search Regulations"/>
-    <button type="submit" class="search-submit" aria-label="Search Regulations">
+    <input type=search name="q" placeholder="Search"/>
+    <button type="submit" class="search-submit" aria-label="Search">
         <i class="fa fa-search"></i>
     </button>
 </form>

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -12,6 +12,7 @@ describe("Search flow", () => {
         cy.visit("/");
         cy.get(".search-header > form > input")
             .should("be.visible")
+            .should("have.attr", "placeholder", "Search")
             .type(`${SEARCH_TERM}`);
         cy.get(".search-header > form").submit();
 


### PR DESCRIPTION
Resolves [EREGCSC-1694](https://jiraent.cms.gov/browse/EREGCSC-1694)

**Description**

The search input in the header searches more than just regulations, so the placeholder text and aria-label should be shortened to "Search" to remove the inaccurate emphasis on searching within regulations.

**This pull request changes:**

- changes input placeholder text and aria-label from "Search Regulations" to "Search"

**Steps to manually verify this change:**

1. Visit experimental deployment and ensure the header input placeholder text and aria-label say "Search" everywhere in the app

