### PR TITLE
EREGCSC-1648 -- Cypress 12 Deployment Issues

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -275,6 +275,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      # Setup node environment
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
       # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v5

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: lts/hydrogen # 18 LTS
+          node-version: 18.14
       # setup python
       - uses: actions/setup-python@v2
         if: success() && steps.findPr.outputs.number
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: lts/hydrogen # 18 LTS
+          node-version: 18.14
       # setup python
       - uses: actions/setup-python@v2
         if: success() && steps.findPr.outputs.number
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: lts/hydrogen # 18 LTS
+          node-version: 18.14
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:
@@ -279,7 +279,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: lts/hydrogen # 18 LTS
+          node-version: 18.14
       # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v5

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: lts/hydrogen # 18 LTS
       # setup python
       - uses: actions/setup-python@v2
         if: success() && steps.findPr.outputs.number
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: lts/hydrogen # 18 LTS
       # setup python
       - uses: actions/setup-python@v2
         if: success() && steps.findPr.outputs.number
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: lts/hydrogen # 18 LTS
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:
@@ -279,7 +279,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: lts/hydrogen # 18 LTS
       # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v5

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18
       # setup python
       - uses: actions/setup-python@v2
         if: success() && steps.findPr.outputs.number
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18
       # setup python
       - uses: actions/setup-python@v2
         if: success() && steps.findPr.outputs.number
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:
@@ -279,7 +279,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: 18
       # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       # should build first and save the artifact
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18.14
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,21 +115,10 @@ jobs:
           serverless deploy --stage ${{ matrix.environment }} --config ./serverless-fr.yml
           AWS_CLIENT_TIMEOUT=360000 serverless invoke --function fr_parser --stage ${{ matrix.environment }} --config ./serverless-fr.yml
           popd
-
-  test-cypress:
-    needs: [deploy]
-    runs-on: ubuntu-20.04
-    steps:
-      # Checkout the code
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      # Run the cypress tests
       - name: end-to-end tests
         uses: cypress-io/github-action@v5
         with:
           working-directory: solution/ui/e2e
-          config: baseUrl=${{ needs.deploy.outputs.url }}
+          config: baseUrl=${{ steps.deploy-regulations-site-server.outputs.url }}
         env:
           CYPRESS_DEPLOYING: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We have public documentation about our product, design, and research processes i
 - Docker Compose
 - go version 1.16
 - git
-- node >= v15 (We suggest using [nvm](https://github.com/nvm-sh/nvm))
+- node >= v18 (We suggest using [nvm](https://github.com/nvm-sh/nvm))
 
 # Getting setup
 

--- a/solution/ui/regulations/eregs-vite/package-lock.json
+++ b/solution/ui/regulations/eregs-vite/package-lock.json
@@ -15,7 +15,6 @@
         "vuetify": "^2.6.10"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue": "^2.3.1",
         "sass": "~1.32",
         "unplugin-vue-components": "^0.19.3",
         "vite": "^2.9.13",
@@ -797,19 +796,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/@vitejs/plugin-vue": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.1.tgz",
-      "integrity": "sha512-YNzBt8+jt6bSwpt7LP890U1UcTOIZZxfpE5WOJ638PNxSEKOqAi0+FSKS0nVeukfdZ0Ai/H7AFd6k3hayfGZqQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^2.5.10",
-        "vue": "^3.2.25"
       }
     },
     "node_modules/@vue/babel-helper-vue-jsx-merge-props": {
@@ -3125,12 +3111,6 @@
         "picomatch": "^2.2.2"
       }
     },
-    "@vitejs/plugin-vue": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.1.tgz",
-      "integrity": "sha512-YNzBt8+jt6bSwpt7LP890U1UcTOIZZxfpE5WOJ638PNxSEKOqAi0+FSKS0nVeukfdZ0Ai/H7AFd6k3hayfGZqQ==",
-      "dev": true
-    },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.2.1.tgz",
@@ -4266,7 +4246,8 @@
     "vuetify": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.10.tgz",
-      "integrity": "sha512-fgUeRDDCwYkwu6WGEEKGe7IdfzOsXJCZGrqkn1pcS2ycuoDL8mR2/dejH5iFNnBY6MnsT365PAGn0J+9otjfQg=="
+      "integrity": "sha512-fgUeRDDCwYkwu6WGEEKGe7IdfzOsXJCZGrqkn1pcS2ycuoDL8mR2/dejH5iFNnBY6MnsT365PAGn0J+9otjfQg==",
+      "requires": {}
     },
     "webpack-sources": {
       "version": "3.2.3",

--- a/solution/ui/regulations/eregs-vite/package.json
+++ b/solution/ui/regulations/eregs-vite/package.json
@@ -16,7 +16,6 @@
     "vue-template-compiler": "^2.7.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^2.3.1",
     "sass": "~1.32",
     "unplugin-vue-components": "^0.19.3",
     "vite": "^2.9.13",


### PR DESCRIPTION
Resolves [EREGCSC-1648](https://jiraent.cms.gov/browse/EREGCSC-1648)

**Description:**

Cypress was recently updated to v12.  The end to end tests worked well, were much faster, and much less flaky on our Experimental Deployments, which use `deploy-experimental.yml` as a config file.

However, the tests would not run when deploying to `dev`/`val`/`prod` (known as the "production deployment").  This deployment uses a different config file -- `deploy.yml`.  

It was noted that our experimental deployments use Node v16, while our production deployments were using Node v14.  A likely explanation is that the Cypress v12 upgrade installed or upgraded dependencies that need Node 16+ to run successfully.

As such, this pull request updates Node to v18 for both the Experimental Deployments and the Production Deployments.  Node v18 was chosen because it is the [current LTS release](https://github.com/nodejs/release#release-schedule).

**This pull request changes:**

- Reverts exploratory changes to `deploy.yml` that added a separate job for cypress testing -- that separate job has been removed.
- Updates all steps and jobs using Node to use Node 18.14 (the current LTS version)
- Removes unnecessary Vite plugin that was causing [peer dependency errors with Node 16+ and NPM 7+](https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh).

**Steps to manually verify this change:**

1. Make sure tests pass and site works on Experimental Deployment
2. After merging PR into main, make sure site builds and deploys to `dev` environment correctly
3. Make sure tests pass in `dev` environment

