### PR TITLE
Update demo video link on about page

### DIFF
--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -43,12 +43,12 @@
             </p>
             <p>
                 <a
-                    href="https://www.youtube.com/watch?v=_6kqjEVHrZM"
+                    href="https://www.youtube.com/watch?v=dqy8WCFedU4"
                     class="external"
                     target="_blank"
                     rel="noopener noreferrer"
                 >
-                    View a 3-minute video demonstration.
+                    View a 6-minute video demonstration.
                 </a>
             </p>
         </section>


### PR DESCRIPTION
Resolves # EREGCSC-1433

**Description-**

This PR updates our demo video link on our "about" page, along with the length description (6 minutes instead of 3 minutes).

**Steps to manually verify this change...**

1. View the "about" page
2. Click the "video demonstration" link near the top
3. The link should go to a video should be a new one recorded by Betsy, instead of the outdated one I recorded in December 2021.