### PR TITLE
EREGCSC-1702 Adding resources to serverless

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -215,7 +215,7 @@ resources:
       Type: AWS::RDS::DBCluster
       DeletionPolicy: Retain
       Properties:
-        MasterUsername: eregstest1
+        MasterUsername: ${self:custom.settings.USERNAME}
         StorageEncrypted: true
         MasterUserPassword: ${ssm:/eregulations/db/password}
         DBSubnetGroupName:

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -211,6 +211,37 @@ resources:
           search_path: '"$user",public'
           pgaudit.role: "rds_pgaudit"
           pgaudit.log: "ALL"
+    RDSResource:
+      Type: AWS::RDS::DBCluster
+      DeletionPolicy: Retain
+      Properties:
+        MasterUsername: eregstest1
+        StorageEncrypted: true
+        MasterUserPassword: ${ssm:/eregulations/db/password}
+        DBSubnetGroupName:
+          Ref: DBSubnetGroup
+        Engine: aurora-postgresql
+        EngineVersion: "12.8"
+        DatabaseName: 'eregs'
+        BackupRetentionPeriod: 3
+        DBClusterParameterGroupName:
+          Ref: AuroraRDSClusterParameter
+        VpcSecurityGroupIds:
+          - !Ref 'DBSecurityGroup'
+    
+    AuroraRDSInstance:
+      Type: AWS::RDS::DBInstance
+      DeletionPolicy: Retain
+      Properties:
+        DBInstanceClass: db.r6g.large
+        StorageEncrypted: true
+        Engine: aurora-postgresql
+        EngineVersion: "12.8"
+        PubliclyAccessible: false
+        DBParameterGroupName:
+          Ref: AuroraRDSInstanceParameter
+        DBClusterIdentifier:
+          Ref: RDSResource
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Resolves # EREGCSC-1702

**Description-**
Adding database instance and cluster to the serverless file with encrypted on and deletion protection on.  Does not impact anything on the application since this is just getting serverless in line with our application.

**This pull request changes...**

- Adds the resource to the file.  Does not add anything to the application

**Steps to manually verify this change...**

1. After deployed to dev, check dev to see that the stack does not change the resources.
2. After deployed to val same thing
3. After deployed to prod same thing.

