### PR TITLE
[HOTFIX] remove wait in resources test

### DIFF
--- a/solution/ui/e2e/cypress/integration/resources.spec.js
+++ b/solution/ui/e2e/cypress/integration/resources.spec.js
@@ -21,7 +21,6 @@ describe("Resources page", () => {
             );
             cy.get("h1").contains("Resources");
             cy.get("h3").contains("Filter Resources");
-            cy.wait("@resources");
             cy.get(".results-count > span").should(
                 "contain.text",
                 "0 results in Resources"


### PR DESCRIPTION
Resolves issue where resources test suite fails consistently

**Description**

Removing a `wait` in the resources test suite because it causes extra flake

