### PR TITLE
EREGCSC-1684 API Gateway REST and WebSocket API execution logging should be enabled

### DIFF
--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -7,9 +7,9 @@ provider:
   region: us-east-1
   iam:
     role: LambdaFunctionRole
-#  logs:
-#    restApi:
-#      role: ApiGatewayRole
+  logs:
+    restApi:
+      role: !GetAtt ApiGatewayLoggingRole.Arn
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -109,7 +109,7 @@ resources:
 
   Resources:
 
-    ApiGatewayRole:
+    ApiGatewayLoggingRole:
       Type: AWS::IAM::Role
       Properties:
         Path: ${ssm:/account_vars/iam/path}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -3,13 +3,13 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  logs:
-    restApi:
-      role: LambdaFunctionRole
   runtime: python3.8
   region: us-east-1
   iam:
     role: LambdaFunctionRole
+  logs:
+    restApi:
+      role: LambdaFunctionRole
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -150,13 +150,6 @@ resources:
                         - Ref: 'AWS::Region'
                         - Ref: 'AWS::AccountId'
                         - 'log-group:/aws/lambda/*:*:*'
-                    - 'Fn::Join':
-                      - ':'
-                      -
-                        - 'arn:aws:logs'
-                        - Ref: 'AWS::Region'
-                        - Ref: 'AWS::AccountId'
-                        - 'log-group:/aws/api-gateway/*:*:*'
                 -  Effect: "Allow"
                    Action:
                      - "s3:PutObject"

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -9,7 +9,7 @@ provider:
     role: LambdaFunctionRole
   logs:
     restApi:
-      role: LambdaFunctionRole
+      role: ApiGatewayRole
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -108,6 +108,28 @@ functions:
 resources:
 
   Resources:
+
+    ApiGatewayRole:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: ${ssm:/account_vars/iam/path}
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - apigateway.amazonaws.com
+              Action: sts:AssumeRole
+        PermissionsBoundary:
+          Fn::Join:
+            - ''
+            - - 'arn:aws:iam::'
+              - Ref: AWS::AccountId
+              - ':policy'
+              - ${ssm:/account_vars/iam/permissions_boundary_policy}
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -10,9 +10,8 @@ provider:
   logs:
     restApi:
       level: INFO
-      role: "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
       roleManagedExternally: true
-      #role: !GetAtt ApiGatewayLoggingRole.Arn
+      role: !GetAtt ApiGatewayLoggingRole.Arn
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -112,27 +111,27 @@ resources:
 
   Resources:
 
-    # ApiGatewayLoggingRole:
-    #   Type: AWS::IAM::Role
-    #   Properties:
-    #     Path: ${ssm:/account_vars/iam/path}
-    #     AssumeRolePolicyDocument:
-    #       Version: '2012-10-17'
-    #       Statement:
-    #         - Effect: Allow
-    #           Principal:
-    #             Service:
-    #               - apigateway.amazonaws.com
-    #           Action: sts:AssumeRole
-    #     PermissionsBoundary:
-    #       Fn::Join:
-    #         - ''
-    #         - - 'arn:aws:iam::'
-    #           - Ref: AWS::AccountId
-    #           - ':policy'
-    #           - ${ssm:/account_vars/iam/permissions_boundary_policy}
-    #     ManagedPolicyArns:
-    #       - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+    ApiGatewayLoggingRole:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: ${ssm:/account_vars/iam/path}
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - apigateway.amazonaws.com
+              Action: sts:AssumeRole
+        PermissionsBoundary:
+          Fn::Join:
+            - ''
+            - - 'arn:aws:iam::'
+              - Ref: AWS::AccountId
+              - ':policy'
+              - ${ssm:/account_vars/iam/permissions_boundary_policy}
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -9,7 +9,7 @@ provider:
     role: LambdaFunctionRole
   logs:
     restApi:
-      role: ApiGatewayRole
+      role: arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -108,28 +108,6 @@ functions:
 resources:
 
   Resources:
-
-    ApiGatewayRole:
-      Type: AWS::IAM::Role
-      Properties:
-        Path: ${ssm:/account_vars/iam/path}
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - apigateway.amazonaws.com
-              Action: sts:AssumeRole
-        PermissionsBoundary:
-          Fn::Join:
-            - ''
-            - - 'arn:aws:iam::'
-              - Ref: AWS::AccountId
-              - ':policy'
-              - ${ssm:/account_vars/iam/permissions_boundary_policy}
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -11,7 +11,6 @@ provider:
     restApi:
       level: INFO
       roleManagedExternally: true
-      role: !GetAtt ApiGatewayLoggingRole.Arn
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -110,28 +109,6 @@ functions:
 resources:
 
   Resources:
