### PR TITLE
Add simple security policy to the repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+To report a vulnerability in this project, please see the [CMS/HHS Vulnerability Disclosure Policy](https://www.cms.gov/vulnerability-disclosure-policy). 


### PR DESCRIPTION
No Jira ticket number.

**Description-**

GitHub recommends [setting up a security.md file](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).

**This pull request changes...**

This PR adds a security.md file that links to the HHS/CMS vulnerability disclosure policy, because that's where a member of the public should go if they wanted to report a vulnerability.

No impact on our application.

**Steps to manually verify this change...**

When you click the link, it should go to the relevant page.