### PR TITLE
Hotfix: search/resources links to reg text

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResultsItem.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/reg_search/RegResultsItem.vue
@@ -56,7 +56,7 @@ export default {
                     ? `?q=${uniqTermsArray.join(",")}`
                     : "";
 
-            return `${base}/${result.title}/${result.part_number}/${
+            return `${base}${result.title}/${result.part_number}/${
                 result.section_number
             }/${result.date}/${highlightParams}#${result.part_number}-${result.section_number}`;
         },


### PR DESCRIPTION
Resolves bug introduced in [EREGCSC-1708](https://jiraent.cms.gov/browse/EREGCSC-1708)

**Description**

A few link-creating methods in deeply nested Vue components were not updated to handle the new Django-created baseUrl that is now used as of EREGCSC-1708

**This pull request changes**

- TBD

**Steps to manually verify this change**

1. TBD

