### PR TITLE
EREGCSC-1800 Medium - dev,prod,val RDS.11 RDS instances should have automatic backups enabled

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -233,7 +233,8 @@ resources:
         Engine: aurora-postgresql
         EngineVersion: "15.2"
         DatabaseName: 'eregs'
-        BackupRetentionPeriod: 3
+        BackupRetentionPeriod: 7
+        BackupRetentionMinimum: 7
         DBClusterParameterGroupName:
           Ref: AuroraRDSClusterParameter15
         VpcSecurityGroupIds:


### PR DESCRIPTION
Resolves #1800

**Description-**

To satisfy ATO requirements, we must have a minimum database backup period of 7 days.

**This pull request changes...**

- Sets `BackupRetentionPeriod` and `BackupRetentionMinimum` to 7

**Steps to manually verify this change...**

1. Run `serverless package --stage dev` and verify no errors
2. Run `serverless package --stage val` and verify no errors
3. Run `serverless package --stage prod` and verify no errors
4. Deploy this PR and check AWS console to make sure backups are being retained for 7 days

