### PR TITLE
update db instance to correct version r6

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -228,7 +228,7 @@ resources:
     AuroraRDSInstance:
       Type: AWS::RDS::DBInstance
       Properties:
-        DBInstanceClass: db.r5.large
+        DBInstanceClass: db.r6.large
         Engine: aurora-postgresql
         EngineVersion: "12.8"
         PubliclyAccessible: false

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -228,7 +228,7 @@ resources:
     AuroraRDSInstance:
       Type: AWS::RDS::DBInstance
       Properties:
-        DBInstanceClass: db.r6.large
+        DBInstanceClass: db.r6g.large
         Engine: aurora-postgresql
         EngineVersion: "12.8"
         PubliclyAccessible: false


### PR DESCRIPTION
Resolves # wrong db instance in yml file

**Description-**
yml file had the wrong db instance. We are on r6 now. 


**Steps to manually verify this change...**

1. Go to yml file check that the db instance is r6 not r5
2. Go to dev and val and see that the db instance is now r6 not r5

