### PR TITLE
EREGCSC-1823 Missing results in regs search

### DIFF
--- a/solution/backend/regcore/search/migrations/0007_populate_index.py
+++ b/solution/backend/regcore/search/migrations/0007_populate_index.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+from regcore.models import Part
+
+
+def update_part(apps, schema_editor):
+    parts = Part.objects.all()
+    for part in parts:
+        part = part
+        part.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('search', '0006_delete_searchindex'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_part),
+    ]


### PR DESCRIPTION
Resolves # EREGCSC-1823

**Description-**

Certain part versions are missing in regulations search due to the index not containing all of them particularly the most recent version.  This is a data migration to just save each part as it currently is.  Whenever a part is saved it updates in the index

**This pull request changes...**

- More results will appear in serach


**Steps to manually verify this change...**

1. Pull the branch onto your local.  Run the data migrations.  Search for FMAP.  You should get more than 3 results.  
2. Cant really properly test until its in dev.  In dev search for FMAP.  Should get more results
3. In val as well should get more than 3 results
4. In prod should get part 431 appearing in search.

