### PR TITLE
EREGCSC-1699 Update "Expand Search" new url

### DIFF
--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -78,6 +78,12 @@ describe("Search flow", () => {
             });
         });
     });
+    it("should have a valid link to medicaid.gov", () => {
+        cy.viewport("macbook-15");
+        cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
+        cy.get("external-resource-links external-resource-links li a")
+        .should("have.attr", "href");
+    })
 
     it("checks a11y for search page", () => {
         cy.viewport("macbook-15");
@@ -118,4 +124,10 @@ describe("Search flow", () => {
 
         cy.findByRole("textbox").should("have.value", "");
     });
+
+    it("should have a valid link to medicaid.gov", () => {
+        cy.viewport("macbook-15");
+        cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
+        cy.get("external-resource-links external-resource-links li a")
+    })
 });

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -81,7 +81,7 @@ describe("Search flow", () => {
     it("should have a valid link to medicaid.gov", () => {
         cy.viewport("macbook-15");
         cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
-        cy.get("external-resource-links external-resource-links li a")
+        cy.get("external-resource-links li:nth-child(3) a")
         .should("have.attr", "href");
     })
 
@@ -125,9 +125,4 @@ describe("Search flow", () => {
         cy.findByRole("textbox").should("have.value", "");
     });
 
-    it("should have a valid link to medicaid.gov", () => {
-        cy.viewport("macbook-15");
-        cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
-        cy.get("external-resource-links external-resource-links li a")
-    })
 });

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -78,6 +78,7 @@ describe("Search flow", () => {
             });
         });
     });
+
     it("should have a valid link to medicaid.gov", () => {
         cy.viewport("macbook-15");
         cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -83,10 +83,8 @@ describe("Search flow", () => {
         cy.viewport("macbook-15");
         cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
         cy.get(".options-list li:nth-child(3) a")
-    cy.get(".options-list li:nth-child(3) a")
-        .should("have.attr", "href")
-        .and('include', "search-gsc");
-        .and('include', "search-gsc");
+            .should("have.attr", "href")
+            .and('include', "search-gsc");
     })
 
     it("checks a11y for search page", () => {

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -83,7 +83,9 @@ describe("Search flow", () => {
         cy.viewport("macbook-15");
         cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
         cy.get(".options-list li:nth-child(3) a")
+    cy.get(".options-list li:nth-child(3) a")
         .should("have.attr", "href")
+        .and('include', "search-gsc");
         .and('include', "search-gsc");
     })
 

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -51,10 +51,13 @@ describe("Search flow", () => {
             ".resources-results-content .search-results-count > span"
         ).should("be.visible");
         cy.get(
+            ".reg-results-content .reg-results-container .result:nth-child(1) .results-section"
+        )
+            .should("be.visible");    
+        cy.get(
             ".reg-results-content .reg-results-container .result:nth-child(1) .results-section a"
         )
-            .should("be.visible")
-            .and("have.attr", "href");
+            .should("have.attr", "href");
         cy.get(
             ".reg-results-content .reg-results-container .result:nth-child(1) .results-section a"
         ).click({ force: true });

--- a/solution/ui/e2e/cypress/integration/search.spec.js
+++ b/solution/ui/e2e/cypress/integration/search.spec.js
@@ -81,8 +81,9 @@ describe("Search flow", () => {
     it("should have a valid link to medicaid.gov", () => {
         cy.viewport("macbook-15");
         cy.visit(`/search/?q=${SEARCH_TERM}`, { timeout: 60000 });
-        cy.get("external-resource-links li:nth-child(3) a")
-        .should("have.attr", "href");
+        cy.get(".options-list li:nth-child(3) a")
+        .should("have.attr", "href")
+        .and('include', "search-gsc");
     })
 
     it("checks a11y for search page", () => {

--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -6,7 +6,7 @@
                 See results for
                 <span class="query-emphasis">{{ query }}</span> on:
             </div>
-            <ul>
+            <ul class="external-resource-links">
                 <li v-if="showInternalLink">
                     <a :href="eregsLink">{{ eregs_url_label }}</a>
                 </li>

--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -99,7 +99,7 @@ export default {
             return `https://www.federalregister.gov/documents/search?conditions[agencies][]=centers-for-medicare-medicaid-services&conditions[term]=${this.query}`;
         },
         medicaidGovLink() {
-            return `https://search.usa.gov/search?affiliate=medicaid&query=${this.query}&commit=Search`;
+            return `https://www.medicaid.gov/search-gsc?&gsc.sort=#gsc.tab=0&gsc.q=${this.query}&gsc.sort=`;
         },
         unitedStatesCodeLink() {
             return `https://uscode.house.gov/search.xhtml?edition=prelim&searchString=%28${this.query}+%28title%3A42+chapter%3A7+subchapter%3A19%29+OR+%28title%3A42+chapter%3A7+subchapter%3A21%29+%29&pageNumber=1&itemsPerPage=100&sortField=RELEVANCE&displayType=CONTEXT&action=search&q=dGVzdCAodGl0bGU6NDIgY2hhcHRlcjo3IHN1YmNoYXB0ZXI6MTkpIE9SICh0aXRsZTo0MiBjaGFwdGVyOjcgc3ViY2hhcHRlcjoyMSkg%7C%3A%3A%3A%3A%3A%3A%3A%3Afalse%3A%7C%3A%3A%3A%3A%3A%3A%3A%3Afalse%3A%7Ctrue%7C%5B%3A%3A%3A%3A%3A%3A%3A%3Afalse%3A%5D%7C%5BQWxsIEZpZWxkcw%3D%3D%3A%3BQWxsIEZpZWxkcw%3D%3D%3A%5D`;


### PR DESCRIPTION
Resolves #EREGCSC-1699

**Description-**
Updates the medicaid.gov url on both resources search page for blank results and combined search resutls.  Url format is 
https://www.medicaid.gov/search-gsc?&gsc.sort=#gsc.tab=0&gsc.q=${this.query}&gsc.sort=
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change
Go to combine search.  Search for something.  New url will use the new search URL
Go to resources.  Do a search and make it have 0 results.  New url should be there for medicaid search.