### PR TITLE
EREGCSC-1755 -- Highlighting Bug

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/node_types/Citation.html
+++ b/solution/backend/regulations/templates/regulations/partials/node_types/Citation.html
@@ -1,2 +1,2 @@
 {% load citation %}
-<p>{{node.content | citation}}</p>
+<p class="citation-node">{{node.content | citation}}</p>

--- a/solution/ui/regulations/eregs-component-lib/src/utils.js
+++ b/solution/ui/regulations/eregs-component-lib/src/utils.js
@@ -156,7 +156,10 @@ const getQueryParam = (location, key) => {
  * @param {string} highlightString - string to match
  */
 function addMarks(element, highlightString) {
-    const regex = new RegExp(highlightString, "gi");
+    function escapeRegex(string) {
+        return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+    const regex = new RegExp(escapeRegex(highlightString));
     if (element.nodeType === document.TEXT_NODE) {
         // note `nodeValue` vs `innerHTML`
         // nodeValue gives inner text without Vue component markup tags;

--- a/solution/ui/regulations/eregs-component-lib/src/utils.js
+++ b/solution/ui/regulations/eregs-component-lib/src/utils.js
@@ -202,7 +202,7 @@ const highlightText = (location, paramKey) => {
         if (targetedSection) {
             const textArr = textToHighlight.split(",");
             textArr.forEach((text) => {
-                if (text.length > 2) {
+                if (text.length > 1) {
                     addMarks(targetedSection, text);
                 }
             });

--- a/solution/ui/regulations/eregs-component-lib/src/utils.js
+++ b/solution/ui/regulations/eregs-component-lib/src/utils.js
@@ -199,7 +199,9 @@ const highlightText = (location, paramKey) => {
         if (targetedSection) {
             const textArr = textToHighlight.split(",");
             textArr.forEach((text) => {
-                addMarks(targetedSection, text);
+                if (text.length > 2) {
+                    addMarks(targetedSection, text);
+                }
             });
         }
     }

--- a/solution/ui/regulations/eregs-component-lib/src/utils.js
+++ b/solution/ui/regulations/eregs-component-lib/src/utils.js
@@ -157,9 +157,11 @@ const getQueryParam = (location, key) => {
  */
 function addMarks(element, highlightString) {
     function escapeRegex(string) {
-        return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+        return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&");
     }
+
     const regex = new RegExp(escapeRegex(highlightString));
+
     if (element.nodeType === document.TEXT_NODE) {
         // note `nodeValue` vs `innerHTML`
         // nodeValue gives inner text without Vue component markup tags;
@@ -167,6 +169,10 @@ function addMarks(element, highlightString) {
         // Currently there is only the tooltip <trigger-btn> tag at beginning
         const text = element.nodeValue;
         if (text.toUpperCase().indexOf(highlightString.toUpperCase()) !== -1) {
+            if (element?.parentNode?.className === "citation-node") {
+                return false;
+            }
+
             const innerHtmlOfParentNode = element.parentNode.innerHTML;
             const indexOfText = innerHtmlOfParentNode.indexOf(text);
             const textToKeep = innerHtmlOfParentNode.slice(0, indexOfText);

--- a/solution/ui/regulations/eregs-component-lib/src/utils.js
+++ b/solution/ui/regulations/eregs-component-lib/src/utils.js
@@ -169,8 +169,16 @@ function addMarks(element, highlightString) {
         // Currently there is only the tooltip <trigger-btn> tag at beginning
         const text = element.nodeValue;
         if (text.toUpperCase().indexOf(highlightString.toUpperCase()) !== -1) {
+            // ignore citation node at bottom of section
             if (element?.parentNode?.className === "citation-node") {
-                return false;
+                return;
+            }
+
+            if (element?.parentNode?.nodeName === "A") {
+                const closestParagraph = element.parentNode.closest("p");
+                if (closestParagraph.className === "citation-node") {
+                    return;
+                }
             }
 
             const innerHtmlOfParentNode = element.parentNode.innerHTML;
@@ -182,7 +190,7 @@ function addMarks(element, highlightString) {
                 "<mark class='highlight'>$&</mark>"
             );
             element.parentNode.innerHTML = textToKeep + newText;
-            return true;
+            return;
         }
     } else if (element.nodeType === document.ELEMENT_NODE) {
         for (let i = 0; i < element.childNodes.length; i++) {

--- a/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResults.vue
@@ -2,7 +2,12 @@
     <div class="reg-results-container">
         <slot name="empty-state"></slot>
         <template v-for="(result, i) in results">
-            <RegResultsItem :key="i" :base="base" :result="result" />
+            <RegResultsItem
+                :key="i"
+                :base="base"
+                :result="result"
+                :query="query"
+            />
         </template>
     </div>
 </template>
@@ -25,6 +30,10 @@ export default {
         results: {
             type: Array,
             default: () => [],
+        },
+        query: {
+            type: String,
+            default: "",
         },
     },
 };

--- a/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResultsItem.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResultsItem.vue
@@ -5,7 +5,7 @@
         </div>
         <div class="results-section">
             <a
-                :href="createResultLink(result, base)"
+                :href="createResultLink(result, base, query)"
                 v-html="removeQuotes(result.parentHeadline)"
             />
         </div>
@@ -30,21 +30,32 @@ export default {
             type: Object,
             required: true,
         },
+        query: {
+            type: String,
+            default: "",
+        },
     },
 
     methods: {
         removeQuotes(string) {
             return stripQuotes(string);
         },
-        createResultLink(result, base) {
+        createResultLink(result, base, query) {
             // get highlight content from result.headline
-            const highlightedTerms = getTagContent(
+            const highlightedTermsArray = getTagContent(
                 result.headline,
                 "search-highlight"
             );
-            const highlightParams = highlightedTerms
-                ? `?q=${highlightedTerms}`
-                : "";
+
+            const uniqTermsArray = Array.from(
+                new Set([query, ...highlightedTermsArray])
+            );
+
+            const highlightParams =
+                uniqTermsArray.length > 0
+                    ? `?q=${uniqTermsArray.join(",")}`
+                    : "";
+
             return `${base}/${result.part_title}/${result.label[0]}/${
                 result.label[1]
             }/${result.date}/${highlightParams}#${result.label.join("-")}`;
@@ -54,7 +65,7 @@ export default {
     filters: {
         partDocumentTitleLabel(string) {
             return string.toLowerCase();
-        }
+        },
     },
 };
 </script>

--- a/solution/ui/regulations/eregs-vite/src/utilities/utils.js
+++ b/solution/ui/regulations/eregs-vite/src/utilities/utils.js
@@ -474,7 +474,7 @@ const stripQuotes = (string) => {
 /**
  * @param htmlString {string} - string of HTML markup
  * @param tagClass {string} - class to identify target HTML tag
- * @returns {string} - comma-separated string of unique highlight terms
+ * @returns {Array<string>} - array of of highlight terms as strings
  */
 const getTagContent = (htmlString, tagClass) => {
     const parser = new DOMParser();
@@ -483,8 +483,7 @@ const getTagContent = (htmlString, tagClass) => {
     const highlightTermsArray = [...highlightCollection].map((highlightEl) => {
         return highlightEl.innerHTML;
     });
-    const uniqTermsArray = Array.from(new Set(highlightTermsArray));
-    return uniqTermsArray.join(",");
+    return highlightTermsArray;
 };
 
 /**

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -38,7 +38,11 @@
                         </span>
                     </div>
                     <template v-if="!regsLoading">
-                        <RegResults :base="base" :results="regResults">
+                        <RegResults
+                            :base="base"
+                            :results="regResults"
+                            :query="searchQuery"
+                        >
                             <template #empty-state>
                                 <template
                                     v-if="


### PR DESCRIPTION
Resolves [EREGCSC-1755](https://jiraent.cms.gov/browse/EREGCSC-1755)

**Description**
Parentheses and other special characters cause problems when using them to highlight text in the reg text reader view.

**This pull request changes:**

- Updates regex logic to handle parens and other special characters
- limits highlightable terms to strings with a length greater than one (1)
- Adds actual user-defined query as a highlightable string in the URL
- Ignores citation node at bottom of section when highlighting text

**Steps to manually verify this change:**

1. Search for "1903(r)", click a result to visit the reader view, and make sure "1903(r)" is highlighted in the reg text
2. Make sure all previous searches work

