### PR TITLE
EREGCSC-1689: Cloudfront associated with WAF ACL

### DIFF
--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -27,7 +27,7 @@ from regcore.views import SettingsAuthentication
 
 
 @extend_schema(
-    description="Retrieve a list ofs all resources. "
+    description="Retrieve a list of all resources. "
                 "Includes all types e.g. supplemental content, Federal Register Documents, etc. "
                 "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
                 "Results are paginated by default.",

--- a/solution/backend/resources/v3views/resources.py
+++ b/solution/backend/resources/v3views/resources.py
@@ -27,7 +27,7 @@ from regcore.views import SettingsAuthentication
 
 
 @extend_schema(
-    description="Retrieve a list of all resources. "
+    description="Retrieve a list ofs all resources. "
                 "Includes all types e.g. supplemental content, Federal Register Documents, etc. "
                 "Searching is supported as well as inclusive filtering by title, part, subpart, and section. "
                 "Results are paginated by default.",

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -106,14 +106,14 @@ resources:
         Bucket: !Ref AssetsBucket
     CloudFrontWebACL:
       Type: AWS::WAFv2::WebACL
+      Properties:
         DefaultAction: 
           Allow: {}
-      Properties:
-        Scope: REGIONAL
+        Scope: us-east-1
         VisibilityConfig:
           SampledRequestsEnabled: true
           CloudWatchMetricsEnabled: true
-          MetricName: eregs-${self:custom.stage}-metric
+          MetricName: eregs-${self:custom.stage}-cloudfront-metric
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -110,7 +110,7 @@ resources:
         Name: eregs-${self:custom.stage}-cloudfront-ACL
         DefaultAction: 
           Allow: {}
-        Scope: REGIONAL
+        Scope: GLOBAL
         VisibilityConfig:
           SampledRequestsEnabled: true
           CloudWatchMetricsEnabled: true

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -107,9 +107,10 @@ resources:
     CloudFrontWebACL:
       Type: AWS::WAFv2::WebACL
       Properties:
+        Name: eregs-${self:custom.stage}-cloudfront-ACL
         DefaultAction: 
           Allow: {}
-        Scope: us-east-1
+        Scope: REGIONAL
         VisibilityConfig:
           SampledRequestsEnabled: true
           CloudWatchMetricsEnabled: true

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -110,7 +110,7 @@ resources:
         Name: eregs-${self:custom.stage}-cloudfront-ACL
         DefaultAction: 
           Allow: {}
-        Scope: GLOBAL
+        Scope: CLOUDFRONT
         VisibilityConfig:
           SampledRequestsEnabled: true
           CloudWatchMetricsEnabled: true

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -120,7 +120,7 @@ resources:
       Properties:
         DistributionConfig:
           Comment: CloudFront Distro for the static website hosted in S3
-          WebACLId: !GetAtt CloudFrontWebACL.arn
+          WebACLId: !GetAtt CloudFrontWebACL.Arn
           Aliases:
             - Ref: AWS::NoValue
           Origins:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -104,12 +104,22 @@ resources:
                 Bool:
                   aws:SecureTransport: false
         Bucket: !Ref AssetsBucket
-
+    CloudFrontWebACL:
+      Type: AWS::WAFv2::WebACL
+        DefaultAction: 
+          Allow: {}
+      Properties:
+        Scope: REGIONAL
+        VisibilityConfig:
+          SampledRequestsEnabled: true
+          CloudWatchMetricsEnabled: true
+          MetricName: eregs-${self:custom.stage}-metric
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:
         DistributionConfig:
           Comment: CloudFront Distro for the static website hosted in S3
+          WebACLId: !Ref CloudFrontWebACL
           Aliases:
             - Ref: AWS::NoValue
           Origins:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -120,7 +120,7 @@ resources:
       Properties:
         DistributionConfig:
           Comment: CloudFront Distro for the static website hosted in S3
-          WebACLId: !Ref CloudFrontWebACL
+          WebACLId: !GetAtt CloudFrontWebACL.arn
           Aliases:
             - Ref: AWS::NoValue
           Origins:


### PR DESCRIPTION
Resolves # 1689 & 1690

Description- Enable WAF/ACL on Cloudfront.   Ticket was originally just for 1689 but when adding the WAF/ACL resource to serverless, it requires you to say if you want logging or not. To make it simple, logging was added.

This pull request changes...

- All new experimental deploys have waf/acl enabled as well as dev, prod and val.  
- 
Steps to manually verify this change...
 
Go to the resource for this PR in Cloudfront,
See that aws/waf has a value there.
When deployed to dev, verify it gets added.  ONce its deployed to dev it takes about 15 minutes to create the resource.
Same as above for val and prod.