### PR TITLE
EREGCSC-1682 Buckets should require requests to use Secure Socket Layer

### DIFF
--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -87,6 +87,22 @@ resources:
                   Fn::GetAtt:
                   - CloudFrontOriginAccessIdentity
                   - S3CanonicalUserId
+            - Effect: Deny
+              Action: 's3:*'
+              Resource:
+                - !Join
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - !Ref AssetsBucket
+                    - /*
+                - !Join
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - !Ref AssetsBucket
+              Principal: '*'
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
         Bucket: !Ref AssetsBucket
 
     CloudFrontDistribution:


### PR DESCRIPTION
Resolves #1682

**Description-**

As part of our ATO, all S3 buckets must require SSL. Due to a lack of serverless config, the `static-assets` bucket did not enforce this.

Note that due to the nature of this change, it will affect both experimental and production deployments without the need for additional serverless code.

**This pull request changes...**

- `serverless.yml` for static assets explicitly enforces SSL.

**Steps to manually verify this change...**

1. Go to the AWS console for dev.
2. Under S3, go to `eregs-dev710-site-assets` and click "Permissions".
3. Verify the following code is present in the Bucket Policy, and that it matches the [AWS remediation docs](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#s3-5-remediation):
    ```
    {
        "Effect": "Deny",
        "Principal": "*",
        "Action": "s3:*",
        "Resource": [
            "arn:aws:s3:::eregs-dev710-site-assets/*",
            "arn:aws:s3:::eregs-dev710-site-assets"
        ],
        "Condition": {
            "Bool": {
                "aws:SecureTransport": "false"
            }
        }
    }
    ```
4. Go to the [demo site ](https://4a4svt07w2.execute-api.us-east-1.amazonaws.com/dev710) and verify static assets are loading correctly, i.e. the site looks and acts normal.

