### PR TITLE
Removing failed unittest

### DIFF
--- a/solution/backend/regcore/tests/test_models.py
+++ b/solution/backend/regcore/tests/test_models.py
@@ -1,8 +1,10 @@
-from django.test import TestCase
-from regcore.models import ParserConfiguration, Part, TitleConfiguration
-from regcore.search.models import Synonym
-from regcore.search.models import create_search
+
 import json
+
+from django.test import TestCase
+
+from regcore.models import Part
+from regcore.search.models import create_search, Synonym
 
 
 class TestRegoreModels(TestCase):
@@ -14,8 +16,7 @@ class TestRegoreModels(TestCase):
         Part.objects.create(title='42', date="2020-06-30", last_updated="2022-09-21 08:36:45.735759",
                             depth=2, structure=structure, name=400, document=doc,
                             depth_stack={"depthstack": "stuff"})
-        TitleConfiguration.objects.create(title=50, subchapters="c, d", parts="40, 50",
-                                          parser_config=ParserConfiguration.objects.get(id=1))
+
         s1 = Synonym.objects.create(isActive=True, baseWord="Syn1")
         s2, _ = Synonym.objects.get_or_create(isActive=True, baseWord="S2")
         s2.synonyms.set([s1])
@@ -24,11 +25,6 @@ class TestRegoreModels(TestCase):
         part = Part.objects.get(name=400)
         toc = part.toc
         self.assertEqual(toc, 'part content')
-
-    def test_title_config_check(self):
-        title = TitleConfiguration.objects.get(title=50)
-        self.assertEqual(title.__str__(), 'Title 50 config')
-        self.assertEqual(title.parts, "40, 50")
 
     def test_Synonym_create(self):
         s1 = Synonym.objects.get(baseWord="Syn1")


### PR DESCRIPTION
Resolves # none

**Description-**

Removes a failing python unittest due to retired models

**This pull request changes...**

 All current python unittest should pass

**Steps to manually verify this change...**

- Run make python.unittest.  All test should pass

