### PR TITLE
EREGCSC-1712 API endpoint for retrieving a list of valid years for GovInfo display

### DIFF
--- a/solution/backend/regcore/serializers/history.py
+++ b/solution/backend/regcore/serializers/history.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+
 class HistorySerializer(serializers.Serializer):
     year = serializers.CharField()
     link = serializers.CharField()

--- a/solution/backend/regcore/serializers/history.py
+++ b/solution/backend/regcore/serializers/history.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+class HistorySerializer(serializers.Serializer):
+    year = serializers.CharField()
+    link = serializers.CharField()

--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -113,3 +113,12 @@ class RegcoreSerializerTestCase(APITestCase):
         response = self.client.get("/v3/title/42/part/400/versions")
         data = response.data
         self.assertEqual(data, [date(2020, 6, 30)])
+
+    def test_get_historical_sections(self):
+        data = self.client.get("/v3/title/42/part/433/history/section/50").data
+        if not data:
+            raise AssertionError("no years present for known-good section")
+        if "year" not in data[0] or "link" not in data[0]:
+            raise AssertionError("missing one of 'year' or 'link' in response")
+        if data[0]["year"] != "1996":
+            raise AssertionError("known-good section doesn't contain 1996")

--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -10,23 +10,6 @@ from regcore.models import Part
 from regcore.search.models import Synonym
 
 
-async def get_year_data_400(section, year, client):
-    return httpx.Response(status_code=400)
-
-
-async def get_year_data_302(section, year, client):
-    return httpx.Response(
-        status_code=302,
-        headers={
-            "location": "http://a.govinfo.pdf.link/xyz.pdf",
-        }
-    )
-
-
-async def get_year_data_404(section, year, client):
-    return httpx.Response(status_code=404)
-
-
 class RegcoreSerializerTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -1,9 +1,30 @@
 from datetime import date
+from collections import OrderedDict
+from unittest.mock import patch
+
+import httpx
+from rest_framework import status
+from rest_framework.test import APITestCase
+
 from regcore.models import Part
 from regcore.search.models import Synonym
-from rest_framework import status
-from collections import OrderedDict
-from rest_framework.test import APITestCase
+
+
+async def get_year_data_400(section, year, client):
+    return httpx.Response(status_code=400)
+
+
+async def get_year_data_302(section, year, client):
+    return httpx.Response(
+        status_code=302,
+        headers={
+            "location": "http://a.govinfo.pdf.link/xyz.pdf",
+        }
+    )
+
+
+async def get_year_data_404(section, year, client):
+    return httpx.Response(status_code=404)
 
 
 class RegcoreSerializerTestCase(APITestCase):
@@ -114,11 +135,23 @@ class RegcoreSerializerTestCase(APITestCase):
         data = response.data
         self.assertEqual(data, [date(2020, 6, 30)])
 
-    def test_get_historical_sections(self):
+    @patch("regcore.v3views.history.get_year_data")
+    def test_get_historical_sections(self, get_year_data):
+        get_year_data.return_value = httpx.Response(status_code=400)
         data = self.client.get("/v3/title/42/part/433/history/section/50").data
-        if not data:
-            raise AssertionError("no years present for known-good section")
-        if "year" not in data[0] or "link" not in data[0]:
-            raise AssertionError("missing one of 'year' or 'link' in response")
-        if data[0]["year"] != "1996":
-            raise AssertionError("known-good section doesn't contain 1996")
+        self.assertEqual(data, [])
+
+        get_year_data.return_value = httpx.Response(
+            status_code=302,
+            headers={
+                "location": "http://a.link.to.govinfo.gov/xyz.pdf",
+            }
+        )
+        data = self.client.get("/v3/title/42/part/433/history/section/50").data
+        self.assertEqual(len(data), date.today().year - 1996 + 1)
+        self.assertEqual(data[0], OrderedDict([("year", "1996"), ("link", "http://a.link.to.govinfo.gov/xyz.pdf")]))
+
+        get_year_data.return_value = httpx.Response(status_code=404)
+        data = self.client.get("/v3/title/42/part/433/history/section/50").data
+        self.assertEqual(len(data), date.today().year - 1996 + 1)
+        self.assertEqual(data[0], OrderedDict([("year", "1996"), ("link", None)]))

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -19,6 +19,7 @@ from regcore.v3views import (
     metadata,
     synonyms,
     parser,
+    history,
 )
 
 
