### PR TITLE
EREGCSC-1744: Minimum viable homepage updates for 45

### DIFF
--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -38,13 +38,13 @@
                     <div class="toc-container">
 
                         {% for title in structure %}
-
+                            <div class="toc-title-container">
                             <h1> {{title.label}} </h1>
 
                             {% for child in title.children %}
                                 {% render_nested "regulations/homepage/"|add:child.type|add:".html" "regulations/homepage/child.html" context=child title=title.identifier.0 %}
                             {% endfor %}
-
+                        </div>
                         {% endfor %}
 
                     </div>    

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -39,12 +39,12 @@
 
                         {% for title in structure %}
                             <div class="toc-title-container">
-                            <h1> {{title.label}} </h1>
+                                <h1> {{title.label}} </h1>
 
-                            {% for child in title.children %}
-                                {% render_nested "regulations/homepage/"|add:child.type|add:".html" "regulations/homepage/child.html" context=child title=title.identifier.0 %}
-                            {% endfor %}
-                        </div>
+                                {% for child in title.children %}
+                                    {% render_nested "regulations/homepage/"|add:child.type|add:".html" "regulations/homepage/child.html" context=child title=title.identifier.0 %}
+                                {% endfor %}
+                            </div>
                         {% endfor %}
 
                     </div>    

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -47,8 +47,6 @@
 
                         {% endfor %}
 
-                        <p class="toc-external-ref">For subsequent subchapters (F-I), see <a href="https://www.ecfr.gov/current/title-42/chapter-IV" target="_blank" class="external" aria-label="link to Federal Register Title 42 Chapter 4">Title 42 Chapter IV in eCFR</a></p>
-
                     </div>    
 
                 </div>

--- a/solution/backend/regulations/templates/regulations/homepage/child.html
+++ b/solution/backend/regulations/templates/regulations/homepage/child.html
@@ -1,9 +1,6 @@
 {% load render_nested %}
 <h4>{{ label }}</h4>
 
-<p class="toc-external-ref">For preceding subchapters (A-B), see <a href="https://www.ecfr.gov/current/title-42/chapter-IV" target="_blank" class="external">Title 42 Chapter IV in eCFR</a></p>
-
-
 {% for child in children %}
     {% render_nested "regulations/homepage/"|add:child.type|add:".html" "regulations/homepage/child.html" context=child title=title%}
 {% endfor %}

--- a/solution/ui/regulations/css/scss/partials/_site_homepage.scss
+++ b/solution/ui/regulations/css/scss/partials/_site_homepage.scss
@@ -210,6 +210,7 @@
 }
 
 .homepage-main-content {
+    padding-bottom: 16px;
     .ds-l-row {
         @include custom-max(1024) {
             display: block;
@@ -228,7 +229,9 @@
     .toc-container {
         max-width: $text-max-width;
     }
-
+    .toc-title-container{
+        padding-bottom: 16px;
+    }
     h1 {
         margin-top: $spacer-2;
         margin-bottom: 0 !important;

--- a/solution/ui/regulations/css/scss/partials/_site_homepage.scss
+++ b/solution/ui/regulations/css/scss/partials/_site_homepage.scss
@@ -57,7 +57,7 @@
                 background-size: 55%;
                 background-position: bottom 50% right 25px;
 
-                > * {
+                >* {
                     width: 40%;
                 }
             }
@@ -67,7 +67,7 @@
                 background-size: auto 45%;
                 background-position: bottom 0px right 50%;
 
-                > * {
+                >* {
                     width: 100%;
                 }
             }
@@ -79,7 +79,7 @@
                 background-size: auto;
                 background-position: bottom 0px right 50%;
 
-                > * {
+                >* {
                     width: 100%;
                 }
             }
@@ -211,6 +211,7 @@
 
 .homepage-main-content {
     padding-bottom: 16px;
+
     .ds-l-row {
         @include custom-max(1024) {
             display: block;
@@ -229,9 +230,11 @@
     .toc-container {
         max-width: $text-max-width;
     }
-    .toc-title-container{
+
+    .toc-title-container {
         padding-bottom: 16px;
     }
+
     h1 {
         margin-top: $spacer-2;
         margin-bottom: 0 !important;
@@ -258,7 +261,7 @@
         margin: 1.33em 0 1.33em 0 !important;
     }
 
-    h4 + .toc-external-ref {
+    h4+.toc-external-ref {
         margin: $spacer-2 0 0 !important;
     }
 

--- a/solution/ui/regulations/css/scss/partials/_site_homepage.scss
+++ b/solution/ui/regulations/css/scss/partials/_site_homepage.scss
@@ -219,7 +219,6 @@
 }
 
 .homepage-toc {
-    margin-top: $spacer-2;
 
     @include custom-max(1024) {
         max-width: 100%;
@@ -231,7 +230,7 @@
     }
 
     h1 {
-        margin-top: 0 !important;
+        margin-top: $spacer-2;
         margin-bottom: 0 !important;
         font-size: $base-font-size * 1.8;
 


### PR DESCRIPTION
Resolves # EREGCSC-1744

**Description-**

Minimum updates to make the homepage ready for title 45

**This pull request changes...**

-Adjust the spacing between the end of Title 42 and the start of Title 45 (it's a bit squished)

-Remove all of the hardcoded "preceding" and "subsequent" notes from the homepage – they're outdated anyway, and probably not super effective; we should deal with that problem in a different way

**Steps to manually verify this change...**

1. Go to the homepage
2. Scroll down to title 45.  Spacing should be more than it was before.  Will look less squished.  Margin for top of h1 was changed from 0px to 16px.  This was taken from margin-top of the toc so that the first title doesn't move from where it was previously while adding padding for subsequent titles.

4. There should be no preceding or subsequent notes on the homepage now.  
