### PR TITLE
update rss feed to show 900 at a time

### DIFF
--- a/solution/backend/cmcs_regulations/urls.py
+++ b/solution/backend/cmcs_regulations/urls.py
@@ -35,5 +35,5 @@ urlpatterns = [
     path('robots.txt', TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),
     path('__debug__/', include('debug_toolbar.urls')),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
-    path('latest/feed/', ResourceFeed()),
+    path('latest/feed/<int:feed_number>/', ResourceFeed(), name='latest_feed'),
 ]

--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -1,13 +1,24 @@
+from django.urls import reverse
 from resources.models import AbstractResource
 from django.contrib.syndication.views import Feed
 from dateutil import parser
-
+import math
 
 class ResourceFeed(Feed):
     title = 'Resources RSS Feed'
     link = '/latest/feed/'
     description = 'Displays the latest Resources RSS feed'
 
+    def __init__(self):
+        self.feed_number = None
+
+    def get_object(self, request, feed_number):
+        page_size = 900
+        start = (feed_number - 1) * page_size
+        end = feed_number * page_size
+        self.feed_number = feed_number
+        return {'start': start, 'end': end}
+    
     def get_feed(self, obj, request):
         feedgen = super().get_feed(obj, request)
         feedgen.content_type = 'application/xml'  # New standard
@@ -17,9 +28,11 @@ class ResourceFeed(Feed):
         date = parser.parse(date_time) if date_time else ''
         return date
 
-    def items(self):
+    def items(self, obj):
+        start = obj['start']
+        end = obj['end']
         results = []
-        resources = AbstractResource.objects.filter(approved=True).select_subclasses()
+        resources = AbstractResource.objects.filter(approved=True).select_subclasses()[start:end]
         # if there is no date value then we will use this placeholder date for the datepublished.
         place_holder_pubdate = '1970-01-01'
         for resource in resources:
@@ -43,3 +56,7 @@ class ResourceFeed(Feed):
 
     def item_link(self, item):
         return item['url'] if item['url'] else '/'
+
+    def link(self):
+        # Add the current feed number to the link URL to distinguish between multiple feeds
+        return reverse('latest_feed', args=[self.feed_number])

--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -18,7 +18,7 @@ class ResourceFeed(Feed):
         end = feed_number * page_size
         self.feed_number = feed_number
         return {'start': start, 'end': end}
-    
+
     def get_feed(self, obj, request):
         feedgen = super().get_feed(obj, request)
         feedgen.content_type = 'application/xml'  # New standard

--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from resources.models import AbstractResource
 from django.contrib.syndication.views import Feed
 from dateutil import parser
-import math
+
 
 class ResourceFeed(Feed):
     title = 'Resources RSS Feed'


### PR DESCRIPTION
Resolves #

**Description-**
According to the search.gov documentation the RSS feed does not parse more than 1000 at a time. Looking at their website it looks like it got cut off at 990. Therefore this code change will show 900 RSS feed values at a time

**This pull request changes...**

The url will now be latest/feed/{feed_number}
for example latest/feed/2 will show the 2nd 900 results while latest/feed/1 returns the first 900 results

**Steps to manually verify this change...**

1. Visit experimental website 
https://60jn5d8mob.execute-api.us-east-1.amazonaws.com/dev807/latest/feed/1
https://60jn5d8mob.execute-api.us-east-1.amazonaws.com/dev807/latest/feed/2
https://60jn5d8mob.execute-api.us-east-1.amazonaws.com/dev807/latest/feed/3
Notice 
https://60jn5d8mob.execute-api.us-east-1.amazonaws.com/dev807/latest/feed/4 has no result since it exceeds the number of items in the feed.

