### PR TITLE
Add Cypress test suite for Error Page

### DIFF
--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -33,7 +33,7 @@
             <h1 class="error-header">{% block error_header %}{% endblock %}</h1>
             {% block error_body %}{% endblock %}
         </div>
-        <img class="error-image" src="{% static 'images/browser.svg' %}" />
+        <img class="error-image" src="{% static 'images/browser.svg' %}" alt=""/>
     </main>
 {% endblock %}
 

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -1,0 +1,101 @@
+const mainContentId = "#main-content";
+
+describe("Error page", { scrollBehavior: "center" }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.intercept("/**", (req) => {
+            req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
+        });
+    });
+
+    it("loads as a 404 page when server returns a 404 error", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/asdf");
+        cy.injectAxe();
+        cy.get(".error-code").should("have.text", "Error 404");
+        cy.get(".error-header").should(
+            "have.text",
+            "Sorry, the page you were looking for doesn't exist."
+        );
+        cy.checkAccessibility();
+    });
+
+    it("has a flash banner at the top with a link to a feedback survey", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/asdf");
+        cy.get("div.flash-banner").should("be.visible");
+
+        cy.get("div.flash-banner .greeting")
+            .invoke("text")
+            // remove the space char
+            .invoke("replace", /\u00a0/g, " ")
+            .should("eq", "We welcome questions and suggestions — ");
+
+        cy.get("div.flash-banner a").should("have.text", "give us feedback.");
+    });
+
+    it("shows feedback form in modal when clicking feedback link in flash banner", () => {
+        // feedback link is in banner
+        cy.viewport("macbook-15");
+        cy.visit("/asdf");
+        // modal doesn't exist
+        cy.get("div.blocking-modal-content").should("not.be.visible");
+        // click link
+        cy.get("div.flash-banner a")
+            .should("have.text", "give us feedback.")
+            .click({ force: true });
+        // modal exists
+        cy.get("div.blocking-modal-content").should("be.visible");
+        // make sure background is right color etc
+        cy.get("div.blocking-modal").should(
+            "have.css",
+            "background-color",
+            "rgba(0, 0, 0, 0.8)"
+        );
+        // a11y
+        cy.injectAxe();
+        cy.checkAccessibility();
+        // query iframe source to make sure it's google forms
+        cy.get(".blocking-modal-content iframe#iframeEl")
+            .should("have.attr", "src")
+            .then((src) => {
+                expect(src.includes("docs.google.com/forms")).to.be.true;
+            });
+        // click close
+        cy.get("button.close-modal")
+            .should("be.visible")
+            .click({ force: true });
+        // modal doesn't exist again
+        cy.get("div.blocking-modal-content").should("not.be.visible");
+    });
+
+    it("jumps to a regulation Part using the jump-to select", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/");
+        cy.get("#jumpToPart").select("433");
+        cy.get("#jumpBtn").click({ force: true });
+
+        cy.url().should("eq", Cypress.config().baseUrl + "/42/433/#433");
+    });
+
+    it("jumps to a regulation Part section using the section number text input", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/asdf");
+        cy.get("#jumpToPart").should("be.visible").select("433");
+        cy.get("#jumpToSection").type("40");
+        cy.get("#jumpBtn").click({ force: true });
+
+        cy.url().should(
+            "eq",
+            Cypress.config().baseUrl + "/42/433/Subpart-A/2021-03-01/#433-40"
+        );
+    });
+
+    it("allows a user to go back to the homepage by clicking the top left link", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/asdf");
+        cy.contains("Medicaid & CHIP eRegulations").click();
+
+        cy.url().should("eq", Cypress.config().baseUrl + "/");
+    });
+});

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -10,7 +10,10 @@ describe("Error page", { scrollBehavior: "center" }, () => {
 
     it("loads as a 404 page when server returns a 404 error", () => {
         cy.viewport("macbook-15");
-        cy.visit("/asdf");
+        cy.request({ url: "/404", failOnStatusCode: false })
+            .its("status")
+            .should("equal", 404);
+        cy.visit('/404', {failOnStatusCode: false})
         cy.injectAxe();
         cy.get(".error-code").should("have.text", "Error 404");
         cy.get(".error-header").should(
@@ -22,7 +25,10 @@ describe("Error page", { scrollBehavior: "center" }, () => {
 
     it("has a flash banner at the top with a link to a feedback survey", () => {
         cy.viewport("macbook-15");
-        cy.visit("/asdf");
+        cy.request({ url: "/404", failOnStatusCode: false })
+            .its("status")
+            .should("equal", 404);
+        cy.visit('/404', {failOnStatusCode: false})
         cy.get("div.flash-banner").should("be.visible");
 
         cy.get("div.flash-banner .greeting")
@@ -37,7 +43,10 @@ describe("Error page", { scrollBehavior: "center" }, () => {
     it("shows feedback form in modal when clicking feedback link in flash banner", () => {
         // feedback link is in banner
         cy.viewport("macbook-15");
-        cy.visit("/asdf");
+        cy.request({ url: "/404", failOnStatusCode: false })
+            .its("status")
+            .should("equal", 404);
+        cy.visit('/404', {failOnStatusCode: false})
         // modal doesn't exist
         cy.get("div.blocking-modal-content").should("not.be.visible");
         // click link
@@ -80,7 +89,10 @@ describe("Error page", { scrollBehavior: "center" }, () => {
 
     it("jumps to a regulation Part section using the section number text input", () => {
         cy.viewport("macbook-15");
-        cy.visit("/asdf");
+        cy.request({ url: "/404", failOnStatusCode: false })
+            .its("status")
+            .should("equal", 404);
+        cy.visit('/404', {failOnStatusCode: false})
         cy.get("#jumpToPart").should("be.visible").select("433");
         cy.get("#jumpToSection").type("40");
         cy.get("#jumpBtn").click({ force: true });
@@ -93,7 +105,10 @@ describe("Error page", { scrollBehavior: "center" }, () => {
 
     it("allows a user to go back to the homepage by clicking the top left link", () => {
         cy.viewport("macbook-15");
-        cy.visit("/asdf");
+        cy.request({ url: "/404", failOnStatusCode: false })
+            .its("status")
+            .should("equal", 404);
+        cy.visit('/404', {failOnStatusCode: false})
         cy.contains("Medicaid & CHIP eRegulations").click();
 
         cy.url().should("eq", Cypress.config().baseUrl + "/");

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -90,7 +90,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.url().should("eq", Cypress.config().baseUrl + "/42/433/#433");
     });
 
-    it("jumps to a regulation Part section using the section number text input", () => {
+    it("NEW -- jumps to a regulation Part section using the section number text input", () => {
         cy.viewport("macbook-15");
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -15,9 +15,9 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .should("equal", 404);
         cy.visit('/404', {failOnStatusCode: false})
         cy.injectAxe();
-        cy.get(".error-code").should("have.text", "Error 404");
+        cy.get(".error-code").should("include", "404");
         cy.get(".error-header").should(
-            "have.text",
+            "include",
             "Sorry, the page you were looking for doesn't exist."
         );
         cy.checkAccessibility();

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -1,5 +1,3 @@
-const mainContentId = "#main-content";
-
 describe("Error page", { scrollBehavior: "center" }, () => {
     beforeEach(() => {
         cy.clearIndexedDB();

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -84,7 +84,10 @@ describe("Error page", { scrollBehavior: "center" }, () => {
 
     it("jumps to a regulation Part using the jump-to select", () => {
         cy.viewport("macbook-15");
-        cy.visit("/");
+        cy.request({ url: "/404", failOnStatusCode: false })
+            .its("status")
+            .should("equal", 404);
+        cy.visit("/404", { failOnStatusCode: false });
         cy.get("#jumpToPart").select("433");
         cy.get("#jumpBtn").click({ force: true });
 

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -13,13 +13,19 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")
             .should("equal", 404);
-        cy.visit('/404', {failOnStatusCode: false})
+        cy.visit("/404", { failOnStatusCode: false });
         cy.injectAxe();
-        cy.get(".error-code").should("include", "404");
-        cy.get(".error-header").should(
-            "include",
-            "Sorry, the page you were looking for doesn't exist."
-        );
+        cy.get(".error-code")
+            .invoke("text")
+
+            .should("include", "404");
+        cy.get(".error-header")
+
+            .invoke("text")
+            .should(
+                "include",
+                "Sorry, the page you were looking for doesn't exist."
+            );
         cy.checkAccessibility();
     });
 
@@ -28,7 +34,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")
             .should("equal", 404);
-        cy.visit('/404', {failOnStatusCode: false})
+        cy.visit("/404", { failOnStatusCode: false });
         cy.get("div.flash-banner").should("be.visible");
 
         cy.get("div.flash-banner .greeting")
@@ -46,7 +52,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")
             .should("equal", 404);
-        cy.visit('/404', {failOnStatusCode: false})
+        cy.visit("/404", { failOnStatusCode: false });
         // modal doesn't exist
         cy.get("div.blocking-modal-content").should("not.be.visible");
         // click link
@@ -92,7 +98,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")
             .should("equal", 404);
-        cy.visit('/404', {failOnStatusCode: false})
+        cy.visit("/404", { failOnStatusCode: false });
         cy.get("#jumpToPart").should("be.visible").select("433");
         cy.get("#jumpToSection").type("40");
         cy.get("#jumpBtn").click({ force: true });
@@ -108,7 +114,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")
             .should("equal", 404);
-        cy.visit('/404', {failOnStatusCode: false})
+        cy.visit("/404", { failOnStatusCode: false });
         cy.contains("Medicaid & CHIP eRegulations").click();
 
         cy.url().should("eq", Cypress.config().baseUrl + "/");

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -15,10 +15,8 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.injectAxe();
         cy.get(".error-code")
             .invoke("text")
-
             .should("include", "404");
         cy.get(".error-header")
-
             .invoke("text")
             .should(
                 "include",

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -13,9 +13,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
         cy.injectAxe();
-        cy.get(".error-code")
-            .invoke("text")
-            .should("include", "404");
+        cy.get(".error-code").invoke("text").should("include", "404");
         cy.get(".error-header")
             .invoke("text")
             .should(
@@ -102,10 +100,15 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.get("#jumpToSection").type("40");
         cy.get("#jumpBtn").click({ force: true });
 
-        cy.url().should(
-            "eq",
-            Cypress.config().baseUrl + "/42/433/Subpart-A/2021-03-01/#433-40"
-        );
+        expect(
+            Cypress.minimatch(
+                cy.url(),
+                "/42/433/Subpart-A/*/#433-40",
+                {
+                    matchBase: true,
+                }
+            )
+        ).to.be.true;
     });
 
     it("allows a user to go back to the homepage by clicking the top left link", () => {

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -100,15 +100,17 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.get("#jumpToSection").type("40");
         cy.get("#jumpBtn").click({ force: true });
 
-        expect(
-            Cypress.minimatch(
-                cy.url(),
-                "/42/433/Subpart-A/*/#433-40",
-                {
-                    matchBase: true,
-                }
-            )
-        ).to.be.true;
+        cy.url().then((urlString) => {
+            expect(
+                Cypress.minimatch(
+                    urlString,
+                    Cypress.config().baseUrl + "/42/433/Subpart-A/*/#433-40",
+                    {
+                        matchBase: false,
+                    }
+                )
+            ).to.be.true;
+        });
     });
 
     it("allows a user to go back to the homepage by clicking the top left link", () => {

--- a/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
@@ -153,10 +153,17 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.get("#jumpToSection").type("40");
         cy.get("#jumpBtn").click({ force: true });
 
-        cy.url().should(
-            "eq",
-            Cypress.config().baseUrl + "/42/433/Subpart-A/2021-03-01/#433-40"
-        );
+        cy.url().then((urlString) => {
+            expect(
+                Cypress.minimatch(
+                    urlString,
+                    Cypress.config().baseUrl + "/42/433/Subpart-A/*/#433-40",
+                    {
+                        matchBase: false,
+                    }
+                )
+            ).to.be.true;
+        });
     });
 
     it("clicks on part 430 and loads the page", () => {


### PR DESCRIPTION
Resolves error pages not having any end to end test coverage

**Description**

The header for every page on the app was recently redesigned and refactored (see [EREGCSC-1547](https://jiraent.cms.gov/browse/EREGCSC-1547) ).  Unfortunately, the Error pages did not get the updated header and for the past several days these error pages did not have a header at all.  

The header was added back to the error pages via a hotfix pull request (see [here](https://github.com/CMSgov/cmcs-eregulations/pull/751) ).

This pull request will add tests so that if header functionality or body text should change (like if the header disappears again), then the tests will fail.

**This pull request changes**

- adds new test suite for 404 error page

**Steps to manually verify this change**

1. Make sure tests pass on a hosted environment