@@ -53,6 +54,9 @@ urlpatterns = [
             "get": "list",
         })),
         path("title/<title>/versions", title.VersionsViewSet.as_view({
+            "get": "list",
+        })),
+        path("title/<title>/part/<part>/history/section/<section>", history.SectionHistoryViewSet.as_view({
             "get": "list",
         })),
         path("title/<title>/part/<part>/versions", part.VersionsViewSet.as_view({

--- a/solution/backend/regcore/v3views/history.py
+++ b/solution/backend/regcore/v3views/history.py
@@ -32,16 +32,15 @@ async def check_year(section, year, client):
 
 
 async def get_years(title, part, section):
-    client = httpx.AsyncClient()
+    max_year = datetime.date.today().year + 1
     section_data = {
         "title": title,
         "part": part,
         "section": section,
     }
-    max_year = datetime.date.today().year + 1
-    years = await asyncio.gather(*[check_year(section_data, year, client) for year in range(GOVINFO_YEAR_MIN, max_year)])
-    await client.aclose()
-    return sorted([year for year in years if year is not None], key=lambda year: year["year"])
+    async with httpx.AsyncClient() as client:
+        years = await asyncio.gather(*[check_year(section_data, year, client) for year in range(GOVINFO_YEAR_MIN, max_year)])
+    return [year for year in years if year is not None]
 
 
 @extend_schema(

--- a/solution/backend/regcore/v3views/history.py
+++ b/solution/backend/regcore/v3views/history.py
@@ -7,14 +7,20 @@ from rest_framework.response import Response
 
 from regcore.serializers.history import HistorySerializer
 
-async def compute_object(section, year, client):
-    data = await client.head(f"https://www.govinfo.gov/link/cfr/{section['title']}/{section['part']}?sectionnum={section['section']}&year={year}&link-type=pdf")
+
+GOVINFO_YEAR_MIN = 1996
+GOVINFO_LINK = "https://www.govinfo.gov/link/cfr/{}/{}?sectionnum={}&year={}&link-type=pdf"
+
+
+async def check_year(section, year, client):
+    data = await client.head(GOVINFO_LINK.format(section["title"], section["part"], section["section"], year))
     if data.status_code != 302:
         return None
     return {
         "year": str(year),
         "link": data.headers["location"],
     }
+
 
 def year_generator(title, part, section):
     loop = asyncio.new_event_loop()
@@ -25,11 +31,13 @@ def year_generator(title, part, section):
         "part": part,
         "section": section,
     }
-    for future in asyncio.as_completed([compute_object(section_data, year, client) for year in range(1996, datetime.date.today().year + 1)]):
+    max_year = datetime.date.today().year + 1
+    for future in asyncio.as_completed([check_year(section_data, year, client) for year in range(GOVINFO_YEAR_MIN, max_year)]):
         yield loop.run_until_complete(future)
+
 
 class SectionHistoryViewSet(viewsets.ViewSet):
     def list(self, request, *args, **kwargs):
         title, part, section = [self.kwargs.get(i) for i in ["title", "part", "section"]]
-        years = sorted([year for year in year_generator(title, part, section) if year != None], key=lambda year: year["year"])
+        years = sorted([year for year in year_generator(title, part, section) if year is not None], key=lambda year: year["year"])
         return Response(HistorySerializer(instance=years, many=True).data)

--- a/solution/backend/regcore/v3views/history.py
+++ b/solution/backend/regcore/v3views/history.py
@@ -1,0 +1,16 @@
+import datetime
+
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from regcore.serializers.history import HistorySerializer
+
+class SectionHistoryViewSet(viewsets.ViewSet):
+    def list(self, request, *args, **kwargs):
+        years = []
+        for year in range(1996, datetime.date.today().year + 1):
+            years.append({
+                "year": str(year),
+                "link": "a-link",
+            })
+        return Response(HistorySerializer(instance=years, many=True).data)

--- a/solution/backend/regcore/v3views/history.py
+++ b/solution/backend/regcore/v3views/history.py
@@ -1,16 +1,35 @@
 import datetime
+import asyncio
+import httpx
 
 from rest_framework import viewsets
 from rest_framework.response import Response
 
 from regcore.serializers.history import HistorySerializer
 
+async def compute_object(section, year, client):
+    data = await client.head(f"https://www.govinfo.gov/link/cfr/{section['title']}/{section['part']}?sectionnum={section['section']}&year={year}&link-type=pdf")
+    if data.status_code != 302:
+        return None
+    return {
+        "year": str(year),
+        "link": data.headers["location"],
+    }
+
+def year_generator(title, part, section):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    client = httpx.AsyncClient()
+    section_data = {
+        "title": title,
+        "part": part,
+        "section": section,
+    }
+    for future in asyncio.as_completed([compute_object(section_data, year, client) for year in range(1996, datetime.date.today().year + 1)]):
+        yield loop.run_until_complete(future)
+
 class SectionHistoryViewSet(viewsets.ViewSet):
     def list(self, request, *args, **kwargs):
-        years = []
-        for year in range(1996, datetime.date.today().year + 1):
-            years.append({
-                "year": str(year),
-                "link": "a-link",
-            })
+        title, part, section = [self.kwargs.get(i) for i in ["title", "part", "section"]]
+        years = sorted([year for year in year_generator(title, part, section) if year != None], key=lambda year: year["year"])
         return Response(HistorySerializer(instance=years, many=True).data)

--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -14,3 +14,4 @@ drf-spectacular==0.24.2
 django-model-utils
 django-jsonform
 django-csp
+httpx

--- a/solution/ui/e2e/cypress/integration/api.spec.js
+++ b/solution/ui/e2e/cypress/integration/api.spec.js
@@ -19,6 +19,7 @@ const API_ENDPOINTS_V3 = [
     `/v3/resources/locations/subparts`,
     `/v3/resources/supplemental_content`,
     `/v3/synonym/${SYNONYM}`,
+    `/v3/title/${TITLE}/part/${PART}/history/section/${SECTION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/section/${SECTION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/sections`,


### PR DESCRIPTION
Resolves #1712

**Description-**

This endpoint takes a title, part, and section combination and queries GovInfo's link service to determine which years have valid historical PDFs associated with them.

**This pull request changes...**

- New endpoint exists, `/v3/title/<title>/part/<part>/history/section/<section>`.
- Endpoint returns a list of valid years and links to PDF versions of the reg for that year.
- Queries are performed asynchronously which should be fine as the number of requests (per request) is small.

**Steps to manually verify this change...**

1. Visit `/v3/title/<title>/part/<part>/history/section/<section>` and plug in valid values like `title=42`, `part=433`, `section=50`.
2. Verify the data returned is returned quickly, and contains valid years and PDF links.

