### PR TITLE
EREGCSC-1829 Duplicate groups in sidebar rules + unapproved items showing

### DIFF
--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -230,7 +230,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         query = query.select_subclasses().prefetch_related(
             Prefetch("locations", queryset=locations_prefetch),
             Prefetch("category", queryset=category_prefetch),
-            Prefetch("related_resources", AbstractResource.objects.all().select_subclasses().prefetch_related(
+            Prefetch("related_resources", AbstractResource.objects.filter(approved=True).select_subclasses().prefetch_related(
                 Prefetch("locations", queryset=locations_prefetch),
                 Prefetch("category", queryset=category_prefetch),
             )),

--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -205,7 +205,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         categories = self.request.GET.getlist("categories")
         search_query = self.request.GET.get("q")
         sort_method = self.request.GET.get("sort")
-        fr_grouping = self.request.GET.get("fr_grouping", "false").lower() == "true"
+        fr_grouping = self.request.GET.get("fr_grouping", "true").lower() == "true"
 
         query = self.model.objects\
                     .filter(approved=True)\

--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -219,7 +219,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         if categories:
             query = query.filter(category__id__in=categories)
 
-        if fr_grouping:
+        if fr_grouping and hasattr(self, "get_final_ids"):
             ids = self.get_final_ids(query)
             query = self.model.objects.filter(id__in=ids)
 


### PR DESCRIPTION
Resolves #1829

**Description-**

Due to inconsistencies with the default setting of the `fr_grouping` parameter in the resources endpoint, duplicate groups were appearing. Also, unapproved related docs were showing up because they were not filtered out.

**This pull request changes...**

- Fix `fr_grouping` default so that duplicate groups don't appear
- Filter by `approved=True` on related resources prefetch

**Steps to manually verify this change...**

1. Visit `/42/447/Subpart-C/2023-01-01/` and `/42/447/Subpart-B/2023-01-01/` and verify that no duplicate groups or unapproved items appear

