### PR TITLE
Serverless proposal.  seperates creating db

### DIFF
--- a/solution/backend/create_db.yml
+++ b/solution/backend/create_db.yml
@@ -1,0 +1,102 @@
+resources:
+
+  Resources:
+    ServerlessSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+        GroupDescription: SecurityGroup for Serverless Functions
+        VpcId: ${ssm:/account_vars/vpc/id}
+        Tags:
+          - Key: "Name"
+            Value: "ServerlessSecurityGroup"
+
+    DBSecurityGroup:
+      Type: AWS::EC2::SecurityGroup
+      Properties:
+        GroupDescription: SecurityGroup for Database
+        VpcId: ${ssm:/account_vars/vpc/id}
+        Tags:
+          - Key: "Name"
+            Value: "DBSecurityGroup"
+
+    DBSecurityGroupIngress:
+      Type: AWS::EC2::SecurityGroupIngress
+      Properties:
+        GroupId: !Ref 'DBSecurityGroup'
+        IpProtocol: tcp
+        FromPort: !GetAtt [RDSResource, Endpoint.Port]
+        ToPort: !GetAtt [RDSResource, Endpoint.Port]
+        SourceSecurityGroupId: !Ref 'ServerlessSecurityGroup'
+
+    DBSubnetGroup:
+      Type: AWS::RDS::DBSubnetGroup
+      Properties:
+        DBSubnetGroupDescription: "RDS Subnet Group"
+        SubnetIds:
+          - ${ssm:/account_vars/vpc/subnets/private/a/id}
+          - ${ssm:/account_vars/vpc/subnets/private/b/id}
+        Tags:
+          - Key: "Name"
+            Value: "DBSubnetGroup"
+    # =============================================================================================
+    # Aurora DB
+    # =============================================================================================
+
+    AuroraRDSClusterParameter:
+      Type: AWS::RDS::DBClusterParameterGroup
+      Properties:
+        Description: Parameter group for the Serverless Aurora RDS DB.
+        Family: aurora-postgresql12
+        Parameters:
+          rds.force_ssl: 1
+
+    AuroraRDSInstanceParameter:
+      Type: AWS::RDS::DBParameterGroup
+      Properties:
+        Description: Parameter group for the Serverless Aurora RDS DB.
+        Family: aurora-postgresql12
+        Parameters:
+          shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
+          log_statement: "ddl"
+          log_connections: 1
+          log_disconnections: 1
+          log_lock_waits: 1
+          log_min_duration_statement: 5000
+          auto_explain.log_min_duration: 5000
+          auto_explain.log_verbose: 1
+          log_rotation_age: 1440
+          log_rotation_size: 102400
+          rds.log_retention_period: 10080
+          random_page_cost: 1
+          track_activity_query_size: 16384
+          idle_in_transaction_session_timeout: 7200000
+          statement_timeout: 7200000
+          search_path: '"$user",public'
+
+    RDSResource:
+      Type: AWS::RDS::DBCluster
+      Properties:
+        MasterUsername: ${self:custom.settings.USERNAME}
+        MasterUserPassword: ${ssm:/eregulations/db/password}
+        DBSubnetGroupName:
+          Ref: DBSubnetGroup
+        Engine: aurora-postgresql
+        EngineVersion: "12.8"
+        DatabaseName: ${self:custom.settings.DB_NAME}
+        BackupRetentionPeriod: 3
+        DBClusterParameterGroupName:
+          Ref: AuroraRDSClusterParameter
+        VpcSecurityGroupIds:
+          - !Ref 'DBSecurityGroup'
+
+    AuroraRDSInstance:
+      Type: AWS::RDS::DBInstance
+      Properties:
+        DBInstanceClass: db.r5.large
+        Engine: aurora-postgresql
+        EngineVersion: "12.8"
+        PubliclyAccessible: false
+        DBParameterGroupName:
+          Ref: AuroraRDSInstanceParameter
+        DBClusterIdentifier:
+          Ref: RDSResource

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -12,8 +12,8 @@ provider:
     DB_NAME: ${self:custom.settings.DB_NAME}
     DB_USER: ${self:custom.settings.USERNAME}
     DB_PASSWORD: ${ssm:/eregulations/db/password}
-    DB_HOST: !GetAtt [RDSResource, Endpoint.Address]
-    DB_PORT: !GetAtt [RDSResource, Endpoint.Port]
+    DB_HOST: ${ssm:/eregulations/db/host}
+    DB_PORT: ${ssm:/eregulations/db/port}
     GA_ID: ${ssm:/eregulations/http/google_analytics}
     HTTP_AUTH_USER: ${ssm:/eregulations/http/user}
     HTTP_AUTH_PASSWORD: ${ssm:/eregulations/http/password}
@@ -26,7 +26,7 @@ provider:
     SURVEY_URL: ${ssm:/eregulations/survey_url}
   vpc:
     securityGroupIds:
-      - !Ref ServerlessSecurityGroup
+      - ${ssm:/eregulations/aws/securitygroupid}
     subnetIds:
       - ${ssm:/account_vars/vpc/subnets/private/a/id}
       - ${ssm:/account_vars/vpc/subnets/private/b/id}
