### PR TITLE
EREGCSC-1678-B Switch default logging mode to ALL

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -209,7 +209,7 @@ resources:
           statement_timeout: 7200000
           search_path: '"$user",public'
           pgaudit.role: "rds_pgaudit"
-          pgaudit.log: "none"
+          pgaudit.log: "ALL"
 
     RDSResource:
       Type: AWS::RDS::DBCluster

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -208,6 +208,8 @@ resources:
           idle_in_transaction_session_timeout: 7200000
           statement_timeout: 7200000
           search_path: '"$user",public'
+          pgaudit.role: "rds_pgaudit"
+          pgaudit.log: "none"
 
     RDSResource:
       Type: AWS::RDS::DBCluster


### PR DESCRIPTION
Resolves #

**Description-**

Switches pgaudit to log all transactions of any type.

**This pull request changes...**

- `pgaudit.log` is set to `ALL`.

**Steps to manually verify this change...**

1. Once deployed to dev, reboot the dev RDS instance and run `show pgaudit.log;` in psql to verify it is set correctly.
2. Do this for val and prod next.

