### PR TITLE
EREGCSC-1708 -- fix prod cypress failures

### DIFF
--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -10,7 +10,8 @@
         >
             <jump-to
                 slot="jump-to"
-                apiurl="{{ API_BASE }}"
+                api-url="{{ API_BASE }}"
+                home-url="{% url 'homepage' %}"
             ></jump-to>
             <header-links
                 slot="links"

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -17,7 +17,8 @@
         >
             <jump-to
                 slot="jump-to"
-                apiurl="{{ API_BASE }}"
+                api-url="{{ API_BASE }}"
+                home-url="{% url 'homepage' %}"
             ></jump-to>
             <header-links
                 slot="links"

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -17,7 +17,8 @@
                 slot="jump-to"
                 part="{{ part }}"
                 title="{{ title }}"
-                apiurl="{{ API_BASE }}"
+                api-url="{{ API_BASE }}"
+                home-url="{% url 'homepage' %}"
             ></jump-to>
             <header-links
                 slot="links"

--- a/solution/backend/regulations/templates/regulations/regulation_landing.html
+++ b/solution/backend/regulations/templates/regulations/regulation_landing.html
@@ -14,7 +14,8 @@
                 slot="jump-to"
                 part="{{ part }}"
                 title="{{ title }}"
-                apiurl="{{ API_BASE }}"
+                api-url="{{ API_BASE }}"
+                home-url="{% url 'homepage' %}"
             ></jump-to>
             <header-links
                 slot="links"

