### PR TITLE
[Quickfix] Better handle long strings in search results columns

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -33,6 +33,8 @@
                 flex: 1;
                 margin: 0 auto;
                 padding: 0 45px;
+                max-width: calc(50% - 90px);
+                overflow-wrap: break-word;
                 @content;
             }
 


### PR DESCRIPTION
Resolves bug where long strings (URLs) can make the two search columns different widths.

**Description**

There is one `searchgov` search result that returns a snippet that's one [long incredibly unbroken](https://www.youtube.com/watch?v=5YOVN2BTSmI&t=18s) URL string without any dashes.  This is causing the combined search page's Resources column's width to stretch to be 80% of the page, and it is compressing the reg search column width to be 20% of the page.

This is because we're not setting a max width on the columns and we're not setting the overflow correctly.  This PR addresses both issues.

**This pull request changes...**

- Adds styles to prevent search results columns from expanding wider than half the page
- Adds overflow style to break long URL strings so they overflow within column

**Steps to manually verify this change...**

1. Visit `/search/?q=timely%20filing&searchgov` on prod and on experimental deployment
2. Make sure experimental deployment has column widths that are equal

