### PR TITLE
EREGCSC-1780 Enable new FR documents to be automatically approved

### DIFF
--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -123,7 +123,7 @@ class FederalRegisterDocumentCreateSerializer(serializers.Serializer):
     docket_numbers = serializers.ListField(child=serializers.CharField())
     document_number = serializers.CharField(allow_blank=True, allow_null=True)
     date = serializers.CharField(allow_blank=True, allow_null=True)
-    approved = serializers.BooleanField(required=False, default=False)
+    approved = serializers.BooleanField(required=False, default=True)
     id = serializers.CharField(required=False)
     doc_type = serializers.CharField(required=False, allow_null=True, allow_blank=True)
 


### PR DESCRIPTION
Resolves #1780

**Description-**

We want new Federal Register documents to be automatically approved as the FR parser has proven to be reliable enough.

**This pull request changes...**

- Incoming FR docs get approved automatically

**Steps to manually verify this change...**

1. Locally, run the FR parser on a clean database
2. Verify in the admin panel that the docs that came in are approved