--- a/solution/ui/regulations/eregs-vite/src/components/JumpTo.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/JumpTo.vue
@@ -69,7 +69,7 @@ export default {
     name: "JumpTo",
 
     props: {
-        apiurl: {
+        apiUrl: {
             type: String,
             required: true,
         },
@@ -82,6 +82,10 @@ export default {
             type: String,
             required: false,
             default: "",
+        },
+        homeUrl: {
+            type: String,
+            default: "/",
         },
     },
     data() {
@@ -96,16 +100,12 @@ export default {
             isActive: false,
             parts: [],
             link: "",
-            base:
-                import.meta.env.VITE_ENV && import.meta.env.VITE_ENV !== "prod"
-                    ? `/${import.meta.env.VITE_ENV}`
-                    : "",
         };
     },
 
     async created() {
         // When title 45 or another title is added uncomment line below, and remove the hardcoded
-        // this.titles = await getTitles(this.apiurl);
+        // this.titles = await getTitles(this.apiUrl);
         this.titles = ["42"];
 
         if (this.titles.length === 1) {
@@ -144,11 +144,11 @@ export default {
 
     methods: {
         async getParts(title) {
-            const partsList = await getParts(title, this.apiurl);
+            const partsList = await getParts(title, this.apiUrl);
             this.filteredParts = partsList.map((part) => part.name);
         },
         getLink(e) {
-            let link = `${this.base}/goto/?title=${this.selectedTitle}&part=${this.selectedPart}`;
+            let link = `${this.homeUrl}goto/?title=${this.selectedTitle}&part=${this.selectedPart}`;
             if (this.selectedSection !== "") {
                 link += `&section=${this.selectedSection}&-version='latest'`;
             }

--- a/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResultsItem.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResultsItem.vue
@@ -56,7 +56,7 @@ export default {
                     ? `?q=${uniqTermsArray.join(",")}`
                     : "";
 
-            return `${base}/${result.part_title}/${result.label[0]}/${
+            return `${base}${result.part_title}/${result.label[0]}/${
                 result.label[1]
             }/${result.date}/${highlightParams}#${result.label.join("-")}`;
         },

--- a/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/resources/ResourcesResults.vue
@@ -133,15 +133,15 @@ export default {
 
             // early return if related regulation is a subpart and not a section
             if (type.toLowerCase() === "subpart") {
-                return `${base}/${title}/${part}/Subpart-${subpart_id}/${partDate}`;
+                return `${base}${title}/${part}/Subpart-${subpart_id}/${partDate}`;
             }
             const partObj = partsList.find((parts) => parts.name == part);
             const subpart = partObj?.sections?.[section_id];
 
             // todo: Figure out which no subpart sections are invalid and which are orphans
             return subpart
-                ? `${base}/${title}/${part}/Subpart-${subpart}/${partDate}#${part}-${section_id}`
-                : `${base}/${title}/${part}/${partDate}#${part}-${section_id}`;
+                ? `${base}${title}/${part}/Subpart-${subpart}/${partDate}#${part}-${section_id}`
+                : `${base}${title}/${part}/${partDate}#${part}-${section_id}`;
         },
     },
 };

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -10,7 +10,7 @@
         <header id="header" class="sticky">
             <HeaderComponent :home-url="homeUrl">
                 <template #jump-to>
-                    <JumpTo />
+                    <JumpTo :home-url="homeUrl"/>
                 </template>
                 <template #links>
                     <HeaderLinks

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -10,7 +10,7 @@
         <header id="header" class="sticky">
             <HeaderComponent :home-url="homeUrl">
                 <template #jump-to>
-                    <JumpTo />
+                    <JumpTo :home-url="homeUrl"/>
                 </template>
                 <template #links>
                     <HeaderLinks

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -201,6 +201,10 @@ export default {
             type: String,
             default: "/about/",
         },
+        apiUrl: {
+            type: String,
+            default: "/v3/",
+        },
         homeUrl: {
             type: String,
             default: "/",
@@ -218,6 +222,8 @@ export default {
     beforeCreate() {},
 
     async created() {
+        console.log("this.apiUrl", this.apiUrl);
+        console.log("this.homeUrl", this.homeUrl);
         if (this.searchQuery) {
             await Promise.allSettled([
                 this.getPartLastUpdatedDates(),

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -57,7 +57,7 @@
                     </div>
                     <template v-if="!regsLoading">
                         <RegResults
-                            :base="base"
+                            :base="homeUrl"
                             :results="regResults"
                             :query="searchQuery"
                         >
@@ -95,7 +95,7 @@
                     </div>
                     <template v-if="!resourcesLoading">
                         <ResourcesResults
-                            :base="base"
+                            :base="homeUrl"
                             :count="resourcesResults.length"
                             :parts-last-updated="partsLastUpdated"
                             :parts-list="partsList"
@@ -222,8 +222,6 @@ export default {
     beforeCreate() {},
 
     async created() {
-        console.log("this.apiUrl", this.apiUrl);
-        console.log("this.homeUrl", this.homeUrl);
         if (this.searchQuery) {
             await Promise.allSettled([
                 this.getPartLastUpdatedDates(),
@@ -246,10 +244,6 @@ export default {
     },
     data() {
         return {
-            base:
-                import.meta.env.VITE_ENV && import.meta.env.VITE_ENV !== "prod"
-                    ? `/${import.meta.env.VITE_ENV}`
-                    : "",
             pageSize: 50,
             regsLoading: true,
             resourcesLoading: true,


### PR DESCRIPTION
Resolves [EREGCSC-1708](https://jiraent.cms.gov/browse/EREGCSC-1708)

**Description**
Our unique production environment has two URLs that can cause headaches for tests and api calls.  This PR will attempt to mitigate these issues to cause fewer headaches.

**This pull request changes:**

- Removed complicated and brittle logic that determines the proper `base` URL on the front end
- Pass in `homepage` URL from Django instead, which should always just know if the URL for the site has a subdirectory or not

**Steps to manually verify this change:**

1. Build locally and make sure the Jump To in the header works from every route (`/`, `/resources`, `/search`, `/about`, ToC for a part, reader view for a subpart)
2. Build locally and make sure highlighting in a Subpart section works when visiting from the search page
3. Make sure all tests pass on experimental deployment
4. make sure all tests pass in `dev` and `val` when merged into `main`
5. make sure tests pass on `prod` when approved to deploy to `prod`
6. Visit https://regulations-pilot.cms.gov/ and make sure the Jump To in the header works from every route (`/`, `/resources`, `/search`, `/about`, ToC for a part, reader view for a subpart)
7. Visit https://regulations-pilot.cms.gov/ and make sure highlighting in a Subpart section works when visiting from the search page

