### PR TITLE
EREGCSC-1779 Searching for certain characters causes error

### DIFF
--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -108,6 +108,11 @@ class RegcoreSerializerTestCase(APITestCase):
         synonyms = dict(data)
         self.assertEqual(synonyms['synonyms'], [{'baseWord': "S2", "isActive": True}])
 
+    def test_synonyms_special_characters(self):
+        for i in ["%", "138% FPL", "138 % FPL", "\"", "\"\"", "#", ".", "..", "?"]:
+            response = self.client.get(f"/v3/synonyms?q={i}")
+            self.assertEqual(response.status_code, 200)
+
     def test_get_title_versions(self):
         response = self.client.get("/v3/title/42/versions")
         data = dict(response.data[0])

--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -99,11 +99,11 @@ class RegcoreSerializerTestCase(APITestCase):
         self.assertEqual(x['id'], parts[0]['id'])
 
     def test_get_synonyms(self):
-        response = self.client.get("/v3/synonym/S2")
+        response = self.client.get("/v3/synonyms?q=S2")
         data = dict(response.data[0])
         synonyms = dict(data)
         self.assertEqual(synonyms['synonyms'], [{'baseWord': "Syn1", "isActive": True}])
-        response = self.client.get("/v3/synonym/Syn1")
+        response = self.client.get("/v3/synonyms?q=Syn1")
         data = dict(response.data[0])
         synonyms = dict(data)
         self.assertEqual(synonyms['synonyms'], [{'baseWord': "S2", "isActive": True}])
@@ -118,7 +118,7 @@ class RegcoreSerializerTestCase(APITestCase):
         data = response.data
         self.assertEqual(data, [date(2020, 6, 30)])
 
