### PR TITLE
Fix failing parser checks

### DIFF
--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -3,8 +3,8 @@ name: Parser Checks
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths:
-      - 'solution/parser/**'
+    # paths:
+    #   - 'solution/parser/**'
   # push:
   #   branches:
   #     - main

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -50,11 +50,11 @@ jobs:
         gofmt-path: './solution/parser/${{ matrix.dir }}'
         gofmt-flags: '-l -d'
 
-    - uses: dominikh/staticcheck-action@v1.3.0
-      with:
-        version: "2022.1"
-        install-go: false
-        working-directory: "./solution/parser/${{ matrix.dir }}"
+    # - uses: dominikh/staticcheck-action@v1.3.0
+    #   with:
+    #     version: "2022.1"
+    #     install-go: false
+    #     working-directory: "./solution/parser/${{ matrix.dir }}"
 
     # Run lint on the code
     - name: Run lint

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -3,11 +3,11 @@ name: Parser Checks
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    # paths:
-    #   - 'solution/parser/**'
-  # push:
-  #   branches:
-  #     - main
+    paths:
+      - 'solution/parser/**'
+  push:
+    branches:
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -53,7 +53,6 @@ jobs:
     - uses: dominikh/staticcheck-action@v1.3.0
       with:
         version: "2022.1.3"
-        #install-go: false
         working-directory: "./solution/parser/${{ matrix.dir }}"
 
     # Run lint on the code

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: dominikh/staticcheck-action@v1.3.0
       with:
         version: "2022.1.3"
-        install-go: false
+        #install-go: false
         working-directory: "./solution/parser/${{ matrix.dir }}"
 
     # Run lint on the code

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -31,17 +31,17 @@ jobs:
       with:
         go-version: '^1.16' # The Go version to download (if necessary) and use.
   
-    # # set up build cache
-    # - name: Set up build cache
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: |
-    #       ~/go/pkg/mod
-    #       ~/go/bin
-    #       ~/.cache/go-build
-    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-go-
+    # set up build cache
+    - name: Set up build cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/go/bin
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
       # Run go fmt on the code
     - name: Run gofmt
@@ -50,11 +50,11 @@ jobs:
         gofmt-path: './solution/parser/${{ matrix.dir }}'
         gofmt-flags: '-l -d'
 
-    # - uses: dominikh/staticcheck-action@v1.3.0
-    #   with:
-    #     version: "2022.1"
-    #     install-go: false
-    #     working-directory: "./solution/parser/${{ matrix.dir }}"
+    - uses: dominikh/staticcheck-action@v1.3.0
+      with:
+        version: "2022.1.3"
+        install-go: false
+        working-directory: "./solution/parser/${{ matrix.dir }}"
 
     # Run lint on the code
     - name: Run lint

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -31,17 +31,17 @@ jobs:
       with:
         go-version: '^1.16' # The Go version to download (if necessary) and use.
   
-    # set up build cache
-    - name: Set up build cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/go/bin
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+    # # set up build cache
+    # - name: Set up build cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: |
+    #       ~/go/pkg/mod
+    #       ~/go/bin
+    #       ~/.cache/go-build
+    #     key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-go-
 
       # Run go fmt on the code
     - name: Run gofmt

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -5,9 +5,9 @@ on:
     types: [ opened, synchronize, reopened ]
     paths:
       - 'solution/parser/**'
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -33,7 +33,7 @@ jobs:
   
     # set up build cache
     - name: Set up build cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod
@@ -45,12 +45,12 @@ jobs:
 
       # Run go fmt on the code
     - name: Run gofmt
-      uses: Jerome1337/gofmt-action@v1.0.4
+      uses: Jerome1337/gofmt-action@v1.0.5
       with:
         gofmt-path: './solution/parser/${{ matrix.dir }}'
         gofmt-flags: '-l -d'
 
-    - uses: dominikh/staticcheck-action@v1.2.0
+    - uses: dominikh/staticcheck-action@v1.3.0
       with:
         version: "2022.1"
         install-go: false


### PR DESCRIPTION
Resolves #n/a

**Description-**

Parser checks were failing due to configuration that recently became invalid. Also we were receiving set-output and save-state deprecation warnings.

**This pull request changes...**

- Packages are updated to remove set-output and save-state warnings
- `install-go: false` removed to fix failures

**Steps to manually verify this change...**

1. Go to [this most recent run](https://github.com/CMSgov/cmcs-eregulations/actions/runs/4357203064) to see that parser checks succeeded
2. After merging to main, verify it succeeds again

