### PR TITLE
EREGCSC-1837 Make FR-type an editable field

### DIFF
--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -320,7 +320,7 @@ class SupContentForm(ResourceForm):
 
 
 class FederalResourceForm(ResourceForm):
-    doc_types = [('RFI', 'RFI'), ('NPRM', 'NPRM'), ("Final Rule", 'Final Rule'), ('None', None)]
+    doc_types = [('RFI', 'RFI'), ('NPRM', 'NPRM'), ("Final", 'Final')]
 
     class Meta:
         model = FederalRegisterDocument

--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -320,9 +320,18 @@ class SupContentForm(ResourceForm):
 
 
 class FederalResourceForm(ResourceForm):
+    doc_types = [('RFI', 'RFI'), ('NPRM', 'NPRM'), ("Final Rule", 'Final Rule'), ('None', None)]
+
     class Meta:
         model = FederalRegisterDocument
         fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super(FederalResourceForm, self).__init__(*args, **kwargs)
+        if self.instance.id:
+            CHOICES_INCLUDING_DB_VALUE = [(self.instance.doc_type,)*2] + self.doc_types
+            self.fields['doc_type'] = forms.ChoiceField(
+                choices=CHOICES_INCLUDING_DB_VALUE)
 
     def save(self, commit=True):
         return super(FederalResourceForm, self).save(commit=commit)
@@ -358,9 +367,6 @@ class FederalRegisterDocumentAdmin(AbstractResourceAdmin):
         return super().get_queryset(request).prefetch_related(
             Prefetch("group", FederalRegisterDocumentGroup.objects.all()),
         )
-
-    def get_readonly_fields(self, request, obj=None):
-        return self.readonly_fields + (("doc_type",) if obj else ())  # prevent changing name field on existing objects
 
 
 class FederalRegisterDocumentGroupForm(forms.ModelForm):


### PR DESCRIPTION
Resolves # EREGCSC-1837

**Description-**

Allows doc_type to be editable for FR-documents in django admin.  Admin is only editable as a drop down value.  If there is an already existing value, that value will still appear in the drop down until it is changed.
Options are:

RFI
NPRM
Final Rule
None
**This pull request changes...**

- Doc-type is editable in fr-documents

**Steps to manually verify this change...**

1. steps to view and verify change

Log into django admin
Select an FR-document
Doc Type will be editable through a drop down.
Select a different doc type
reopen FR-document to verify it changed.