-    @patch("regcore.v3views.history.get_year_data")
+    @patch("regcore.views.history.get_year_data")
     def test_get_historical_sections(self, get_year_data):
         get_year_data.return_value = httpx.Response(status_code=400)
         data = self.client.get("/v3/title/42/part/433/history/section/50").data

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -69,7 +69,7 @@ urlpatterns = [
         path("part", parser.PartUploadViewSet.as_view({
             "put": "update",
         })),
-        path("synonym/<path:synonym>", synonyms.SynonymViewSet.as_view({
+        path("synonyms", synonyms.SynonymViewSet.as_view({
             "get": "list",
         })),
         path("parser_config", parser.ParserConfigurationViewSet.as_view({

--- a/solution/backend/regcore/views/synonyms.py
+++ b/solution/backend/regcore/views/synonyms.py
@@ -1,18 +1,18 @@
 from rest_framework import viewsets
 from drf_spectacular.utils import extend_schema
 
-from .utils import OpenApiPathParameter
+from common.api import OpenApiQueryParameter
 from regcore.serializers.synonyms import SynonymsSerializer
 from regcore.search.models import Synonym
 
 
 @extend_schema(
     description="Retrieve relevant synonyms for a word or phrase",
-    parameters=[OpenApiPathParameter("synonym", "Word you are looking for a synonym for.", str)]
+    parameters=[OpenApiQueryParameter("synonym", "Word you are looking for a synonym for.", str, True)]
 )
 class SynonymViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = SynonymsSerializer
 
     def get_queryset(self):
-        syn = self.kwargs.get("synonym")
+        syn = self.request.GET.get("q")
         return Synonym.objects.filter(baseWord__iexact=syn)

--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -18,7 +18,7 @@ const API_ENDPOINTS_V3 = [
     `/v3/resources/locations/sections`,
     `/v3/resources/locations/subparts`,
     `/v3/resources/supplemental_content`,
-    `/v3/synonym/${SYNONYM}`,
+    `/v3/synonyms?q=${SYNONYM}`,
     `/v3/title/${TITLE}/part/${PART}/history/section/${SECTION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/section/${SECTION}`,

--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -42,7 +42,7 @@ const API_ENDPOINTS_V3 = [
 describe("API testing", () => {
     API_ENDPOINTS_V3.forEach(endpoint => {
         it(`sends GET request to ${endpoint} and checks for a 200 response`, () => {
-            cy.request(encodeURIComponent(endpoint)).as("request");
+            cy.request(endpoint).as("request");
             cy.get("@request").then((response) => {
                 cy.log(`${endpoint} - ${response.status}`);
                 expect(response.status).to.eq(200);
@@ -53,7 +53,7 @@ describe("API testing", () => {
 
 describe("Synonyms endpoint special character testing", () => {
     SPECIAL_CHARACTERS.forEach(character => {
-        const endpoint = `${SYNONYMS_ENDPOINT}${character}`;
+        const endpoint = SYNONYMS_ENDPOINT + encodeURIComponent(character);
         it(`sends GET request to ${endpoint} and checks for a 200 response`, () => {
             cy.request(endpoint).as("request");
             cy.get("@request").then((response) => {

--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -7,7 +7,7 @@ const SYNONYM = "synonym";
 const SEARCH_TERM = "a+search+term";
 
 const SYNONYMS_ENDPOINT = "/v3/synonyms?q=";
-const SPECIAL_CHARACTERS = ["%", "138% FPL", "138 % FPL", "\"", "\"\"", "#", ".", "..", "?"]
+const SPECIAL_CHARACTERS = ["\%", "138\% FPL", "138 \% FPL", "\"", "\"\"", "#", ".", "..", "?"]
 
 const API_ENDPOINTS_V3 = [
     `/v3/ecfr_parser_result/${TITLE}`,

--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -6,6 +6,9 @@ const VERSION = "latest";
 const SYNONYM = "synonym";
 const SEARCH_TERM = "a+search+term";
 
+const SYNONYMS_ENDPOINT = "/v3/synonyms?q=";
+const SPECIAL_CHARACTERS = ["%", "138% FPL", "138 % FPL", "\"", "\"\"", "#", ".", "..", "?"]
+
 const API_ENDPOINTS_V3 = [
     `/v3/ecfr_parser_result/${TITLE}`,
     `/v3/parser_config`,
@@ -18,7 +21,7 @@ const API_ENDPOINTS_V3 = [
     `/v3/resources/locations/sections`,
     `/v3/resources/locations/subparts`,
     `/v3/resources/supplemental_content`,
-    `/v3/synonyms?q=${SYNONYM}`,
+    `${SYNONYMS_ENDPOINT}${SYNONYM}`,
     `/v3/title/${TITLE}/part/${PART}/history/section/${SECTION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/section/${SECTION}`,
@@ -45,5 +48,18 @@ describe("API testing", () => {
                 expect(response.status).to.eq(200);
             });
         });
+    });
+});
+
+describe("Synonyms endpoint special character testing", () => {
+    SPECIAL_CHARACTERS.forEach(character => {
+        const endpoint = `${SYNONYMS_ENDPOINT}${character}`;
+        it(`sends GET request to ${endpoint} and checks for a 200 response`, () => {
+            cy.request(endpoint).as("request");
+            cy.get("@request").then((response) => {
+                cy.log(`${endpoint} - ${response.status}`);
+                expect(response.status).to.eq(200);
+            });
+        })
     });
 });

--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -7,7 +7,7 @@ const SYNONYM = "synonym";
 const SEARCH_TERM = "a+search+term";
 
 const SYNONYMS_ENDPOINT = "/v3/synonyms?q=";
-const SPECIAL_CHARACTERS = ["\%", "138\% FPL", "138 \% FPL", "\"", "\"\"", "#", ".", "..", "?"]
+const SPECIAL_CHARACTERS = ["%", "138% FPL", "138 % FPL", "\"", "\"\"", "#", ".", "..", "?"]
 
 const API_ENDPOINTS_V3 = [
     `/v3/ecfr_parser_result/${TITLE}`,
@@ -42,7 +42,7 @@ const API_ENDPOINTS_V3 = [
 describe("API testing", () => {
     API_ENDPOINTS_V3.forEach(endpoint => {
         it(`sends GET request to ${endpoint} and checks for a 200 response`, () => {
-            cy.request(endpoint).as("request");
+            cy.request(encodeURIComponent(endpoint)).as("request");
             cy.get("@request").then((response) => {
                 cy.log(`${endpoint} - ${response.status}`);
                 expect(response.status).to.eq(200);

--- a/solution/ui/regulations/eregs-vite/src/utilities/api.js
+++ b/solution/ui/regulations/eregs-vite/src/utilities/api.js
@@ -433,7 +433,7 @@ const getSectionsForPart = async (title, part) => httpApiGet(`title/${title}/par
 
 const getSubpartTOC = async (title, part, subPart) => httpApiGet(`title/${title}/part/${part}/version/latest/subpart/${subPart}/toc`)
 
-const getSynonyms = async(query) => httpApiGet(`synonym/${query}`);
+const getSynonyms = async(query) => httpApiGet(`synonyms?q=${query}`);
 
 /**
  * @param {string} [apiUrl] - API base url passed in from Django template when component is used in Django template


### PR DESCRIPTION
Resolves #1779

**Description-**

Searching for some characters caused search to fail with an error popup. This was due to the synonyms endpoint using a path parameter (e.g. `/v3/synonym/X`) which prevented special characters from being encoded properly. (E.g. `%` should be encoded to `%25` but wasn't). This PR changes it to use a query parameter (`/v3/synonyms?q=X`) which is encoded properly.

**This pull request changes...**

- Synonyms endpoint uses query parameter
- Cypress test updated
- api.js file updated

**Steps to manually verify this change...**

1. Visit the experimental deploy and search for the following: `%`, `138% FPL`, `138 % FPL`, `"`, `""`, `#`, `.`, `..` , `?` 
2. Verify for each of the above, there are no errors


