### PR TITLE
EREGCSC-1825: Unit test for creating search object

### DIFF
--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/solution/backend/regcore/tests/fixtures/depth.json
+++ b/solution/backend/regcore/tests/fixtures/depth.json
@@ -1,0 +1,69 @@
+[
+	{
+		"type": "title",
+		"label": "Title 42 - Public Health",
+		"parent": [],
+		"reserved": false,
+		"identifier": [
+			"42"
+		],
+		"label_level": "Title 42",
+		"parent_type": "",
+		"descendant_range": [],
+		"label_description": "Public Health"
+	},
+	{
+		"type": "chapter",
+		"label": " Chapter IV - Centers for Medicare & Medicaid Services, Department of Health and Human Services",
+		"parent": [
+			"42"
+		],
+		"reserved": false,
+		"identifier": [
+			"IV"
+		],
+		"label_level": " Chapter IV",
+		"parent_type": "title",
+		"descendant_range": [
+			"400",
+			"699"
+		],
+		"label_description": "Centers for Medicare &amp; Medicaid Services, Department of Health and Human Services"
+	},
+	{
+		"type": "subchapter",
+		"label": "Subchapter C - Medical Assistance Programs",
+		"parent": [
+			"IV"
+		],
+		"reserved": false,
+		"identifier": [
+			"C"
+		],
+		"label_level": "Subchapter C",
+		"parent_type": "chapter",
+		"descendant_range": [
+			"430",
+			"456"
+		],
+		"label_description": "Medical Assistance Programs"
+	},
+	{
+		"type": "part",
+		"label": "Part 432 - State Personnel Administration",
+		"parent": [
+			"C"
+		],
+		"reserved": false,
+		"identifier": [
+			"432"
+		],
+		"label_level": "Part 432",
+		"parent_type": "subchapter",
+		"descendant_range": [
+			"432.1",
+			"432.55"
+		],
+		"label_description": "State Personnel Administration"
+	}
+]

--- a/solution/backend/regcore/tests/fixtures/part.json
+++ b/solution/backend/regcore/tests/fixtures/part.json
@@ -1,0 +1,56 @@
+{
+    "label": [
+        "400"
+    ],
+    "title": "PART 400 - PAYMENTS FOR SERVICES ",
+    "source": {
+        "header": "Source:",
+        "content": "fizz buzz ",
+        "node_type": ""
+    },
+    "children": [
+        {
+            "label": [
+                "400",
+                "1"
+            ],
+            "title": "§ 400.1 Purpose.",
+            "children": [
+                {
+                    "text": "fizz buzz",
+                    "label": [
+                        "400",
+                        "1"
+                    ],
+                    "node_type": "Paragraph"
+                }
+            ],
+            "node_type": "SECTION"
+        },
+        {
+            "label": [
+                "400",
+                "10"
+            ],
+            "title": "§ 400.10 stuff.",
+            "children": [
+                {
+                    "text": "some stuff",
+                    "node_type": "Paragraph"
+                }
+            ],
+            "node_type": "SECTION"
+        }
+    ],
+    "authority": {
+        "header": "Authority:",
+        "content": "42 U.S.C. 1302 and 1396r-8. ",
+        "node_type": ""
+    },
+    "node_type": "PART",
+    "editorial_note": {
+        "header": "",
+        "content": "",
+        "node_type": ""
+    }
+}

--- a/solution/backend/regcore/tests/test_models.py
+++ b/solution/backend/regcore/tests/test_models.py
@@ -4,6 +4,7 @@ from regcore.search.models import Synonym
 from regcore.search.models import create_search
 import json
 