@@ -136,106 +136,6 @@ resources:
                        - ""
                        - - "arn:aws:s3:::"
                          - "Ref" : "ServerlessDeploymentBucket"
-
-    ServerlessSecurityGroup:
-      Type: AWS::EC2::SecurityGroup
-      Properties:
-        GroupDescription: SecurityGroup for Serverless Functions
-        VpcId: ${ssm:/account_vars/vpc/id}
-        Tags:
-          - Key: "Name"
-            Value: "ServerlessSecurityGroup"
-
-    DBSecurityGroup:
-      Type: AWS::EC2::SecurityGroup
-      Properties:
-        GroupDescription: SecurityGroup for Database
-        VpcId: ${ssm:/account_vars/vpc/id}
-        Tags:
-          - Key: "Name"
-            Value: "DBSecurityGroup"
-
-    DBSecurityGroupIngress:
-      Type: AWS::EC2::SecurityGroupIngress
-      Properties:
-        GroupId: !Ref 'DBSecurityGroup'
-        IpProtocol: tcp
-        FromPort: !GetAtt [RDSResource, Endpoint.Port]
-        ToPort: !GetAtt [RDSResource, Endpoint.Port]
-        SourceSecurityGroupId: !Ref 'ServerlessSecurityGroup'
-
-    DBSubnetGroup:
-      Type: AWS::RDS::DBSubnetGroup
-      Properties:
-        DBSubnetGroupDescription: "RDS Subnet Group"
-        SubnetIds:
-          - ${ssm:/account_vars/vpc/subnets/private/a/id}
-          - ${ssm:/account_vars/vpc/subnets/private/b/id}
-        Tags:
-          - Key: "Name"
-            Value: "DBSubnetGroup"
-    # =============================================================================================
-    # Aurora DB
-    # =============================================================================================
-
-    AuroraRDSClusterParameter:
-      Type: AWS::RDS::DBClusterParameterGroup
-      Properties:
-        Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql12
-        Parameters:
-          rds.force_ssl: 1
-
-    AuroraRDSInstanceParameter:
-      Type: AWS::RDS::DBParameterGroup
-      Properties:
-        Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql12
-        Parameters:
-          shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
-          log_statement: "ddl"
-          log_connections: 1
-          log_disconnections: 1
-          log_lock_waits: 1
-          log_min_duration_statement: 5000
-          auto_explain.log_min_duration: 5000
-          auto_explain.log_verbose: 1
-          log_rotation_age: 1440
-          log_rotation_size: 102400
-          rds.log_retention_period: 10080
-          random_page_cost: 1
-          track_activity_query_size: 16384
-          idle_in_transaction_session_timeout: 7200000
-          statement_timeout: 7200000
-          search_path: '"$user",public'
-
-    RDSResource:
-      Type: AWS::RDS::DBCluster
-      Properties:
-        MasterUsername: ${self:custom.settings.USERNAME}
-        MasterUserPassword: ${ssm:/eregulations/db/password}
-        DBSubnetGroupName:
-          Ref: DBSubnetGroup
-        Engine: aurora-postgresql
-        EngineVersion: "12.8"
-        DatabaseName: ${self:custom.settings.DB_NAME}
-        BackupRetentionPeriod: 3
-        DBClusterParameterGroupName:
-          Ref: AuroraRDSClusterParameter
-        VpcSecurityGroupIds:
-          - !Ref 'DBSecurityGroup'
-
-    AuroraRDSInstance:
-      Type: AWS::RDS::DBInstance
-      Properties:
-        DBInstanceClass: db.r5.large
-        Engine: aurora-postgresql
-        EngineVersion: "12.8"
-        PubliclyAccessible: false
-        DBParameterGroupName:
-          Ref: AuroraRDSInstanceParameter
-        DBClusterIdentifier:
-          Ref: RDSResource
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Resolves # A lot of things

**Description-**

So this is my proposal for the new serverless file.  Its actually pretty simple but should fix the issues we are seeing.

First thing and this is the most important thing, it is removing creating a database from the serverless file.  Currently if the serverless file is run, and it does if there are any changes(upgrading postgres or anything really) it will run the stuff on it.  The problem is when you run it you are creating a new database as well as connecting the new app to the new database at the same time.  The other issue with that is there are a  few things that end up being incompatible with it, like parameter groups, which cause the builds to fail.  To resolve this this is separated out from serverless into a new file and can just be run by modifying the deploy file, if we want to.

So the next thing that is updated is updating the environment variables for them to pull from aws appconfig instead of taking it from the yml.  The way it is currently set up is that the yml file will create a new resource, try and connect to the new resource, but the resources get all jumbled by the app because cloudwatch does not behave intelligently, crashing it.  So instead we are going to copy how the experimental deploy works and have it pull from app config.  For val and prod new environmental variables will need to be added for hostname, port and security groupid.    As a result of this the environment will be built without creating new things but using the existing db.

**This pull request changes...**

- expected change 1

Deployment to dev, val and prod will just use the existing db and security groups, not creating a new one.

Existing databases and instances will not be destroyed.

