### PR TITLE
Syncing up github actions

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -256,7 +256,7 @@ jobs:
           state: open
       # Notify github that this is deployed and ready to look at
       - name: Create deployment comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         env:
           django_url: ${{ needs.deploy-django.outputs.url }}
         with:

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: 18.14
       # setup python
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
           python-version: '3.8'
@@ -58,7 +58,7 @@ jobs:
           popd
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
@@ -100,13 +100,13 @@ jobs:
         with:
           node-version: 18.14
       # setup python
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
           python-version: '3.8'
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
@@ -170,7 +170,7 @@ jobs:
           popd
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
@@ -212,7 +212,7 @@ jobs:
           go-version: '^1.16' # The Go version to download (if necessary) and use.
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.14
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
           cd ..
           popd
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/load-regulations.yml
+++ b/.github/workflows/load-regulations.yml
@@ -21,14 +21,14 @@ jobs:
       name: ${{ matrix.environment }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: false
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '15.11.0'
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/load-regulations.yml
+++ b/.github/workflows/load-regulations.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: false
       - uses: actions/setup-node@v3
         with:
-          node-version: '15.11.0'
+          node-version: 18.14
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/load-supp-content.yml
+++ b/.github/workflows/load-supp-content.yml
@@ -21,11 +21,11 @@ jobs:
       name: ${{ github.event.inputs.env }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: false
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Setup Go
     - name: Setup Go

--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -15,9 +15,9 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
       - name: Install dependencies

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -28,7 +28,7 @@ jobs:
       # Setup Node
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18.14
       # Setup Python
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -22,20 +22,20 @@ jobs:
           PR: ${{ github.event.number }}
         run: echo "Your PR is ${PR}"
       # Checkout the code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       # Setup Node
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
       # Setup Python
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -12,17 +12,17 @@ jobs:
   remove:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Configure AWS credentials for GitHub Actions
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18.14
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'


### PR DESCRIPTION
Resolves #

**Description-**

Some of the steps were using different versions of github actions.  All processes should work fine.  We updated node for other steps but missed a couple and some are outdated using deprecated github commands and newer versions removed that.

**This pull request changes...**

- Set output is no longer used.  Some of the older libraries used it still

**Steps to manually verify this change...**

1. Close the PR.  Removal step should most likely work properly.  There is a weird bug there that might stop it but it should work if it since it was fully built.
2. Reopen the PR.  The build steps should all execute(make sure the removal step is finished running first)