+
 class TestRegoreModels(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/solution/backend/regcore/tests/test_models.py
+++ b/solution/backend/regcore/tests/test_models.py
@@ -2,67 +2,13 @@ from django.test import TestCase
 from regcore.models import ParserConfiguration, Part, TitleConfiguration
 from regcore.search.models import Synonym
 from regcore.search.models import create_search
-
+import json
 
 class TestRegoreModels(TestCase):
     @classmethod
     def setUpTestData(cls):
-        doc = {
-            "label": [
-                "400"
-            ],
-            "title": "PART 400 - PAYMENTS FOR SERVICES ",
-            "source": {
-                "header": "Source:",
-                "content": "fizz buzz ",
-                "node_type": ""
-            },
-            "children": [
-                {
-                    "label": [
-                        "400",
-                        "1"
-                    ],
-                    "title": "§ 400.1 Purpose.",
-                    "children": [
-                        {
-                            "text": "fizz buzz",
-                            "label": [
-                                "400",
-                                "1"
-                            ],
-                            "node_type": "Paragraph"
-                        }
-                    ],
-                    "node_type": "SECTION"
-                },
-                {
-                    "label": [
-                        "400",
-                        "10"
-                    ],
-                    "title": "§ 400.10 stuff.",
-                    "children": [
-                        {
-                            "text": "some stuff",
-                            "node_type": "Paragraph"
-                        }
-                    ],
-                    "node_type": "SECTION"
-                }
-            ],
-            "authority": {
-                "header": "Authority:",
-                "content": "42 U.S.C. 1302 and 1396r-8. ",
-                "node_type": ""
-            },
-            "node_type": "PART",
-            "editorial_note": {
-                "header": "",
-                "content": "",
-                "node_type": ""
-            }
-        }
+        with open("regcore/tests/fixtures/part.json") as f:
+            doc = json.load(f)
         structure = {"type": "title", "children": [{"type:": "part", "label": 400, "children": ["part content"]}]}
         Part.objects.create(title='42', date="2020-06-30", last_updated="2022-09-21 08:36:45.735759",
                             depth=2, structure=structure, name=400, document=doc,

--- a/solution/backend/regcore/tests/test_models.py
+++ b/solution/backend/regcore/tests/test_models.py
@@ -91,6 +91,6 @@ class TestRegoreModels(TestCase):
         part = Part.objects.get(name=400)
         searchIndexes = create_search(part, part.document, [], parent=None)
         self.assertEqual(searchIndexes[0].part_number, "400")
-        self.assertEqual(len(searchIndexes),2)
+        self.assertEqual(len(searchIndexes), 2)
         self.assertEqual(searchIndexes[1].section_number, "10")
         self.assertEqual(searchIndexes[0].section_string, "400.1")

--- a/solution/backend/regcore/tests/test_models.py
+++ b/solution/backend/regcore/tests/test_models.py
@@ -1,14 +1,71 @@
 from django.test import TestCase
 from regcore.models import ParserConfiguration, Part, TitleConfiguration
 from regcore.search.models import Synonym
+from regcore.search.models import create_search
 
 
 class TestRegoreModels(TestCase):
     @classmethod
     def setUpTestData(cls):
+        doc = {
+            "label": [
+                "400"
+            ],
+            "title": "PART 400 - PAYMENTS FOR SERVICES ",
+            "source": {
+                "header": "Source:",
+                "content": "fizz buzz ",
+                "node_type": ""
+            },
+            "children": [
+                {
+                    "label": [
+                        "400",
+                        "1"
+                    ],
+                    "title": "§ 400.1 Purpose.",
+                    "children": [
+                        {
+                            "text": "fizz buzz",
+                            "label": [
+                                "400",
+                                "1"
+                            ],
+                            "node_type": "Paragraph"
+                        }
+                    ],
+                    "node_type": "SECTION"
+                },
+                {
+                    "label": [
+                        "400",
+                        "10"
+                    ],
+                    "title": "§ 400.10 stuff.",
+                    "children": [
+                        {
+                            "text": "some stuff",
+                            "node_type": "Paragraph"
+                        }
+                    ],
+                    "node_type": "SECTION"
+                }
+            ],
+            "authority": {
+                "header": "Authority:",
+                "content": "42 U.S.C. 1302 and 1396r-8. ",
+                "node_type": ""
+            },
+            "node_type": "PART",
+            "editorial_note": {
+                "header": "",
+                "content": "",
+                "node_type": ""
+            }
+        }
         structure = {"type": "title", "children": [{"type:": "part", "label": 400, "children": ["part content"]}]}
         Part.objects.create(title='42', date="2020-06-30", last_updated="2022-09-21 08:36:45.735759",
-                            depth=2, structure=structure, name=400, document={"document": "test"},
+                            depth=2, structure=structure, name=400, document=doc,
                             depth_stack={"depthstack": "stuff"})
         TitleConfiguration.objects.create(title=50, subchapters="c, d", parts="40, 50",
                                           parser_config=ParserConfiguration.objects.get(id=1))
@@ -29,3 +86,11 @@ class TestRegoreModels(TestCase):
     def test_Synonym_create(self):
         s1 = Synonym.objects.get(baseWord="Syn1")
         self.assertTrue(s1.synonyms.exists())
+
+    def test_create_search(self):
+        part = Part.objects.get(name=400)
+        searchIndexes = create_search(part, part.document, [], parent=None)
+        self.assertEqual(searchIndexes[0].part_number, "400")
+        self.assertEqual(len(searchIndexes),2)
+        self.assertEqual(searchIndexes[1].section_number, "10")
+        self.assertEqual(searchIndexes[0].section_string, "400.1")


### PR DESCRIPTION
Resolves #EREGCSC-1825

**Description-**

Adds a unit test for creating the search objects

None just added a unit test

**Steps to manually verify this change...**

Run "make python.unittest" all test should pass
