### PR TITLE
EREGCSC-1696 -DB upgrade, create parameter groups

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -219,6 +219,73 @@ resources:
           search_path: '"$user",public'
           pgaudit.role: "rds_pgaudit"
           pgaudit.log: "ALL"
+
+    AuroraRDSClusterParameter13:
+      Type: AWS::RDS::DBClusterParameterGroup
+      Properties:
+        Description: Parameter group for the Serverless Aurora RDS DB.
+        Family: aurora-postgresql13
+        Parameters:
+          rds.force_ssl: 1
+
+    AuroraRDSInstanceParameter13:
+      Type: AWS::RDS::DBParameterGroup
+      Properties:
+        Description: Parameter group for the Serverless Aurora RDS DB.
+        Family: aurora-postgresql13
+        Parameters:
+          shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
+          log_statement: "ddl"
+          log_connections: 1
+          log_disconnections: 1
+          log_lock_waits: 1
+          log_min_duration_statement: 5000
+          auto_explain.log_min_duration: 5000
+          auto_explain.log_verbose: 1
+          log_rotation_age: 1440
+          log_rotation_size: 102400
+          rds.log_retention_period: 10080
+          random_page_cost: 1
+          track_activity_query_size: 16384
+          idle_in_transaction_session_timeout: 7200000
+          statement_timeout: 7200000
+          search_path: '"$user",public'
+          pgaudit.role: "rds_pgaudit"
+          pgaudit.log: "ALL"
+
+    AuroraRDSClusterParameter14:
+      Type: AWS::RDS::DBClusterParameterGroup
+      Properties:
+        Description: Parameter group for the Serverless Aurora RDS DB.
+        Family: aurora-postgresql14
+        Parameters:
+          rds.force_ssl: 1
+
+    AuroraRDSInstanceParameter14:
+      Type: AWS::RDS::DBParameterGroup
+      Properties:
+        Description: Parameter group for the Serverless Aurora RDS DB.
+        Family: aurora-postgresql14
+        Parameters:
+          shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
+          log_statement: "ddl"
+          log_connections: 1
+          log_disconnections: 1
+          log_lock_waits: 1
+          log_min_duration_statement: 5000
+          auto_explain.log_min_duration: 5000
+          auto_explain.log_verbose: 1
+          log_rotation_age: 1440
+          log_rotation_size: 102400
+          rds.log_retention_period: 10080
+          random_page_cost: 1
+          track_activity_query_size: 16384
+          idle_in_transaction_session_timeout: 7200000
+          statement_timeout: 7200000
+          search_path: '"$user",public'
+          pgaudit.role: "rds_pgaudit"
+          pgaudit.log: "ALL"
+
     RDSResource:
       Type: AWS::RDS::DBCluster
       DeletionPolicy: Retain


### PR DESCRIPTION
Resolves # EREGCSC- 1696 (partially)

**Description-**

Creates parameter groups for the environments for postgres 13 and 14 which will not be immediately used.
**This pull request changes...**

Parameter groups created in dev, val, and prod

**Steps to manually verify this change...**

Once merged in main will create new parameter groups for postgres 13 and 14

