### PR TITLE
EREGCSC-1737 - update code to return title as "-"

### DIFF
--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -33,7 +33,7 @@ class ResourceFeed(Feed):
         return results
 
     def item_title(self, item):
-        return item['name'] if item['name'] else ""
+        return item['name'] if item['name'] else "-"
 
     def item_pubdate(self, item):
         return self.get_date(item['date_published'])

--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -33,7 +33,7 @@ class ResourceFeed(Feed):
         return results
 
     def item_title(self, item):
-        return item['name'] if item['name'] else "none"
+        return item['name'] if item['name'] else ""
 
     def item_pubdate(self, item):
         return self.get_date(item['date_published'])

--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -33,13 +33,7 @@ class ResourceFeed(Feed):
         return results
 
     def item_title(self, item):
-        date = item['date'].strftime("%b %d, %Y") if item['date'] else ''
-        if date and item['name']:
-            return f"{date} | {item['name']}"
-        elif date:
-            return date
-        else:
-            return item['name']
+        return item['name'] if item['name'] else "none"
 
     def item_pubdate(self, item):
         return self.get_date(item['date_published'])


### PR DESCRIPTION
Resolves #[EREGCSC-1737](https://jiraent.cms.gov/browse/EREGCSC-1737)

**Description-**
We want the RSS feed to be match up with our resource data. The resource data name field will be equivalent to title for the rss feed. However we do not always have a name value. Since RSS requires the title field its been decided to return a string "none" instead. That way when we use the search.gov api we get the raw data and can build the correct title on our side. 

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**


1. steps to view and verify change

Visit the RSS feed to this pull request /latest/feed and see that the title is "none" in some cases when we do not have a name value for resources. 