### PR TITLE
EREGCSC-1678 Add pgaudit params to RDS parameter group

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -208,6 +208,8 @@ resources:
           idle_in_transaction_session_timeout: 7200000
           statement_timeout: 7200000
           search_path: '"$user",public'
+          pgaudit.role: "rds_pgaudit"
+          pgaudit.log: "none"
 
     RDSResource:
       Type: AWS::RDS::DBCluster


### PR DESCRIPTION
Resolves #1678

**Description-**

As part of the process for enabling pgaudit, 2 parameters need to be added to the RDS parameter group.

**This pull request changes...**

- `pgaudit.log` is set to "none" for now.
- `pgaudit.role` is set to "rds_pgaudit".

