### PR TITLE
EREGCSC-1758 Convert the remainder of V2 calls to V3

### DIFF
--- a/solution/ui/regulations/eregs-component-lib/src/api.js
+++ b/solution/ui/regulations/eregs-component-lib/src/api.js
@@ -245,20 +245,6 @@ const getGovInfoLinks = async (apiURL, params) => {
     return result;
 };
 
-const getSupplementalContentByCategory = async (
-    api_url,
-    categories = [1, 2]
-) => {
-    const result = await httpApiGetLegacy(
-        `${api_url}all_sup?category=${categories.join(
-            "&category="
-        )}&max_results=100`,
-        {}, // params, default
-        api_url
-    );
-    return result.filter((r) => r.supplemental_content.length);
-};
-
 const getTitles = async (apiUrl) => {
     const url = apiUrl.replace("/v2/", "/v3/");
     return httpApiGetLegacy(`${url}titles`);
@@ -302,7 +288,6 @@ const getSubpartTOC = async (apiURL, title, part, subPart) => {
 
 export {
     getLastParserSuccessDate,
-    getSupplementalContentByCategory,
     v3GetSupplementalContent,
     v3GetFederalRegisterDocs,
     getCacheKeys,

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -10,7 +10,7 @@
             >
             ({{ resourceCount }})
         </a>
-        <h2 v-if="!requested_categories" id="subpart-resources-heading">
+        <h2 id="subpart-resources-heading">
             {{ activePart }} Resources
         </h2>
         <div v-if="resource_display" class="resource_btn_container">
@@ -39,7 +39,6 @@ import SimpleSpinner from "./SimpleSpinner.vue";
 import SupplementalContentCategory from "./SupplementalContentCategory.vue";
 
 import {
-    getSupplementalContentByCategory,
     v3GetSupplementalContent,
     getSubpartTOC
 } from "../api";
@@ -104,20 +103,10 @@ export default {
             required: false,
             default: v3GetSupplementalContent,
         },
-        getSupplementalContentByCategory: {
-            type: Function,
-            required: false,
-            default: getSupplementalContentByCategory,
-        },
         resource_display:{
             type: Boolean,
             required: false,
             default: false
-        },
-        requested_categories: {
-            type: String,
-            required: false,
-            default: "",
         },
     },
 
@@ -237,31 +226,21 @@ export default {
         },
         async fetch_content(title, part, location) {
             try {
-                if (this.requested_categories.length > 0) {
-                    // todo convert this to V3 API
-                    this.categories =
-                        await this.getSupplementalContentByCategory(
-                            this.api_url,
-                            this.requested_categories.split(",")
-                        );
-                } else {
-                    await this.get_location_string()
-                    const response = await v3GetSupplementalContent(
-                        this.api_url,
-                        {locations: location || this.joined_locations }
-                    );
+                await this.get_location_string()
+                const response = await v3GetSupplementalContent(
+                    this.api_url,
+                    {locations: location || this.joined_locations }
+                );
 
-                    const subpart_response = await v3GetSupplementalContent(
-                        this.api_url,
-                        {locations: this.joined_locations}
-                    )
-                    if (!this.resourceCount) {
-                        this.resourceCount = subpart_response.length;
-                    }
-
-
-                    this.categories = formatResourceCategories(response);
+                const subpart_response = await v3GetSupplementalContent(
+                    this.api_url,
+                    {locations: this.joined_locations}
+                )
+                if (!this.resourceCount) {
+                    this.resourceCount = subpart_response.length;
                 }
+
+                this.categories = formatResourceCategories(response);
             } catch (error) {
                 console.error(error);
             } finally {


### PR DESCRIPTION
Resolves #1758

**Description-**

Turns out getSupplementalContentByCategory isn't used after all, if you pull the thread. The function is only called if `requested_categories.length > 0` in SupplementalContent.vue, which is never true because `requested_categories` is never assigned anything other than an empty string.

**This pull request changes...**

- Remove getSupplementalContentByCategory
- Remove references to it from SupplementalContent.vue, as well as `requested_categories`

**Steps to manually verify this change...**

1. Verify PR deploys properly
2. Make sure the right sidebar still works in reader view

