### PR TITLE
Cypress-fix deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,6 +130,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: solution/ui/e2e
-          config: baseUrl=${{ steps.deploy-regulations-site-server.outputs.url }}
+          config: baseUrl=${{ needs.deploy.outputs.url }}
         env:
           CYPRESS_DEPLOYING: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,6 +130,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: solution/ui/e2e
-          config: baseUrl=${{ needs.deploy-django.outputs.url }}
+          config: baseUrl=${{ steps.deploy-regulations-site-server.outputs.url }}
         env:
           CYPRESS_DEPLOYING: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,10 +115,21 @@ jobs:
           serverless deploy --stage ${{ matrix.environment }} --config ./serverless-fr.yml
           AWS_CLIENT_TIMEOUT=360000 serverless invoke --function fr_parser --stage ${{ matrix.environment }} --config ./serverless-fr.yml
           popd
+
+  test-cypress:
+    needs: [deploy]
+    runs-on: ubuntu-20.04
+    steps:
+      # Checkout the code
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v5
         with:
           working-directory: solution/ui/e2e
-          config: baseUrl=${{ steps.deploy-regulations-site-server.outputs.url }}
+          config: baseUrl=${{ needs.deploy-django.outputs.url }}
         env:
           CYPRESS_DEPLOYING: true


### PR DESCRIPTION
Resolves #

**Description-**

Cypress-test is failing due to it being assigned an incorrect version of node.  Breaking cypress steps into a separate step, should fix this.  tested by copying the behavior in an experimental branch to cause it to break and getting the same error as it was before.

**This pull request changes...**

- expected change 1

When deployed to dev, val , and prod cypress test should run.
