### PR TITLE
EREGCSC-1738 Update set-output in Github Actions files

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -125,7 +125,7 @@ jobs:
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function populate_content --stage dev${PR}
-          echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"
+          echo "{url}={$(cat output.log | grep -m1 'ANY -' | cut -c 9-)}" >> $GITHUB_OUTPUT
           popd
 
   build-and-deploy-vue:

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -125,7 +125,7 @@ jobs:
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function populate_content --stage dev${PR}
-          echo "{url}={$(cat output.log | grep -m1 'ANY -' | cut -c 9-)}" >> $GITHUB_OUTPUT
+          echo "url=$(cat output.log | grep -m1 'ANY -' | cut -c 9-)" >> $GITHUB_OUTPUT
           popd
 
   build-and-deploy-vue:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
           serverless deploy --stage ${{ matrix.environment }} | tee output.log
           serverless invoke --function reg_core_migrate --stage ${{ matrix.environment }}
           serverless invoke --function create_su --stage ${{ matrix.environment }}
-          echo "::set-output name=url::$(cat output.log | grep -m1 'ANY -' | cut -c 9-)"
+          echo "url=$(cat output.log | grep -m1 'ANY -' | cut -c 9-)" >> $GITHUB_OUTPUT
           popd
       # vite needs the .env file in order to know the URL of the api.
       - name: Make envfile


### PR DESCRIPTION
Resolves #1738

**Description-**

`set-output` is deprecated in Github Actions, this PR updates it to the new syntax.

**This pull request changes...**

- `set-output` is replaced with environment files in deploy.yml and deploy-experimental.yml

**Steps to manually verify this change...**

1. Verify this PR deploys successfully

