### PR TITLE
EREGCSC-1666 Improve speed for combined search for resources

### DIFF
--- a/solution/Makefile
+++ b/solution/Makefile
@@ -158,6 +158,9 @@ test.local: ## run cypress tests locally without docker
 python.unittest:
 	docker-compose exec regulations python manage.py test
 
+python.shell:
+	docker-compose exec regulations python manage.py shell
+	
 local.seed:
 	docker-compose exec regulations python manage.py loaddata resources.category.json
 	docker-compose exec regulations python manage.py loaddata resources.subcategory.json

--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -118,7 +118,7 @@ class RegcoreSerializerTestCase(APITestCase):
         data = response.data
         self.assertEqual(data, [date(2020, 6, 30)])
 
-    @patch("regcore.v3views.history.get_year_data")
+    @patch("regcore.views.history.get_year_data")
     def test_get_historical_sections(self, get_year_data):
         get_year_data.return_value = httpx.Response(status_code=400)
         data = self.client.get("/v3/title/42/part/433/history/section/50").data

--- a/solution/backend/resources/tests/test_queryset_functions.py
+++ b/solution/backend/resources/tests/test_queryset_functions.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+from django.db.models import F, Case, When
+from resources.models import FederalRegisterDocument, FederalRegisterDocumentGroup, AbstractResource, SupplementalContent
+from resources.views.mixins import FRDocGroupingMixin
+from datetime import datetime, timedelta
+
+
+class TestMixinFunctions(TestCase):
+    def setUp(self):
+        FederalRegisterDocumentGroup.objects.create(id=1)
+        FederalRegisterDocumentGroup.objects.create(id=2)
+        FederalRegisterDocumentGroup.objects.create(id=3)
+        a = FederalRegisterDocumentGroup.objects.get(id=1)
+        b = FederalRegisterDocumentGroup.objects.get(id=2)
+        c = FederalRegisterDocumentGroup.objects.get(id=3)
+        today = datetime.today().strftime('%Y-%m-%d')
+        yesterday = (datetime.now() - timedelta(1)).strftime('%Y-%m-%d')
+        twodaysago = (datetime.now() - timedelta(2)).strftime('%Y-%m-%d')
+        FederalRegisterDocument.objects.create(id=1, group=a, date=today)
+        FederalRegisterDocument.objects.create(id=2, group=a, date=twodaysago)
+        FederalRegisterDocument.objects.create(id=3, group=b, date=yesterday)
+        FederalRegisterDocument.objects.create(id=4, group=c, date=today)
+        FederalRegisterDocument.objects.create(id=5, group=b, date=today)
+        SupplementalContent.objects.create(id=6, date=today)
+
+    def get_annotated_date(self):
+        return Case(
+            When(supplementalcontent__isnull=False, then=F("supplementalcontent__date")),
+            When(federalregisterdocument__isnull=False, then=F("federalregisterdocument__date")),
+            default=None,
+        )
+
+    def get_annotated_group(self):
+        return Case(
+            When(federalregisterdocument__isnull=False, then=F("federalregisterdocument__group")),
+            default=-1*F("pk"),
+        )
+
+    def test_get_id_one_groups(self):
+        docs = AbstractResource.objects.filter(id__in=[1, 2]).annotate(group_annotated=self.get_annotated_group())
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        self.assertEqual([1], ids)
+
+    def test_get_id_two_groups(self):
+        docs = AbstractResource.objects.filter(id__in=[1, 5]).annotate(group_annotated=self.get_annotated_group())
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        self.assertEqual([1, 5], ids)
+
+    def test_get_id_two_groups_different_return(self):
+        docs = AbstractResource.objects.filter(id__in=[1, 3]).annotate(group_annotated=self.get_annotated_group())
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        self.assertEqual([1, 5], ids)
+
+    def test_get_id_two_groups_share_group(self):
+        docs = AbstractResource.objects.filter(id__in=[1, 3, 5]) \
+                                       .annotate(group_annotated=self.get_annotated_group()) \
+                                       .annotate(date=self.get_annotated_date())
+
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        self.assertEqual([1, 5], ids)
+
+    def test_get_id_two_groups_share_group_one_sup(self):
+        docs = AbstractResource.objects.filter(id__in=[1, 3, 5, 6]) \
+                                       .annotate(group_annotated=self.get_annotated_group()) \
+                                       .annotate(date=self.get_annotated_date())
+
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        self.assertEqual([1, 5, 6], ids)
+
+    def test_one_sup(self):
+        docs = AbstractResource.objects.filter(id__in=[6]) \
+                                       .annotate(group_annotated=self.get_annotated_group()) \
+                                       .annotate(date=self.get_annotated_date())
+
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        self.assertEqual([6], ids)
+
+    def test_get_all_resources(self):
+        docs = AbstractResource.objects.all().annotate(group_annotated=self.get_annotated_group()) \
+                                             .annotate(date=self.get_annotated_date())
+        mixin = FRDocGroupingMixin()
+        ids = mixin.get_final_ids(docs)
+        ids.sort()
+        self.assertEqual([1, 4, 5, 6], ids)

