### PR TITLE
EREGCSC-1688 Encrypt static assets bucket by default

### DIFF
--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -42,6 +42,10 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: eregs-${self:custom.stage}-site-assets
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
         PublicAccessBlockConfiguration:
           BlockPublicAcls: true
           BlockPublicPolicy: true


### PR DESCRIPTION
Resolves #1688

**Description-**

As part of our ATO, we're required to have server-side encryption on all S3 buckets. Serverless deployment buckets are already encrypted by default, so all that remains is our static assets bucket.

**This pull request changes...**

- `serverless.yml` for static assets is changed to enable encryption.

**Steps to manually verify this change...**

1. Log into our dev environment and find the `eregs-dev704-site-assets` S3 bucket.
2. Click "Properties" and scroll down to "Default encryption".
3. You should see "Encryption key type" is set to "Amazon S3-managed keys (SSE-S3)", whereas before it was "None".

