### PR TITLE
instead of end needs to be fi

### DIFF
--- a/solution/backend/scripts/delete_cloudformation_stack
+++ b/solution/backend/scripts/delete_cloudformation_stack
@@ -5,7 +5,7 @@ PR_NUMBER=$1
 if ! command -v aws >/dev/null 2>&1; then
   echo "you must install aws cli first"
   exit 1
-end
+fi
 
 if [[ ${PR_NUMBER} ]]; then
   STACK_NAMES=("cmcs-eregs-parser-dev${PR_NUMBER}" "cmcs-eregs-site-dev${PR_NUMBER}" "cmcs-eregs-static-assets-dev${PR_NUMBER}" "cmcs-eregs-fr-parser-dev${PR_NUMBER}")
@@ -14,22 +14,21 @@ if [[ ${PR_NUMBER} ]]; then
   # Loop through the list of stack names and delete each stack and associated S3 buckets
   for STACK_NAME in "${STACK_NAMES[@]}"
   do
-
     # Get list of S3 bucket names associated with the stack
     S3_BUCKETS=$(aws cloudformation describe-stack-resources --stack-name $STACK_NAME --region $REGION --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)
-  
+
     echo "deleting s3 buckets: ${S3_BUCKETS}"
     # Loop through the list of S3 bucket names and delete each bucket
     for BUCKET_NAME in $S3_BUCKETS
     do
       aws s3 rb s3://$BUCKET_NAME --force
-    done  
-  
+    done
+
     # Delete the CloudFormation stack
     echo "Delete stack ${STACK_NAME}\n"
     aws cloudformation delete-stack --stack-name $STACK_NAME --region $REGION
-  
-  
+
+
     # Wait for stack deletion to complete
     aws cloudformation wait stack-delete-complete --stack-name $STACK_NAME --region $REGION
 

--- a/solution/backend/scripts/delete_cloudformation_stack
+++ b/solution/backend/scripts/delete_cloudformation_stack
@@ -16,8 +16,8 @@ if [[ ${PR_NUMBER} ]]; then
   do
     # Get list of S3 bucket names associated with the stack
     S3_BUCKETS=$(aws cloudformation describe-stack-resources --stack-name $STACK_NAME --region $REGION --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)
-
     echo "deleting s3 buckets: ${S3_BUCKETS}"
+
     # Loop through the list of S3 bucket names and delete each bucket
     for BUCKET_NAME in $S3_BUCKETS
     do
@@ -27,7 +27,6 @@ if [[ ${PR_NUMBER} ]]; then
     # Delete the CloudFormation stack
     echo "Delete stack ${STACK_NAME}\n"
     aws cloudformation delete-stack --stack-name $STACK_NAME --region $REGION
-
 
     # Wait for stack deletion to complete
     aws cloudformation wait stack-delete-complete --stack-name $STACK_NAME --region $REGION


### PR DESCRIPTION
Resolves #

**Description-**

There was a bug in the script instead of fi it had 'end' which is wrong syntax for a shell script

- expected change 1

**Steps to manually verify this change...**

1. run the script manually on your local and notice it does not give an error anymore.