--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -102,30 +102,24 @@ class FRDocGroupingMixin:
         return context
 
     def get_final_ids(self, id_query):
-        fr_grouping = self.request.GET.get("fr_grouping", "true").lower() == "true"
-        if fr_grouping:
-            fr_groups = []
-            ids = []
+        fr_groups = []
+        ids = []
 
-            for i in id_query:
-                if i.group_annotated not in fr_groups:
-                    fr_groups.append(i.group_annotated)
-                # Supplemental content either is none or negative on group annotated. Those must be on the list if requested for
-                # abstract resource
-                if i.group_annotated is None or i.group_annotated < 0:
-                    ids.append(i.id)
+        for i in id_query:
+            if i.group_annotated is None or i.group_annotated < 0:
+                ids.append(i.id)
+            elif i.group_annotated not in fr_groups:
+                fr_groups.append(i.group_annotated)
 
-            #  This uses a subquery  to get the latest fr_document ID for the fr groups and uses that in place of the original
-            #  ID found.
-            if fr_groups:
-                newest = FederalRegisterDocument.objects.filter(group_id=OuterRef('pk')).order_by('-date')
-                groups = FederalRegisterDocumentGroup.objects\
-                    .annotate(newest_doc=Subquery(newest.values('id')[:1]))\
-                    .filter(id__in=fr_groups)\
-                    .values_list('newest_doc', flat=True)
-                ids = list(groups) + ids
-        else:
-            ids = super().get_final_ids(id_query)
+        #  This uses a subquery  to get the latest fr_document ID for the fr groups and uses that in place of the original
+        #  ID found.
+        if fr_groups:
+            newest = FederalRegisterDocument.objects.filter(group_id=OuterRef('pk')).order_by('-date')
+            groups = FederalRegisterDocumentGroup.objects\
+                .annotate(newest_doc=Subquery(newest.values('id')[:1]))\
+                .filter(id__in=fr_groups)\
+                .values_list('newest_doc', flat=True)
+            ids = list(groups) + ids
         return ids
 
 
@@ -206,33 +200,34 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
                     annotations[f"{model}_{field}_headline"] = self.make_headline(f"{model}__{field}", search_query, search_type)
         return annotations
 
-    def get_final_ids(self, id_query):
-        return [i[0] for i in id_query.values_list("id", "group_annotated")]
-
     def get_queryset(self):
         locations = self.request.GET.getlist("locations")
         categories = self.request.GET.getlist("categories")
         search_query = self.request.GET.get("q")
         sort_method = self.request.GET.get("sort")
+        fr_grouping = self.request.GET.get("fr_grouping", "true").lower() == "true"
 
-        id_query = self.model.objects\
-                       .filter(approved=True)\
-                       .annotate(group_annotated=self.get_annotated_group())
+        query = self.model.objects\
+                    .filter(approved=True)\
+                    .annotate(group_annotated=self.get_annotated_group())
 
         q_obj = self.get_location_filter(locations)
+
         if q_obj:
-            id_query = id_query.filter(q_obj)
+            query = query.filter(q_obj)
 
         if categories:
-            id_query = id_query.filter(category__id__in=categories)
+            query = query.filter(category__id__in=categories)
 
-        ids = self.get_final_ids(id_query)
+        if fr_grouping:
+            ids = self.get_final_ids(query)
+            query = self.model.objects.filter(id__in=ids)
 
         annotations = {}
         locations_prefetch = AbstractLocation.objects.all().select_subclasses()
         category_prefetch = AbstractCategory.objects.all().select_subclasses().select_related("subcategory__parent")\
                                             .contains_fr_docs()
-        query = self.model.objects.filter(id__in=ids).select_subclasses().prefetch_related(
+        query = query.select_subclasses().prefetch_related(
             Prefetch("locations", queryset=locations_prefetch),
             Prefetch("category", queryset=category_prefetch),
             Prefetch("related_resources", AbstractResource.objects.all().select_subclasses().prefetch_related(


### PR DESCRIPTION
Resolves # EREGCSC-1666

**Description-**

Increase speed for  abstract resource querysets by eliminating a bunch of fluff used for calculating fr_groups when not necessary.

**This pull request changes...**

- Search for supplementalcontent/federalregisterdocuments is much faster.  Less than about 2 seconds.
- Added a few unit test that check that the filtering for resources is working correctly for fr group.  This test the function within the mixin not the queryset.
- Fixed a unit test that failed after the v2 conversion(just had to change a line to point to correct file)
- Add a  command for python.shell.  "make python.shell".  will open the python terminal for the application for testing.

**Steps to manually verify this change...**

1. Home page resources should load correctly.
2. Resources page, resources should load correctly.
3. Make a search, resources for search should pull up fast and correctly.
4.  Run "make python.unittest", all test should pass
5. Run python.shell.  Python terminal will pull up.

