### PR TITLE
EREGCSC 1548- Reg page left nav shows part info 

### DIFF
--- a/solution/backend/regcore/models.py
+++ b/solution/backend/regcore/models.py
@@ -41,6 +41,13 @@ class Part(models.Model):
             structure = structure["children"][0]
         return structure
 
+    @property
+    def subchapter(self):
+        structure = self.structure
+        for _ in range(self.depth-1):
+            structure = structure["children"][0]
+        return structure["label"]
+
 
 class ParserConfiguration(SingletonModel):
     LOGLEVEL_CHOICES = [

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/base.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/base.html
@@ -14,7 +14,7 @@
 
 <div class="toc-header">
     <div class="toc-subchapter">{{ subchapter }}</div>
-    <div class="toc-part"> {{ title }} CFR  {{ part }} - <span class="description">{{ part_label }}</span></div> 
+    <div class="toc-part"> {{ title }} CFR  Part {{ part }} - <span class="description">{{ part_label }}</span></div> 
 </div>
 
 <nav role="navigation">

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/base.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/base.html
@@ -12,9 +12,10 @@
     </div>
 {% endblock %}
 
-{% block jump-to %}
-    {% include "regulations/partials/jump_to.html" %}
-{% endblock %}
+<div class="toc-header">
+    <p>{{ subchapter }}</p>
+    {{ title }} CFR  {{ part }} - {{ part_label }}
+</div>
 
 <nav role="navigation">
     {% block navigation %}{% endblock %}

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/base.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/base.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 <div class="toc-header">
-    <p>{{ subchapter }}</p>
-    {{ title }} CFR  {{ part }} - {{ part_label }}
+    <div class="toc-subchapter">{{ subchapter }}</div>
+    <div class="toc-part"> {{ title }} CFR  {{ part }} - <span class="description">{{ part_label }}</span></div> 
 </div>
 
 <nav role="navigation">

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -40,6 +40,7 @@ class ReaderView(CitationContextMixin, TemplateView):
         parts = Part.objects.filter(title=reg_title).effective(reg_version)
         document = query.document
         toc = query.toc
+        subchapter = query.subchapter
         part_label = toc['label_description']
         tree = self.get_content(context, document, toc)
         node_list = self.get_supp_content_params(context, [tree])
@@ -61,6 +62,7 @@ class ReaderView(CitationContextMixin, TemplateView):
             'reg_part':     reg_part,
             'part_label':   part_label,
             'toc':          toc,
+            'subchapter':   subchapter,
             'parts':        parts,
             'versions':     versions,
             'node_list':    node_list,

--- a/solution/backend/regulations/views/regulation_landing.py
+++ b/solution/backend/regulations/views/regulation_landing.py
@@ -26,6 +26,7 @@ class RegulationLandingView(TemplateView):
         reg_version = current.date.isoformat()
         reg_version_string = datetime.strftime(current.date, "%b %-d, %Y")
         toc = current.toc
+        subchapter = current.subchapter
         part_label = toc['label_description']
         authority = current.document['authority']
         source = current.document['source']
@@ -36,6 +37,7 @@ class RegulationLandingView(TemplateView):
             'title': title,
             'version': reg_version,
             'version_string': reg_version_string,
+            'subchapter': subchapter,
             # last updated dates of Jan 1, 2017 are not meaningful
             'has_meaningful_latest_version_date': current.date > date(2017, 1, 1),
             'part': reg_part,

--- a/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
@@ -231,24 +231,25 @@ aside.left-sidebar {
         background: $reverse_background_lighter;
     }
 }
+
 .toc-header {
     border-bottom: 1px solid $secondary_border_color;
-    margin: 20px 40px 20px 32px;
-    padding-bottom:20px;
+    margin: 25px 40px 16px 32px;
+    padding-bottom: 16px;
     color: white;
 
     .toc-subchapter {
         font-size: 14px;
         line-height: 18px;
-        margin-bottom: 5px;
+        margin-bottom: 8px;
     }
 
     .toc-part {
         font-weight: 700;
         font-size: 18px;
         line-height: 25px;
-        
-        .description{
+
+        .description {
             font-weight: normal;
         }
     }

--- a/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
@@ -232,11 +232,25 @@ aside.left-sidebar {
     }
 }
 .toc-header {
-    box-sizing: border-box;
     border-bottom: 1px solid $secondary_border_color;
+    margin: 20px 40px 20px 32px;
+    padding-bottom:20px;
+    color: white;
 
-    p {
-        padding: $spacer-2;
+    .toc-subchapter {
+        font-size: 14px;
+        line-height: 18px;
+        margin-bottom: 5px;
+    }
+
+    .toc-part {
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 25px;
+        
+        .description{
+            font-weight: normal;
+        }
     }
 }
 // Controls (i.e. Collapse)

--- a/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
@@ -129,7 +129,7 @@ aside.left-sidebar {
 
         background: none;
         border: none;
-        color: $reverse_link_color;
+        color: #CCF2FF;;
         cursor: pointer;
         display: flex;
         justify-content: center;
@@ -177,7 +177,7 @@ aside.left-sidebar {
     }
 
     a {
-        color: $reverse_link_color;
+        color: #CCF2FF;
 
         &:hover,
         &:focus {
@@ -231,7 +231,14 @@ aside.left-sidebar {
         background: $reverse_background_lighter;
     }
 }
+.toc-header {
+    box-sizing: border-box;
+    border-bottom: 1px solid $secondary_border_color;
 
+    p {
+        padding: $spacer-2;
+    }
+}
 // Controls (i.e. Collapse)
 
 .toc-controls {
@@ -240,7 +247,7 @@ aside.left-sidebar {
 
     button {
         outline: none;
-        color: $reverse_link_color;
+        color: #CCF2FF;;
         border: none;
         background: none;
         cursor: pointer;


### PR DESCRIPTION
Resolves # EREGCSC-1548

**Description-**

Removing jump -to from right sidebar replace with text for part and subchapter

**This pull request changes...**

- Right sidebar jump to is gone and replaced with text

**Steps to manually verify this change...**

1. steps to view and verify change

