### PR TITLE
Hotfix: add feedback banner and header back to error pages

### DIFF
--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -3,6 +3,29 @@
 
 {% block title %}Page Not Found | Medicaid & CHIP eRegulations {% endblock %}
 
+{% block header %}
+    <header id="header" class="sticky">
+        <header-component
+            home-url="{% url 'homepage' %}"
+        >
+            <jump-to
+                slot="jump-to"
+                api-url="{{ API_BASE }}"
+                home-url="{% url 'homepage' %}"
+            ></jump-to>
+            <header-links
+                slot="links"
+                about-url="{% url 'about' %}"
+                resources-url="{% url 'resources' %}"
+            ></header-links>
+            <header-search
+                slot="search"
+                search-url="{% url 'search' %}"
+            ></header-search>
+        </header-component>
+    </header>
+{% endblock %}
+
 {% block body %}
     <main class="error-page">
         <div class="error-left">
@@ -12,4 +35,9 @@
         </div>
         <img class="error-image" src="{% static 'images/browser.svg' %}" />
     </main>
+{% endblock %}
+
+{% block post_footer %}
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Resolves bug introduced in [EREGCSC-1547](https://jiraent.cms.gov/browse/EREGCSC-1547) -- global header

**Description**

Error page templates (404, 500, etc) did not have feedback banner or header.

**This pull request changes**

- updated `error_base` template to include everything it needs for a working feedback banner and header.

**Steps to manually verify this change**

1. Go to a page that would trigger a 404 error and make sure it has a header and feedback banner that works
   - ex: https://qx0atg8izb.execute-api.us-east-1.amazonaws.com/dev751/asdfas

