### PR TITLE
Fix destruction of db issues

### DIFF
--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -52,6 +52,11 @@ jobs:
           popd
       # remove the regulations site
       - name: remove experimental regulations site server
+      # If previous step fails the database will not be removed and you cannot rerun it
+      # In this instance we want to just remove the database so that we dont have 
+      # to go into the database and do it manually.
+      # If process is manually stopped it will not run this step.
+        if: success() || failure()
         env:
           PR: ${{ github.event.number }}
         run: |

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -91,7 +91,7 @@ functions:
   drop_database:
     environment:
       STAGE: ${self:custom.stage}
-      DB_NAME: eregs
+      DB_NAME: ${self:custom.stage}
     handler: dropdb.handler
     timeout: 300
     layers:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -91,7 +91,7 @@ functions:
   drop_database:
     environment:
       STAGE: ${self:custom.stage}
-      DB_NAME: main
+      DB_NAME: eregs
     handler: dropdb.handler
     timeout: 300
     layers:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -91,7 +91,7 @@ functions:
   drop_database:
     environment:
       STAGE: ${self:custom.stage}
-      DB_NAME: ${self:custom.stage}
+      DB_NAME: eregs
     handler: dropdb.handler
     timeout: 300
     layers:


### PR DESCRIPTION
Resolves #EREGSCSC-1713


**Description-**

Remove experimental was failing when invoked.  Django was trying to establish a connection to a db of "Main" on the instance.  Since Main no longer existed on our new DB it couldnt connect.  To fix this db_name was just changed to eregs.
Another change is to ensure on failure it can be reran to remove the database.  If the parser.yml file gets removed successfully but the db is not, you cannot simply just rerun the github action(though you can just try executing the lambda directly).  This will say "Ok this failed to remove the create parser stack, lets just remove the database directly.

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change
Create a branch off of this one and create a pr with it.  
Close the PR.  
It will successfully remove the environment/db.

Reopen the PR.
go into aws console and delete the parser lamda for the PR. 
Close the pr
Database remove step will still run.  
