### PR TITLE
EREGCSC-1868: Outbound Links should not use redirects

### DIFF
--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -74,10 +74,6 @@ class TypicalResourceFieldsSerializer(DateFieldSerializer):
     url = serializers.CharField()
     internalURL = serializers.SerializerMethodField()
 
-    @extend_schema_field(OpenApiTypes.STR)
-    def get_internalURL(self, obj):
-        return reverse('supplemental_content', kwargs={'id': obj.pk})
-
 
 class SupplementalContentSerializer(AbstractResourceSerializer, TypicalResourceFieldsSerializer):
     name_headline = HeadlineField("supplementalcontent")

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -1,7 +1,6 @@
 import re
 
-from django.urls import reverse
-from drf_spectacular.utils import extend_schema_field, OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from django.db.models import Q
 from rest_framework import serializers
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
@@ -43,7 +43,7 @@
                 :name="content.name"
                 :description="content.description"
                 :date="content.date"
-                :url="content.internalURL || content.url"
+                :url="content.url"
             >
             </supplemental-content-object>
             <collapse-button


### PR DESCRIPTION
Resolves # EREGCSC 1868

**Description-**
Outbound links on show more are using the redirects instead of the url for the abstract resources.  Needs to be fixed.

**This pull request changes...**

- Supplemental content on showmore will just go to the outbound site instead of a redirect

**Steps to manually verify this change...**

1. steps to view and verify change