-
-    ApiGatewayLoggingRole:
-      Type: AWS::IAM::Role
-      Properties:
-        Path: ${ssm:/account_vars/iam/path}
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - apigateway.amazonaws.com
-              Action: sts:AssumeRole
-        PermissionsBoundary:
-          Fn::Join:
-            - ''
-            - - 'arn:aws:iam::'
-              - Ref: AWS::AccountId
-              - ':policy'
-              - ${ssm:/account_vars/iam/permissions_boundary_policy}
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -3,6 +3,8 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
+  logs:
+    restApi: true
   runtime: python3.8
   region: us-east-1
   iam:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -9,7 +9,10 @@ provider:
     role: LambdaFunctionRole
   logs:
     restApi:
-      role: !GetAtt ApiGatewayLoggingRole.Arn
+      level: INFO
+      role: "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+      roleManagedExternally: true
+      #role: !GetAtt ApiGatewayLoggingRole.Arn
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -109,27 +112,27 @@ resources:
 
   Resources:
 
-    ApiGatewayLoggingRole:
-      Type: AWS::IAM::Role
-      Properties:
-        Path: ${ssm:/account_vars/iam/path}
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - apigateway.amazonaws.com
-              Action: sts:AssumeRole
-        PermissionsBoundary:
-          Fn::Join:
-            - ''
-            - - 'arn:aws:iam::'
-              - Ref: AWS::AccountId
-              - ':policy'
-              - ${ssm:/account_vars/iam/permissions_boundary_policy}
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+    # ApiGatewayLoggingRole:
+    #   Type: AWS::IAM::Role
+    #   Properties:
+    #     Path: ${ssm:/account_vars/iam/path}
+    #     AssumeRolePolicyDocument:
+    #       Version: '2012-10-17'
+    #       Statement:
+    #         - Effect: Allow
+    #           Principal:
+    #             Service:
+    #               - apigateway.amazonaws.com
+    #           Action: sts:AssumeRole
+    #     PermissionsBoundary:
+    #       Fn::Join:
+    #         - ''
+    #         - - 'arn:aws:iam::'
+    #           - Ref: AWS::AccountId
+    #           - ':policy'
+    #           - ${ssm:/account_vars/iam/permissions_boundary_policy}
+    #     ManagedPolicyArns:
+    #       - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -4,7 +4,8 @@ variablesResolutionMode: 20210326
 provider:
   name: aws
   logs:
-    restApi: true
+    restApi:
+      role: LambdaFunctionRole
   runtime: python3.8
   region: us-east-1
   iam:
@@ -148,6 +149,13 @@ resources:
                         - Ref: 'AWS::Region'
                         - Ref: 'AWS::AccountId'
                         - 'log-group:/aws/lambda/*:*:*'
+                    - 'Fn::Join':
+                      - ':'
+                      -
+                        - 'arn:aws:logs'
+                        - Ref: 'AWS::Region'
+                        - Ref: 'AWS::AccountId'
+                        - 'log-group:/aws/api-gateway/*:*:*'
                 -  Effect: "Allow"
                    Action:
                      - "s3:PutObject"

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -7,9 +7,9 @@ provider:
   region: us-east-1
   iam:
     role: LambdaFunctionRole
-  logs:
-    restApi:
-      role: arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+#  logs:
+#    restApi:
+#      role: ApiGatewayRole
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
@@ -108,6 +108,28 @@ functions:
 resources:
 
   Resources:
+
+    ApiGatewayRole:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: ${ssm:/account_vars/iam/path}
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - apigateway.amazonaws.com
+              Action: sts:AssumeRole
+        PermissionsBoundary:
+          Fn::Join:
+            - ''
+            - - 'arn:aws:iam::'
+              - Ref: AWS::AccountId
+              - ':policy'
+              - ${ssm:/account_vars/iam/permissions_boundary_policy}
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
 
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -3,12 +3,14 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  logs:
-    restApi: true
   runtime: python3.8
   region: us-east-1
   iam:
     role: LambdaFunctionRole
+  logs:
+    restApi:
+      level: INFO
+      roleManagedExternally: true
   lambdaHashingVersion: '20201221'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -3,6 +3,8 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
+  logs:
+    restApi: true
   runtime: python3.8
   region: us-east-1
   iam:


### PR DESCRIPTION
Resolves #1684

**Description-**

To satisfy our ATO, we are required to have execution logging enabled for API Gateway and WebSocket API.

**This pull request changes...**

- Logging is enabled with an externally-managed role (requires one-time setup per environment, described in internal runbook.)

**Steps to manually verify this change...**

1. Verify this PR has successfully deployed.
2. Go to CloudWatch for dev and check for the existence of a log group titled `API-Gateway-Execution-Logs_98he0f5e87/dev713`.

