### PR TITLE
EREGCSC-1689Updated serverless file to include postgres14

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -317,6 +317,36 @@ resources:
           Ref: AuroraRDSInstanceParameter
         DBClusterIdentifier:
           Ref: RDSResource
+    RDSResource14:
+      Type: AWS::RDS::DBCluster
+      DeletionPolicy: Retain
+      Properties:
+        MasterUsername: ${self:custom.settings.USERNAME}
+        StorageEncrypted: true
+        MasterUserPassword: ${ssm:/eregulations/db/password}
+        DBSubnetGroupName:
+          Ref: DBSubnetGroup
+        Engine: aurora-postgresql
+        EngineVersion: "14.6"
+        DatabaseName: 'eregs'
+        BackupRetentionPeriod: 3
+        DBClusterParameterGroupName:
+          Ref: AuroraRDSClusterParameter14
+        VpcSecurityGroupIds:
+          - !Ref 'DBSecurityGroup'
+    AuroraRDSInstance14:
+      Type: AWS::RDS::DBInstance
+      DeletionPolicy: Retain
+      Properties:
+        DBInstanceClass: db.r6g.large
+        StorageEncrypted: true
+        Engine: aurora-postgresql
+        EngineVersion: "14.6"
+        PubliclyAccessible: false
+        DBParameterGroupName:
+          Ref: AuroraRDSInstanceParameter14
+        DBClusterIdentifier:
+          Ref: RDSResource14
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Resolves #


**Description-**

Creates or adds postgres 14 db to the environments.  The custom paramter groups are causing issues with just replacing the database the stacks refer too.  So a database is being added to the serverless file, which will be blank in prod and val and they will be removed by the replaced db when it is done.



In dev no changes should occur, resource is already imported
in val and prod a blank database will be created  that is postgres 14

**Steps to manually verify this change...**

Once deployed to dev, no database is added but the 14 dev is there(as well as the 12)
In val a new database is added for 14
In prod a new databasse is added for 14



1. steps to view and verify change

