### PR TITLE
EREGCSC-1868: Outbound link don' use redirects

### DIFF
--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -1,30 +1,39 @@
 import re
 
-from django.urls import reverse
-from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 from django.db.models import Q
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from .categories import AbstractCategoryPolymorphicSerializer, MetaCategorySerializer
+from .categories import (
+    AbstractCategoryPolymorphicSerializer,
+    MetaCategorySerializer
+)
+
 from .locations import (
-    SectionCreateSerializer,
-    SectionRangeCreateSerializer,
     AbstractLocationPolymorphicSerializer,
     MetaLocationSerializer,
+    SectionCreateSerializer,
+    SectionRangeCreateSerializer,
 )
-from .mixins import HeadlineField, PolymorphicSerializer, PolymorphicTypeField
-from .utils import ProxySerializerWrapper
+
+from .mixins import (
+    HeadlineField,
+    PolymorphicSerializer,
+    PolymorphicTypeField
+)
 
 from resources.models import (
-    SupplementalContent,
+    AbstractCategory,
+    AbstractLocation,
+    Category,
     FederalRegisterDocument,
     FederalRegisterDocumentGroup,
     ResourcesConfiguration,
-    Category,
-    AbstractCategory,
     Section,
-    AbstractLocation,
+    SupplementalContent,
 )
+
+from .utils import ProxySerializerWrapper
 
 
 class AbstractResourcePolymorphicSerializer(PolymorphicSerializer):
@@ -72,11 +81,6 @@ class TypicalResourceFieldsSerializer(DateFieldSerializer):
     name = serializers.CharField()
     description = serializers.CharField()
     url = serializers.CharField()
-    internalURL = serializers.SerializerMethodField()
-
-    @extend_schema_field(OpenApiTypes.STR)
-    def get_internalURL(self, obj):
-        return reverse('supplemental_content', kwargs={'id': obj.pk})
 
 
 class SupplementalContentSerializer(AbstractResourceSerializer, TypicalResourceFieldsSerializer):

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
@@ -43,7 +43,7 @@
                 :name="content.name"
                 :description="content.description"
                 :date="content.date"
-                :url="content.internalURL || content.url"
+                :url="content.url"
             >
             </supplemental-content-object>
             <collapse-button


### PR DESCRIPTION
Resolves # EREGCSC 1868

Description-
Outbound links on show more are using the redirects instead of the url for the abstract resources. Needs to be fixed.

This pull request changes...

Supplemental content on showmore will just go to the outbound site instead of a redirect
Steps to manually verify this change...

steps to view and verify change

Go to a subpart for regulations.
Go to the sidebar and pick a resource category  that has a show more.
Url should be a normal url not one for a generic piece of supplemental content.