### PR TITLE
EREGCSC-1800-B Remove extraneous key

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -234,7 +234,6 @@ resources:
         EngineVersion: "15.2"
         DatabaseName: 'eregs'
         BackupRetentionPeriod: 7
-        BackupRetentionMinimum: 7
         DBClusterParameterGroupName:
           Ref: AuroraRDSClusterParameter15
         VpcSecurityGroupIds:


### PR DESCRIPTION
Resolves #1800

**Description-**

Despite https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-11 and https://docs.aws.amazon.com/config/latest/developerguide/db-instance-backup-enabled.html making direct references to `BackupRetentionMinimum`, Serverless complains that this is an extraneous key.

Let's see if just setting `BackupRetentionPeriod` meets the ATO requirements.

**This pull request changes...**

- Remove `BackupRetentionMinimum`

**Steps to manually verify this change...**

You can run `serverless package` locally if you want, but just like the previous PR, it _will_ succeed but deployment could fail. No damage will be done in this case.

